### PR TITLE
short link with esriurl.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Notes:
 
 ## Resources
 
-* [ArcGIS Runtime SDK for .NET](http://esriurl/dotnetsdk)
+* [ArcGIS Runtime SDK for .NET](http://esriurl.com/dotnetsdk)
 
 ## Issues
 


### PR DESCRIPTION
The URL should be something like http://esriurl.com/dotnetsdk instead of http://esriurl/dotnetsdk
