### PR TITLE
Change to Null MapView check

### DIFF
--- a/src/Desktop/ArcGISRuntimeSamplesDesktop/Samples/Mapping/ShowMouseCoordinates.xaml.cs
+++ b/src/Desktop/ArcGISRuntimeSamplesDesktop/Samples/Mapping/ShowMouseCoordinates.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.Samples.Desktop
 
 		private void MyMapView_MouseMove(object sender, MouseEventArgs e)
 		{
-			if (MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry).TargetGeometry.Extent == null)
+			if (MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry) == null)
 				return;
 
 			System.Windows.Point screenPoint = e.GetPosition(MyMapView);

--- a/src/Store/ArcGISRuntimeSamplesStore/Assets/SampleDescriptions.xml
+++ b/src/Store/ArcGISRuntimeSamplesStore/Assets/SampleDescriptions.xml
@@ -1237,13 +1237,6 @@
         <member name="T:ArcGISRuntime.Samples.Store.Samples.DoubleToStringConverter">
             <summary>Double to formatted string value converter</summary>
         </member>
-        <member name="T:ArcGISRuntime.Samples.Store.Samples.InteractionOptionsSample3d">
-            <summary>
-            This sample shows how to change interaction settings that controls the SceneView.
-            </summary>
-            <title>Interaction Options 3d</title>
-            <category>Scene</category>
-        </member>
         <member name="T:ArcGISRuntime.Samples.Store.Samples.OAuthAuthorizeHandler">
             <summary>
             Phone/Store OAuthAuthorize handler which encapsulates the redirection of the user to the OAuth authorization URI by using a WebBrowser.

--- a/src/Store/ArcGISRuntimeSamplesStore/Samples/Mapping/ShowMouseCoordinates.xaml.cs
+++ b/src/Store/ArcGISRuntimeSamplesStore/Samples/Mapping/ShowMouseCoordinates.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.Samples.Store.Samples
 
 		private void MyMapView_PointerMoved(object sender, PointerRoutedEventArgs e)
 		{
-			if (MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry).TargetGeometry.Extent == null)
+			if (MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry) == null)
 				return;
 
 			var pointerPoint = e.GetCurrentPoint(MyMapView);


### PR DESCRIPTION
Update to phone and store samples for Mouse Coords to perform a slightly different null ref check that will not allow the sample to continue until MapView is loaded 