### PR TITLE
Updated to use NavigationChanged instead of SpatialReferenceChanged.

### DIFF
--- a/src/Desktop/ArcGISRuntimeSamplesDesktop/Samples/Mapping/MapOverlays.xaml.cs
+++ b/src/Desktop/ArcGISRuntimeSamplesDesktop/Samples/Mapping/MapOverlays.xaml.cs
@@ -18,14 +18,11 @@ namespace ArcGISRuntime.Samples.Desktop
 			
 			esriOverlay.DataContext = new MapPoint(-117.19568, 34.056601, SpatialReferences.Wgs84);
 
-			MyMapView.SpatialReferenceChanged += MyMapView_SpatialReferenceChanged;
-
+			MyMapView.NavigationCompleted += MyMapView_NavigationCompleted;
 		}
 
-		void MyMapView_SpatialReferenceChanged(object sender, System.EventArgs e)
+		void MyMapView_NavigationCompleted(object sender, System.EventArgs e)
 		{
-			MyMapView.SpatialReferenceChanged -= MyMapView_SpatialReferenceChanged;
-
 			// Get current viewpoints extent from the MapView
 			var currentViewpoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 			var viewpointExtent = currentViewpoint.TargetGeometry.Extent;


### PR DESCRIPTION
@anttikajanus - Do we need to unload the NavigationChanged event handler before switching between samples on this one?