### PR TITLE
Update TypeLink strings due to Namespace changes (Layers to Mapping, Controls to UI)

### DIFF
--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Layers/ArcGISMapImageLayerUrl/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Layers/ArcGISMapImageLayerUrl/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"ArcGISMapImageLayerUrl.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Layers.ArcGISMapImageLayer"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.ArcGISMapImageLayer"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Layers/ArcGISTiledLayerUrl/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Layers/ArcGISTiledLayerUrl/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"ArcGISTiledLayerUrl.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Layers.ArcGISTiledLayer"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.ArcGISTiledLayer"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetInitialMapArea/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetInitialMapArea/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"SetInitialMapArea.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Map.InitialViewpoint","T:Esri.ArcGISRuntime.Viewpoint","M:Esri.ArcGISRuntime.Viewpoint.#ctor(Esri.ArcGISRuntime.Geometry.Geometry)"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint","T:Esri.ArcGISRuntime.Mapping.Viewpoint","M:Esri.ArcGISRuntime.Mapping.Viewpoint.#ctor(Esri.ArcGISRuntime.Geometry.Geometry)"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetInitialMapLocation/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetInitialMapLocation/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"SetInitialMapLocation.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Controls.MapView.Map","M:Esri.ArcGISRuntime.Map.#ctor(Esri.ArcGISRuntime.Layers.BasemapType,System.Double,System.Double,System.Int32)"
+  "TypeLink": ["P:Esri.ArcGISRuntime.UI.MapView.Map","M:Esri.ArcGISRuntime.Mapping.Map.#ctor(Esri.ArcGISRuntime.Layers.BasemapType,System.Double,System.Double,System.Int32)"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetMapSpatialReference/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Map/SetMapSpatialReference/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer": false,
   "Image": "SetMapSpatialReference.jpg",
   "Link": "",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Map","T:Esri.ArcGISRuntime.Geometry.SpatialReference"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Map","T:Esri.ArcGISRuntime.Geometry.SpatialReference"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/ChangeViewpoint/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/ChangeViewpoint/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"ChangeViewpoint.jpg",
   "Link":"",
-  "TypeLink": ["M:Esri.ArcGISRuntime.Controls.GeoView.SetViewpointAsync(Esri.ArcGISRuntime.Viewpoint,System.TimeSpan)","M:Esri.ArcGISRuntime.Controls.MapView.SetViewpointGeometryAsync(Esri.ArcGISRuntime.Geometry.Geometry)","M:Esri.ArcGISRuntime.Controls.MapView.SetViewpointCenterAsync(Esri.ArcGISRuntime.Geometry.MapPoint)","M:Esri.ArcGISRuntime.Controls.MapView.SetViewpointScaleAsync(System.Double)"
+  "TypeLink": ["M:Esri.ArcGISRuntime.UI.GeoView.SetViewpointAsync(Esri.ArcGISRuntime.Viewpoint,System.TimeSpan)","M:Esri.ArcGISRuntime.UI.MapView.SetViewpointGeometryAsync(Esri.ArcGISRuntime.Geometry.Geometry)","M:Esri.ArcGISRuntime.UI.MapView.SetViewpointCenterAsync(Esri.ArcGISRuntime.Geometry.MapPoint)","M:Esri.ArcGISRuntime.UI.MapView.SetViewpointScaleAsync(System.Double)"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/MapRotation/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/MapRotation/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"MapRotation.jpg",
   "Link":"",
-  "TypeLink": ["M:Esri.ArcGISRuntime.Controls.MapView.SetViewpointRotationAsync(System.Double)"
+  "TypeLink": ["M:Esri.ArcGISRuntime.UI.MapView.SetViewpointRotationAsync(System.Double)"
   ]
 }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Tutorials/FirstMapApp/metadata.json
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Tutorials/FirstMapApp/metadata.json
@@ -9,6 +9,6 @@
   "RequiresLocalServer":false,
   "Image":"FirstMapApp.jpg",
   "Link":"https://developers.arcgis.com/net/desktop/guide/develop-your-first-map-app.htm",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Controls.MapView","T:Esri.ArcGISRuntime.Layers.Basemap"
+  "TypeLink": ["T:Esri.ArcGISRuntime.UI.MapView","T:Esri.ArcGISRuntime.Mapping.Basemap"
   ]
 }


### PR DESCRIPTION
Updated the TypeLink strings in the various metadata.json files to account for the new Namespace changes made by Morten. Esri.ArcGISRuntime.Layers is now Esri.ArcGISRuntime.Mapping and Esri.ArcGISRuntime.Controls is now Esri.ArcGISRuntime.UI.