### PR TITLE
Removing as many fully qualified Esri.ArcGISRuntime TYPE references as possible to shorten the syntax.

### DIFF
--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.Desktop.Samples.FeatureLayerQuery
             Map myMap = new Map(Basemap.CreateTopographic());
 
             // Create and set initial map location
-            Esri.ArcGISRuntime.Geometry.MapPoint initialLocation = new MapPoint(
+            MapPoint initialLocation = new MapPoint(
                 -11000000, 5000000, SpatialReferences.WebMercator);
             myMap.InitialViewpoint = new Viewpoint(initialLocation, 100000000);
 

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
@@ -7,6 +7,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
 // language governing permissions and limitations under the License.
 
+using Esri.ArcGISRuntime;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -61,10 +62,10 @@ namespace ArcGISRuntime.Desktop.Samples.ServiceFeatureTableManualCache
             MyMapView.Map = myMap;
         }
 
-        private async void OnLoadedPopulateData(object sender, Esri.ArcGISRuntime.LoadStatusEventArgs e)
+        private async void OnLoadedPopulateData(object sender, LoadStatusEventArgs e)
         {
             // If layer isn't loaded, do nothing
-            if (e.Status != Esri.ArcGISRuntime.LoadStatus.Loaded)
+            if (e.Status != LoadStatus.Loaded)
                 return;
 
             // Create new query object that contains parameters to query specific request types

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
@@ -58,7 +58,7 @@ namespace ArcGISRuntime.Desktop.Samples.IdentifyGraphics
             builder.AddPoint(new MapPoint(-20e5, -20e5));
 
             // Get geometry from the builder
-            Esri.ArcGISRuntime.Geometry.Polygon polygonGeometry = builder.ToGeometry();
+            Polygon polygonGeometry = builder.ToGeometry();
 
             // Create symbol for the polygon
             SimpleFillSymbol polygonSymbol = new SimpleFillSymbol(
@@ -77,7 +77,7 @@ namespace ArcGISRuntime.Desktop.Samples.IdentifyGraphics
             MyMapView.GraphicsOverlays.Add(_polygonOverlay);
         }
 
-        private async void OnMapViewTapped(object sender, Esri.ArcGISRuntime.UI.GeoViewInputEventArgs e)
+        private async void OnMapViewTapped(object sender, GeoViewInputEventArgs e)
         {
             var tolerance = 10d; // Use larger tolerance for touch
             var maximumResults = 1; // Only return one graphic  


### PR DESCRIPTION
…