### PR TITLE
Minor updates to the Quartz Beta 1 ArcGISVectorTiledLayerUrl (UWP) sample.

### DIFF
--- a/src/Windows/ArcGISRuntime.Windows.Samples/ArcGISRuntime.Windows.Samples.CSharp.csproj
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/ArcGISRuntime.Windows.Samples.CSharp.csproj
@@ -110,7 +110,9 @@
     <Content Include="Samples\Layers\ArcGISTiledLayerUrl\ArcGISTiledLayerUrl.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Samples\Layers\ArcGISVectorTiledLayerUrl\ArcGISVectorTiledLayerUrl.jpg" />
+    <Content Include="Samples\Layers\ArcGISVectorTiledLayerUrl\ArcGISVectorTiledLayerUrl.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Samples\Layers\FeatureLayerUrl\FeatureLayerUrl.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntime.Windows.Samples.ArcGISVectorTiledLayerUrl
 
         private void Initialize()
         {
-            // Create a new ArcGISVectorTiledLayer with the navigation serice Url
+            // Create a new ArcGISVectorTiledLayer with the navigation service Url
             _vectorTiledLayer = new ArcGISVectorTiledLayer(new Uri(_navigationUrl));
 
             // Create new Map with basemap
@@ -84,9 +84,8 @@ namespace ArcGISRuntime.Windows.Samples.ArcGISVectorTiledLayerUrl
             // Create a new ArcGISVectorTiledLayer with the Url Selected by the user
             _vectorTiledLayer = new ArcGISVectorTiledLayer(new Uri(_vectorTiledLayerUrl));
 
-            // // Create new Map with basemap and assing to the Mapviews Map
+            // // Create new Map with basemap and assigning to the Mapviews Map
             MyMapView.Map = new Map(new Basemap(_vectorTiledLayer));
-
         }
     }
 }

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrlVB.xaml.vb
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrlVB.xaml.vb
@@ -10,7 +10,9 @@
 Imports Esri.ArcGISRuntime.Mapping
 
 Namespace ArcGISVectorTiledLayerUrl
+
     Partial Public Class ArcGISVectorTiledLayerUrlVB
+
         Private _navigationUrl As String = "http://www.arcgis.com/sharing/rest/content/items/00cd8e843bae49b3a040423e5d65416b/resources/styles/root.json"
         Private _streetUrl As String = "http://www.arcgis.com/sharing/rest/content/items/3b8814f6ddbd485cae67e8018992246e/resources/styles/root.json"
         Private _nightUrl As String = "http://www.arcgis.com/sharing/rest/content/items/f96366254a564adda1dc468b447ed956/resources/styles/root.json"
@@ -23,14 +25,17 @@ Namespace ArcGISVectorTiledLayerUrl
         Private _vectorLayerNames As String() = New String() {"Topo", "Streets", "Night", "Navigation"}
 
         Public Sub New()
+
             InitializeComponent()
 
             ' Create the UI, setup the control references and execute initialization 
             Initialize()
+
         End Sub
 
         Private Sub Initialize()
-            ' Create a new ArcGISVectorTiledLayer with the navigation serice Url
+
+            ' Create a new ArcGISVectorTiledLayer with the navigation service Url
             _vectorTiledLayer = New ArcGISVectorTiledLayer(New Uri(_navigationUrl))
 
             ' Create new Map with basemap
@@ -41,38 +46,49 @@ Namespace ArcGISVectorTiledLayerUrl
 
             ' Assign the map to the MapView
             MyMapView.Map = myMap
+
         End Sub
 
         Private Sub OnVectorLayersChooserSelectionChanged(sender As Object, e As SelectionChangedEventArgs)
+
             Dim selectedVectorLayer = e.AddedItems(0).ToString()
 
             Select Case selectedVectorLayer
+
                 Case "Topo"
+
                     _vectorTiledLayerUrl = _topographicUrl
                     Exit Select
 
                 Case "Streets"
+
                     _vectorTiledLayerUrl = _streetUrl
                     Exit Select
 
                 Case "Night"
+
                     _vectorTiledLayerUrl = _nightUrl
                     Exit Select
 
                 Case "Navigation"
+
                     _vectorTiledLayerUrl = _navigationUrl
                     Exit Select
+
                 Case Else
 
                     Exit Select
+
             End Select
 
             ' Create a new ArcGISVectorTiledLayer with the Url Selected by the user
             _vectorTiledLayer = New ArcGISVectorTiledLayer(New Uri(_vectorTiledLayerUrl))
 
-            ' // Create new Map with basemap and assing to the Mapviews Map
+            ' Create new Map with basemap and assigning to the Mapviews Map
             MyMapView.Map = New Map(New Basemap(_vectorTiledLayer))
 
         End Sub
+
     End Class
+
 End Namespace


### PR DESCRIPTION
Fixed minor things to bring the WPF version of the ArcGISVectorTiledLayerUrl sample into compliance:

~ The screenshot ArcGISVectorTiledLayerUr.jpg 'Copy to Output Directory' was set to 'Copy if newer' so that the image could appear in the 'description' tab of the Viewer application.
~ Spelling corrections were made to the source code.
~ Line spacing was added for readability in VB.NET.
