### PR TITLE
Update the Desktop (WPF and UWP) version of the DisplayLayerViewState to be uniform with the other SDK versions.

### DIFF
--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -15,19 +15,9 @@
             <StackPanel>
                 <TextBlock Text="Layer display status" 
                       Margin="0,0,0,2" TextWrapping="Wrap" />
-                <ListView x:Name="layerStatusListView">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Margin="2">
-                                    <Run Text="{Binding LayerName, Mode=OneWay}"/>
-                                    <Run Text=" - " />
-                                    <Run Text="{Binding LayerViewStatus, Mode=OneWay}"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                <Label x:Name="StatusLabel_TiledLayer" Content=""/>
+                <Label x:Name="StatusLabel_ImageLayer" Content=""/>
+                <Label x:Name="StatusLabel_FeatureLayer" Content=""/>
             </StackPanel>
         </Border>
     </Grid>

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -11,10 +11,10 @@
         <Border
             Background="White" BorderBrush="Black" BorderThickness="1"
             HorizontalAlignment="Right" VerticalAlignment="Top"
-            Margin="30" Padding="20" Width="375">
+            Margin="30" Padding="20" Width="250">
             <StackPanel>
-                <TextBlock Text="Layer display status" 
-                      Margin="0,0,0,2" TextWrapping="Wrap" />
+                <TextBlock Text="Layer display status" FontWeight="Bold" 
+                      HorizontalAlignment="Center" />
                 <Label x:Name="StatusLabel_TiledLayer" Content=""/>
                 <Label x:Name="StatusLabel_ImageLayer" Content=""/>
                 <Label x:Name="StatusLabel_FeatureLayer" Content=""/>

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -10,17 +10,11 @@
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace ArcGISRuntime.Desktop.Samples.DisplayLayerViewState
 {
     public partial class DisplayLayerViewState
     {
-        // Reference to list of view status for each layer
-        private List<LayerStatusModel> _layerStatusModels = new List<LayerStatusModel>();
 
         public DisplayLayerViewState()
         {
@@ -78,15 +72,6 @@ namespace ArcGISRuntime.Desktop.Samples.DisplayLayerViewState
             // Set the initial viewpoint for map
             myMap.InitialViewpoint = new Viewpoint(mapPoint, 50000000);
 
-            // Initialize the model list with unknown status for each layer
-            foreach (Layer layer in myMap.OperationalLayers)
-            {
-                _layerStatusModels.Add(new LayerStatusModel(layer.Name, "Unknown"));
-            }
-
-            // Set models list as a itemssource
-            layerStatusListView.ItemsSource = _layerStatusModels;
-
             // Event for layer view state changed
             MyMapView.LayerViewStateChanged += OnLayerViewStateChanged;
 
@@ -96,42 +81,25 @@ namespace ArcGISRuntime.Desktop.Samples.DisplayLayerViewState
 
         private void OnLayerViewStateChanged(object sender, LayerViewStateChangedEventArgs e)
         {
-            // State changed event is sent by a layer. In the list, find the layer which sends this event. 
-            // If it exists then update the status
-            var model = _layerStatusModels.FirstOrDefault(l => l.LayerName == e.Layer.Name);
-            if (model != null)
-                model.LayerViewStatus = e.LayerViewState.Status.ToString();
-        }
+            // For each execution of the MapView.LayerViewStateChanges Event, get the name of
+            // the layer and it's LayerViewState.Status
+            string lName = e.Layer.Name;
+            string lViewStatus = e.LayerViewState.Status.ToString();
 
-        /// <summary>
-        /// This is a custom class that holds information for layer name and status
-        /// </summary>
-        public class LayerStatusModel : INotifyPropertyChanged
-        {
-            private string layerViewStatus;
-
-            public string LayerName { get; private set; }
-
-            public string LayerViewStatus
+            // Display the layer name and view status in the appropriate Label control
+            switch (lName)
             {
-                get { return layerViewStatus; }
-                set { layerViewStatus = value; NotifyPropertyChanged(); }
-            }
-
-            public LayerStatusModel(string layerName, string layerStatus)
-            {
-                LayerName = layerName;
-                LayerViewStatus = layerStatus;
-            }
-
-            public event PropertyChangedEventHandler PropertyChanged;
-
-            private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
-            {
-                if (PropertyChanged != null)
-                {
-                    PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-                }
+                case "Tiled Layer":
+                    StatusLabel_TiledLayer.Content = lName + " - " + lViewStatus;
+                    break;
+                case "Image Layer":
+                    StatusLabel_ImageLayer.Content = lName + " - " + lViewStatus;
+                    break;
+                case "Feature Layer":
+                    StatusLabel_FeatureLayer.Content = lName + " - " + lViewStatus;
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.Desktop.Samples.DisplayLayerViewState
             // Add the feature layer to map
             myMap.OperationalLayers.Add(myFeatureLayer);
 
-            // Create a mappoint the map should zoom to
+            // Create a map point the map should zoom to
             MapPoint mapPoint = new MapPoint(-11000000, 4500000, SpatialReferences.WebMercator);
 
             // Set the initial viewpoint for map
@@ -81,8 +81,8 @@ namespace ArcGISRuntime.Desktop.Samples.DisplayLayerViewState
 
         private void OnLayerViewStateChanged(object sender, LayerViewStateChangedEventArgs e)
         {
-            // For each execution of the MapView.LayerViewStateChanges Event, get the name of
-            // the layer and it's LayerViewState.Status
+            // For each execution of the MapView.LayerViewStateChanged Event, get the name of
+            // the layer and its LayerViewState.Status
             string lName = e.Layer.Name;
             string lViewStatus = e.LayerViewState.Status.ToString();
 

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
@@ -12,10 +12,10 @@
         <Border
             Background="White" BorderBrush="Black" BorderThickness="1"
             HorizontalAlignment="Right" VerticalAlignment="Top"
-            Margin="30" Padding="20" Width="375">
+            Margin="30" Padding="20" Width="250">
             <StackPanel>
-                <TextBlock Text="Layer display status" 
-                      Margin="0,0,0,2" TextWrapping="Wrap" />
+                <TextBlock Text="Layer display status" FontWeight="Bold"
+                      HorizontalAlignment="Center" />
                 <Label x:Name="StatusLabel_TiledLayer" Content=""/>
                 <Label x:Name="StatusLabel_ImageLayer" Content=""/>
                 <Label x:Name="StatusLabel_FeatureLayer" Content=""/>

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
@@ -16,19 +16,9 @@
             <StackPanel>
                 <TextBlock Text="Layer display status" 
                       Margin="0,0,0,2" TextWrapping="Wrap" />
-                <ListView x:Name="layerStatusListView">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Margin="2">
-                                    <Run Text="{Binding LayerName, Mode=OneWay}"/>
-                                    <Run Text=" - " />
-                                    <Run Text="{Binding LayerViewStatus, Mode=OneWay}"/>
-                                </TextBlock>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                <Label x:Name="StatusLabel_TiledLayer" Content=""/>
+                <Label x:Name="StatusLabel_ImageLayer" Content=""/>
+                <Label x:Name="StatusLabel_FeatureLayer" Content=""/>
             </StackPanel>
         </Border>
     </Grid>

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
@@ -7,24 +7,23 @@
 ' "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
 ' language governing permissions and limitations under the License.
 
-Imports System.ComponentModel
-Imports System.Runtime.CompilerServices
 Imports Esri.ArcGISRuntime.Geometry
 Imports Esri.ArcGISRuntime.Mapping
 
 Namespace DisplayLayerViewState
     Partial Public Class DisplayLayerViewStateVB
-        ' Reference to list of view status for each layer
-        Private _layerStatusModels As New List(Of LayerStatusModel)()
 
         Public Sub New()
+
             InitializeComponent()
 
             ' Create the UI, setup the control references and execute initialization 
             Initialize()
+
         End Sub
 
         Private Sub Initialize()
+
             ' Create new Map
             Dim myMap As New Map()
 
@@ -68,67 +67,34 @@ Namespace DisplayLayerViewState
             ' Set the initial viewpoint for map
             myMap.InitialViewpoint = New Viewpoint(mapPoint, 50000000)
 
-            ' Initialize the model list with unknown status for each layer
-            For Each layer As Layer In myMap.OperationalLayers
-                _layerStatusModels.Add(New LayerStatusModel(layer.Name, "Unknown"))
-            Next
-
-            ' Set models list as a itemssource
-            layerStatusListView.ItemsSource = _layerStatusModels
-
             ' Event for layer view state changed
             AddHandler MyMapView.LayerViewStateChanged, AddressOf OnLayerViewStateChanged
 
             ' Provide used Map to the MapView
             MyMapView.Map = myMap
+
         End Sub
 
         Private Sub OnLayerViewStateChanged(sender As Object, e As LayerViewStateChangedEventArgs)
-            ' State changed event is sent by a layer. In the list, find the layer which sends this event. 
-            ' If it exists then update the status
-            Dim model = _layerStatusModels.FirstOrDefault(Function(l) l.LayerName = e.Layer.Name)
-            If model IsNot Nothing Then
-                model.LayerViewStatus = e.LayerViewState.Status.ToString()
-            End If
+
+            ' For each execution of the MapView.LayerViewStateChanges Event, get the name of
+            ' the layer and it's LayerViewState.Status
+            Dim lName As String = e.Layer.Name
+            Dim lViewStatus As String = e.LayerViewState.Status.ToString()
+
+            ' Display the layer name and view status in the appropriate Label control
+            Select Case lName
+                Case "Tiled Layer"
+                    StatusLabel_TiledLayer.Content = lName & " - " & lViewStatus
+                Case "Image Layer"
+                    StatusLabel_ImageLayer.Content = lName & " - " & lViewStatus
+                Case "Feature Layer"
+                    StatusLabel_FeatureLayer.Content = lName & " - " & lViewStatus
+                Case Else
+            End Select
+
         End Sub
 
-        ''' <summary>
-        ''' This is a custom class that holds information for layer name and status
-        ''' </summary>
-        Public Class LayerStatusModel
-            Implements INotifyPropertyChanged
-            Private m_layerViewStatus As String
-
-            Public Property LayerName() As String
-                Get
-                    Return m_LayerName
-                End Get
-                Private Set
-                    m_LayerName = Value
-                End Set
-            End Property
-            Private m_LayerName As String
-
-            Public Property LayerViewStatus() As String
-                Get
-                    Return m_layerViewStatus
-                End Get
-                Set
-                    m_layerViewStatus = Value
-                    NotifyPropertyChanged()
-                End Set
-            End Property
-
-            Public Sub New(layerName__1 As String, layerStatus As String)
-                LayerName = layerName__1
-                LayerViewStatus = layerStatus
-            End Sub
-
-            Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
-
-            Private Sub NotifyPropertyChanged(<CallerMemberName> Optional propertyName As String = "")
-                RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs(propertyName))
-            End Sub
-        End Class
     End Class
+
 End Namespace

--- a/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
+++ b/src/Desktop/ArcGISRuntime.Desktop.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
@@ -61,7 +61,7 @@ Namespace DisplayLayerViewState
             ' Add the feature layer to map
             myMap.OperationalLayers.Add(myFeatureLayer)
 
-            ' Create a mappoint the map should zoom to
+            ' Create a map point the map should zoom to
             Dim mapPoint As New MapPoint(-11000000, 4500000, SpatialReferences.WebMercator)
 
             ' Set the initial viewpoint for map
@@ -77,8 +77,8 @@ Namespace DisplayLayerViewState
 
         Private Sub OnLayerViewStateChanged(sender As Object, e As LayerViewStateChangedEventArgs)
 
-            ' For each execution of the MapView.LayerViewStateChanges Event, get the name of
-            ' the layer and it's LayerViewState.Status
+            ' For each execution of the MapView.LayerViewStateChanged Event, get the name of
+            ' the layer and its LayerViewState.Status
             Dim lName As String = e.Layer.Name
             Dim lViewStatus As String = e.LayerViewState.Status.ToString()
 

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -14,10 +14,15 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
-        <StackPanel Orientation="Vertical">
-            <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
-            <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
-            <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
-        </StackPanel>
+        <Border
+            Background="White" BorderBrush="Black" BorderThickness="1"
+            HorizontalAlignment="Left" VerticalAlignment="Top"
+            Margin="30" Padding="20" Width="250">
+            <StackPanel Orientation="Vertical">
+                <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
+                <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
+                <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -14,8 +14,10 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
-        <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
-        <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
-        <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
+        <StackPanel Orientation="Vertical">
+            <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
+            <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
+            <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml
@@ -14,16 +14,8 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
-        <ListView x:Name="layerStatusListView" Grid.Row="1">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Margin="2">
-                        <Run Text="{Binding LayerName, Mode=OneWay}"/>
-                        <Run Text=" - " />
-                        <Run Text="{Binding LayerViewStatus, Mode=OneWay}"/>
-                    </TextBlock>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
+        <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
+        <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.Windows.Samples.DisplayLayerViewState
             // Add the feature layer to map
             myMap.OperationalLayers.Add(myFeatureLayer);
 
-            // Create a mappoint the map should zoom to
+            // Create a map point the map should zoom to
             MapPoint mapPoint = new MapPoint(-11000000, 4500000, SpatialReferences.WebMercator);
 
             // Set the initial viewpoint for map
@@ -81,8 +81,8 @@ namespace ArcGISRuntime.Windows.Samples.DisplayLayerViewState
 
         private void OnLayerViewStateChanged(object sender, LayerViewStateChangedEventArgs e)
         {
-            // For each execution of the MapView.LayerViewStateChanges Event, get the name of
-            // the layer and it's LayerViewState.Status
+            // For each execution of the MapView.LayerViewStateChanged Event, get the name of
+            // the layer and its LayerViewState.Status
             string lName = e.Layer.Name;
             string lViewStatus = e.LayerViewState.Status.ToString();
 

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -10,17 +10,11 @@
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace ArcGISRuntime.Windows.Samples.DisplayLayerViewState
 {
     public sealed partial class DisplayLayerViewState
     {
-        // Reference to list of view status for each layer
-        private List<LayerStatusModel> _layerStatusModels = new List<LayerStatusModel>();
 
         public DisplayLayerViewState()
         {
@@ -78,15 +72,6 @@ namespace ArcGISRuntime.Windows.Samples.DisplayLayerViewState
             // Set the initial viewpoint for map
             myMap.InitialViewpoint = new Viewpoint(mapPoint, 50000000);
 
-            // Initialize the model list with unknown status for each layer
-            foreach (Layer layer in myMap.OperationalLayers)
-            {
-                _layerStatusModels.Add(new LayerStatusModel(layer.Name, "Unknown"));
-            }
-
-            // Set models list as a itemssource
-            layerStatusListView.ItemsSource = _layerStatusModels;
-
             // Event for layer view state changed
             MyMapView.LayerViewStateChanged += OnLayerViewStateChanged;
 
@@ -96,42 +81,25 @@ namespace ArcGISRuntime.Windows.Samples.DisplayLayerViewState
 
         private void OnLayerViewStateChanged(object sender, LayerViewStateChangedEventArgs e)
         {
-            // State changed event is sent by a layer. In the list, find the layer which sends this event. 
-            // If it exists then update the status
-            var model = _layerStatusModels.FirstOrDefault(l => l.LayerName == e.Layer.Name);
-            if (model != null)
-                model.LayerViewStatus = e.LayerViewState.Status.ToString();
-        }
+            // For each execution of the MapView.LayerViewStateChanges Event, get the name of
+            // the layer and it's LayerViewState.Status
+            string lName = e.Layer.Name;
+            string lViewStatus = e.LayerViewState.Status.ToString();
 
-        /// <summary>
-        /// This is a custom class that holds information for layer name and status
-        /// </summary>
-        public class LayerStatusModel : INotifyPropertyChanged
-        {
-            private string layerViewStatus;
-
-            public string LayerName { get; private set; }
-
-            public string LayerViewStatus
+            // Display the layer name and view status in the appropriate TextBlock control
+            switch (lName)
             {
-                get { return layerViewStatus; }
-                set { layerViewStatus = value; NotifyPropertyChanged(); }
-            }
-
-            public LayerStatusModel(string layerName, string layerStatus)
-            {
-                LayerName = layerName;
-                LayerViewStatus = layerStatus;
-            }
-
-            public event PropertyChangedEventHandler PropertyChanged;
-
-            private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
-            {
-                if (PropertyChanged != null)
-                {
-                    PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-                }
+                case "Tiled Layer":
+                    StatusLabel_TiledLayer.Text = lName + " - " + lViewStatus;
+                    break;
+                case "Image Layer":
+                    StatusLabel_ImageLayer.Text = lName + " - " + lViewStatus;
+                    break;
+                case "Feature Layer":
+                    StatusLabel_FeatureLayer.Text = lName + " - " + lViewStatus;
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
@@ -14,8 +14,10 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
+      <StackPanel Orientation="Vertical">
         <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
         <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
         <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
+      </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
@@ -14,16 +14,8 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
-        <ListView x:Name="layerStatusListView" Grid.Row="1">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Margin="2">
-                        <Run Text="{Binding LayerName, Mode=OneWay}"/>
-                        <Run Text=" - " />
-                        <Run Text="{Binding LayerViewStatus, Mode=OneWay}"/>
-                    </TextBlock>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
+        <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
+        <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml
@@ -14,10 +14,15 @@
             <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
         <esriUI:MapView x:Name="MyMapView"/>
-      <StackPanel Orientation="Vertical">
-        <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
-        <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
-        <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
-      </StackPanel>
+        <Border
+            Background="White" BorderBrush="Black" BorderThickness="1"
+            HorizontalAlignment="Left" VerticalAlignment="Top"
+            Margin="30" Padding="20" Width="250">
+            <StackPanel Orientation="Vertical">
+                <TextBlock x:Name="StatusLabel_TiledLayer" Text=""/>
+                <TextBlock x:Name="StatusLabel_ImageLayer" Text=""/>
+                <TextBlock x:Name="StatusLabel_FeatureLayer" Text=""/>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
@@ -62,7 +62,7 @@ Namespace DisplayLayerViewState
             ' Add the feature layer to map
             myMap.OperationalLayers.Add(myFeatureLayer)
 
-            ' Create a mappoint the map should zoom to
+            ' Create a map point the map should zoom to
             Dim mapPoint As New MapPoint(-11000000, 4500000, SpatialReferences.WebMercator)
 
             ' Set the initial viewpoint for map
@@ -78,8 +78,8 @@ Namespace DisplayLayerViewState
 
         Private Sub OnLayerViewStateChanged(sender As Object, e As LayerViewStateChangedEventArgs)
 
-            ' For each execution of the MapView.LayerViewStateChanges Event, get the name of
-            ' the layer and it's LayerViewState.Status
+            ' For each execution of the MapView.LayerViewStateChanged Event, get the name of
+            ' the layer and its LayerViewState.Status
             Dim lName As String = e.Layer.Name
             Dim lViewStatus As String = e.LayerViewState.Status.ToString()
 

--- a/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
+++ b/src/Windows/ArcGISRuntime.Windows.Samples/Samples/MapView/DisplayLayerViewState/DisplayLayerViewStateVB.xaml.vb
@@ -11,18 +11,20 @@ Imports Esri.ArcGISRuntime.Geometry
 Imports Esri.ArcGISRuntime.Mapping
 
 Namespace DisplayLayerViewState
+
     Partial Public NotInheritable Class DisplayLayerViewStateVB
-        ' Reference to list of view status for each layer
-        Private _layerStatusModels As New List(Of LayerStatusModel)()
 
         Public Sub New()
+
             InitializeComponent()
 
             ' Create the UI, setup the control references and execute initialization 
             Initialize()
+
         End Sub
 
         Private Sub Initialize()
+
             ' Create new Map
             Dim myMap As New Map()
 
@@ -66,68 +68,34 @@ Namespace DisplayLayerViewState
             ' Set the initial viewpoint for map
             myMap.InitialViewpoint = New Viewpoint(mapPoint, 50000000)
 
-            ' Initialize the model list with unknown status for each layer
-            For Each layer As Layer In myMap.OperationalLayers
-                _layerStatusModels.Add(New LayerStatusModel(layer.Name, "Unknown"))
-            Next
-
-            ' Set models list as a itemssource
-            layerStatusListView.ItemsSource = _layerStatusModels
-
             ' Event for layer view state changed
             AddHandler MyMapView.LayerViewStateChanged, AddressOf OnLayerViewStateChanged
 
             ' Provide used Map to the MapView
             MyMapView.Map = myMap
+
         End Sub
 
         Private Sub OnLayerViewStateChanged(sender As Object, e As LayerViewStateChangedEventArgs)
-            ' State changed event is sent by a layer. In the list, find the layer which sends this event. 
-            ' If it exists then update the status
-            Dim model = _layerStatusModels.FirstOrDefault(Function(l) l.LayerName = e.Layer.Name)
-            If model IsNot Nothing Then
-                model.LayerViewStatus = e.LayerViewState.Status.ToString()
-            End If
+
+            ' For each execution of the MapView.LayerViewStateChanges Event, get the name of
+            ' the layer and it's LayerViewState.Status
+            Dim lName As String = e.Layer.Name
+            Dim lViewStatus As String = e.LayerViewState.Status.ToString()
+
+            ' Display the layer name and view status in the appropriate TextBlock control
+            Select Case lName
+                Case "Tiled Layer"
+                    StatusLabel_TiledLayer.Text = lName & " - " & lViewStatus
+                Case "Image Layer"
+                    StatusLabel_ImageLayer.Text = lName & " - " & lViewStatus
+                Case "Feature Layer"
+                    StatusLabel_FeatureLayer.Text = lName & " - " & lViewStatus
+                Case Else
+            End Select
+
         End Sub
 
-        ''' <summary>
-        ''' This is a custom class that holds information for layer name and status
-        ''' </summary>
-        Public Class LayerStatusModel
-            Implements INotifyPropertyChanged
-            Private m_layerViewStatus As String
-
-            Public Property LayerName() As String
-                Get
-                    Return m_LayerName
-                End Get
-                Private Set
-                    m_LayerName = Value
-                End Set
-            End Property
-            Private m_LayerName As String
-
-
-            Public Property LayerViewStatus() As String
-                Get
-                    Return m_layerViewStatus
-                End Get
-                Set
-                    m_layerViewStatus = Value
-                    NotifyPropertyChanged()
-                End Set
-            End Property
-
-            Public Sub New(layerName__1 As String, layerStatus As String)
-                LayerName = layerName__1
-                LayerViewStatus = layerStatus
-            End Sub
-
-            Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
-
-            Private Sub NotifyPropertyChanged(<CallerMemberName> Optional propertyName As String = "")
-                RaiseEvent PropertyChanged(Me, New PropertyChangedEventArgs(propertyName))
-            End Sub
-        End Class
     End Class
+
 End Namespace


### PR DESCRIPTION
Made changes for the DisplayLayerViewState sample to be uniform with  the other SDK versions. Modified both C# and VB.NET versions. Simplified the code to more applicable for a LibRefAPI code sample rather than a platform specific MVVM/data-binding best practices sample. 

