### PR TITLE
iOS: Build fixes and non-SSL access

### DIFF
--- a/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -30,7 +30,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowMagnifier
             Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
 
             // Enable magnifier
-            MyMapView.IsMagnifierEnabled = true;
+            MyMapView.InteractionOptions.IsMagnifierEnabled = true;
 
             // Assign the map to the MapView
             MyMapView.Map = myMap;

--- a/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
+++ b/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
@@ -81,6 +81,20 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchSdkVersion>9.3</MtouchSdkVersion>
+    <MtouchLink>Full</MtouchLink>
+    <MtouchDebug>False</MtouchDebug>
+    <MtouchProfiling>False</MtouchProfiling>
+    <MtouchFastDev>False</MtouchFastDev>
+    <MtouchUseLlvm>False</MtouchUseLlvm>
+    <MtouchUseThumb>False</MtouchUseThumb>
+    <MtouchEnableBitcode>False</MtouchEnableBitcode>
+    <MtouchUseSGen>False</MtouchUseSGen>
+    <MtouchUseRefCounting>False</MtouchUseRefCounting>
+    <OptimizePNGs>True</OptimizePNGs>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchFloat32>False</MtouchFloat32>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>none</DebugType>

--- a/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
+++ b/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
@@ -29,7 +29,6 @@
     <MtouchSdkVersion>9.2</MtouchSdkVersion>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
-    <MtouchExtraArgs>-gcc_flags "-L${ProjectDir} -lArcGIS"</MtouchExtraArgs>
     <MtouchUseLlvm>False</MtouchUseLlvm>
     <MtouchUseThumb>False</MtouchUseThumb>
     <MtouchUseSGen>False</MtouchUseSGen>
@@ -64,7 +63,6 @@
     <MtouchLink>None</MtouchLink>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchFastDev>False</MtouchFastDev>
-    <MtouchExtraArgs>-gcc_flags "-L${ProjectDir} -lArcGIS"</MtouchExtraArgs>
     <MtouchUseLlvm>False</MtouchUseLlvm>
     <MtouchUseThumb>False</MtouchUseThumb>
     <MtouchUseSGen>False</MtouchUseSGen>

--- a/src/Forms/iOS/Info.plist
+++ b/src/Forms/iOS/Info.plist
@@ -38,5 +38,10 @@
   <string></string>
   <key>NSLocationWhenInUseUsageDescription</key>
   <string></string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -82,6 +82,17 @@
     <MtouchArch>ARMv7, ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchLink>Full</MtouchLink>
+    <MtouchDebug>False</MtouchDebug>
+    <MtouchProfiling>False</MtouchProfiling>
+    <MtouchFastDev>False</MtouchFastDev>
+    <MtouchUseLlvm>False</MtouchUseLlvm>
+    <MtouchUseThumb>False</MtouchUseThumb>
+    <MtouchEnableBitcode>False</MtouchEnableBitcode>
+    <MtouchUseSGen>False</MtouchUseSGen>
+    <MtouchUseRefCounting>False</MtouchUseRefCounting>
+    <OptimizePNGs>True</OptimizePNGs>
+    <MtouchFloat32>False</MtouchFloat32>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>

--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -257,7 +257,7 @@
     <EmbeddedResource Include="Samples\Map\ManageBookmarks\metadata.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
-    <BundleResource Include="Samples\Layers\ArcGISVectorTiledLayerUrl\metadata.json" />
+    <EmbeddedResource Include="Samples\Layers\ArcGISVectorTiledLayerUrl\metadata.json" />
     <BundleResource Include="Samples\MapView\ShowMagnifier\metadata.json" />
     <EmbeddedResource Include="Samples\Layers\CreateFeatureCollectionLayer\metadata.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/iOS/Xamarin.iOS/Info.plist
+++ b/src/iOS/Xamarin.iOS/Info.plist
@@ -45,5 +45,10 @@
   <string></string>
   <key>NSLocationWhenInUseUsageDescription</key>
   <string></string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -43,7 +43,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowMagnifier
             Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
 
             // Enable magnifier
-            _myMapView.IsMagnifierEnabled = true;
+            _myMapView.InteractionOptions.IsMagnifierEnabled = true;
 
             // Assign the map to the MapView
             _myMapView.Map = myMap;


### PR DESCRIPTION
Includes several updates to Forms and Xamarin.iOS sample apps:

- Update magnifier sample to use InteractionOptions
- Fix vector tiled layer sample not showing up in Xamarin.iOS app
- Remove gcc-flags linker parameters
- Link all assemblies for release builds
- Allow access to non-SSL http endpoints