### PR TITLE
Removed references to the PublicKeyToken from the samples.

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Samples/ArcGISRuntime.WPF.Samples.CSharp.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/ArcGISRuntime.WPF.Samples.CSharp.csproj
@@ -33,10 +33,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.WPF.100.0.0\lib\net452\Esri.ArcGISRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/WPF/ArcGISRuntime.WPF.Samples/ArcGISRuntime.WPF.Samples.VBNet.vbproj
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/ArcGISRuntime.WPF.Samples.VBNet.vbproj
@@ -52,10 +52,7 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.WPF.100.0.0\lib\net452\Esri.ArcGISRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -42,10 +42,7 @@
     <ApplicationIcon>Assets\ApplicationIcons\windows-desktop-256.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.WPF.100.0.0\lib\net452\Esri.ArcGISRuntime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />


### PR DESCRIPTION
@mbranscomb The references to the PublicKeyToken are causing compile errors. The shortened syntax for the 'reference' tags work much better in the .csproj and .vbproj files. 