### PR TITLE
Updated Samples service url to use SSL

### DIFF
--- a/src/Forms/Shared/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerQuery
     public partial class FeatureLayerQuery : ContentPage
     {
         // Create reference to service of US States  
-        private string _statesUrl = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2";
+        private string _statesUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2";
 
         // Create globally available feature table for easy referencing 
         private ServiceFeatureTable _featureTable;

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.xaml.cs
@@ -39,7 +39,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableCache
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Create feature table for the pools feature service
             ServiceFeatureTable poolsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
@@ -40,7 +40,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableManualCache
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
 
             // Create feature table for the incident feature service
             _incidentsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.xaml.cs
@@ -39,7 +39,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableNoCache
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Create feature table for the pools feature service
             ServiceFeatureTable poolsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/Forms/Shared/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISMapImageLayerUrl
 
             // Create uri to the map image layer
             var serviceUri = new Uri(
-               "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer");
+               "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer");
 
             // Create new image layer from the url
             ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(serviceUri);

--- a/src/Forms/Shared/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISTiledLayerUrl
 
             // Create uri to the tiled service
             var serviceUri = new Uri(
-               "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer");
+               "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer");
 
             // Create new tiled layer from the url
             ArcGISTiledLayer imageLayer = new ArcGISTiledLayer(serviceUri);

--- a/src/Forms/Shared/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
@@ -15,10 +15,10 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISVectorTiledLayerUrl
 {
     public partial class ArcGISVectorTiledLayerUrl : ContentPage
     {
-        private string _navigationUrl = "http://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "http://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "http://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "http://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/Forms/Shared/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChangeFeatureLayerRenderer
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             ServiceFeatureTable featureTable = new ServiceFeatureTable(serviceUri);

--- a/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChangeSublayerVisibility
 
             // Create uri to the map image layer
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer");
 
             // Create new image layer from the url
             _imageLayer = new ArcGISMapImageLayer(serviceUri)

--- a/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
@@ -17,7 +17,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureCollectionLayerFromQuery
     public partial class FeatureCollectionLayerFromQuery : ContentPage
     {
         // Feature service URL to query for features
-        private const string FeatureLayerUrl = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0";
+        private const string FeatureLayerUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0";
 
         public FeatureCollectionLayerFromQuery()
         {

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.xaml.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerDefinitionExpression
 
             // Create the uri for the feature service
             Uri featureServiceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             ServiceFeatureTable featureTable = new ServiceFeatureTable(featureServiceUri);

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerSelection
 
             // Create Uri for the feature service
             Uri featureServiceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             var featureTable = new ServiceFeatureTable(featureServiceUri);

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.xaml.cs
@@ -38,7 +38,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerUrl
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
 
             // Create new FeatureLayer from service uri and
             FeatureLayer geologyLayer = new FeatureLayer(serviceUri);

--- a/src/Forms/Shared/Samples/Map/OpenExistingMap/OpenExistingMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenExistingMap/OpenExistingMap.xaml.cs
@@ -19,9 +19,9 @@ namespace ArcGISRuntimeXamarin.Samples.OpenExistingMap
         // String array to hold urls to publicly available web maps
         private string[] itemURLs = new string[]
         {
-            "http://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
-            "http://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
-            "http://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
+            "https://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "https://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
+            "https://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
 
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above

--- a/src/Forms/Shared/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.xaml.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntimeXamarin.Samples.SetMapSpatialReference
             // Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial 
             // reference is not the same as the map's spatial reference
             ArcGISMapImageLayer operationalLayer = new ArcGISMapImageLayer(new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
            
             // Add operational layer to the Map
             myMap.OperationalLayers.Add(operationalLayer);

--- a/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -37,7 +37,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayDrawingStatus
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
             // Initialize a new feature layer
             ServiceFeatureTable myFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/Forms/Shared/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.xaml.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
 
             // Create the uri for the tiled layer
             var tiledLayerUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
 
             // Create a tiled layer using url
             ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tiledLayerUri);
@@ -53,7 +53,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
 
             // Create the uri for the ArcGISMapImage layer
             var imageLayerUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
 
             // Create ArcGISMapImage layer using a url
             ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(imageLayerUri);
@@ -68,7 +68,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
 
             // Create Uri for feature layer
             var featureLayerUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0");
 
             // Create a feature layer using url
             FeatureLayer myFeatureLayer = new FeatureLayer(featureLayerUri);

--- a/src/Forms/Shared/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
@@ -59,7 +59,7 @@ namespace ArcGISRuntimeXamarin.Samples.RenderPictureMarkers
         {
             // Create uri to the used image
             var symbolUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
 
             // Create new symbol using asynchronous factory method from uri
             PictureMarkerSymbol campsiteSymbol = new PictureMarkerSymbol(symbolUri);

--- a/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
+++ b/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
@@ -153,11 +153,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=29c6dd6e8553d944, processorArchitecture=MSIL">
+    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.0.0\lib\Xamarin.iOS10\Esri.ArcGISRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Esri.ArcGISRuntime.Xamarin.Forms, Version=100.0.0.0, Culture=neutral, PublicKeyToken=29c6dd6e8553d944, processorArchitecture=MSIL">
+    <Reference Include="Esri.ArcGISRuntime.Xamarin.Forms, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Forms.100.0.0\lib\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.Forms.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/src/Forms/iOS/Info.plist
+++ b/src/Forms/iOS/Info.plist
@@ -38,10 +38,5 @@
 	<string></string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -125,7 +125,7 @@
     <OutputPath>..\..\..\output\iOS\iPhoneSimulator\AppStore\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=29c6dd6e8553d944, processorArchitecture=MSIL">
+    <Reference Include="Esri.ArcGISRuntime, Version=100.0.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.0.0\lib\Xamarin.iOS10\Esri.ArcGISRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/src/iOS/Xamarin.iOS/Entitlements.plist
+++ b/src/iOS/Xamarin.iOS/Entitlements.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict/>
 </plist>

--- a/src/iOS/Xamarin.iOS/Info.plist
+++ b/src/iOS/Xamarin.iOS/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
@@ -45,10 +45,5 @@
   <string></string>
   <key>NSLocationWhenInUseUsageDescription</key>
   <string></string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerQuery
         private MapView _myMapView = new MapView();
 
         // Create reference to service of US States  
-        private string _statesUrl = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2";
+        private string _statesUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/2";
 
         // Create globally available text box for easy referencing 
         private UITextField _queryTextView;

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.cs
@@ -52,8 +52,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableCache
             myMap.InitialViewpoint = new Viewpoint(initialLocation);
 
             // Create uri to the used feature service
-            var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+            var serviceUri = new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Create feature table for the pools feature service
             ServiceFeatureTable poolsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableManualCache
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
 
             // Create feature table for the incident feature service
             _incidentsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cs
@@ -53,7 +53,7 @@ namespace ArcGISRuntimeXamarin.Samples.ServiceFeatureTableNoCache
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Create feature table for the pools feature service
             ServiceFeatureTable poolsFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cs
@@ -45,7 +45,7 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISMapImageLayerUrl
 
             // Create uri to the map image layer
             var serviceUri = new Uri(
-               "http://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer");
+               "https://sampleserver5.arcgisonline.com/arcgis/rest/services/Elevation/WorldElevations/MapServer");
 
             // Create new image layer from the url
             ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
@@ -22,10 +22,10 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISVectorTiledLayerUrl
          // Create and hold reference to the used MapView
         private MapView _myMapView = new MapView();
 
-        private string _navigationUrl = "http://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "http://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "http://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "http://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.cs
@@ -60,7 +60,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChangeFeatureLayerRenderer
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-               "http://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
+               "https://sampleserver6.arcgisonline.com/arcgis/rest/services/PoolPermits/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             ServiceFeatureTable featureTable = new ServiceFeatureTable(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChangeSublayerVisibility
 
             // Create a new ArcGISMapImageLayer instance and pass a Url to the service
             var mapImageLayer = new ArcGISMapImageLayer(
-                new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
+                new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
 
             // Await the load call for the layer.
             await mapImageLayer.LoadAsync();

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureCollectionLayerFromQuery
         private MapView _myMapView;
 
         // URL for a feature service layer to query
-        private const string FeatureLayerUrl = "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0";
+        private const string FeatureLayerUrl = "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/0";
 
         public FeatureCollectionLayerFromQuery()
         {

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cs
@@ -55,7 +55,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerDefinitionExpression
             _myMapView.Map = myMap;
 
             // Create the uri for the feature service
-            Uri featureServiceUri = new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
+            Uri featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             ServiceFeatureTable featureTable = new ServiceFeatureTable(featureServiceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
@@ -60,7 +60,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerSelection
 
             // Create Uri for the feature service
             Uri featureServiceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
             // Initialize feature table using a url to feature server url
             var featureTable = new ServiceFeatureTable(featureServiceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.cs
@@ -51,7 +51,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerUrl
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Energy/Geology/FeatureServer/9");
 
             // Create new FeatureLayer from service uri and
             FeatureLayer geologyLayer = new FeatureLayer(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/Map/OpenExistingMap/OpenExistingMap.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/OpenExistingMap/OpenExistingMap.cs
@@ -27,9 +27,9 @@ namespace ArcGISRuntimeXamarin.Samples.OpenExistingMap
         // String array to hold urls to publicly available web maps
         private string[] itemURLs = new string[] 
         {
-            "http://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
-            "http://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
-            "http://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
+            "https://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "https://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
+            "https://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
 
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntimeXamarin.Samples.SetMapSpatialReference
             // Note: Some layer such as tiled layer cannot reproject and will fail to draw if their spatial 
             // reference is not the same as the map's spatial reference
             ArcGISMapImageLayer operationalLayer = new ArcGISMapImageLayer(new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/SampleWorldCities/MapServer"));
 
             // Add operational layer to the Map
             myMap.OperationalLayers.Add(operationalLayer);

--- a/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -50,7 +50,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayDrawingStatus
 
             // Create uri to the used feature service
             var serviceUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
             // Initialize a new feature layer
             ServiceFeatureTable myFeatureTable = new ServiceFeatureTable(serviceUri);

--- a/src/iOS/Xamarin.iOS/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
             Map myMap = new Map();
 
             // Create the uri for the tiled layer
-            Uri tiledLayerUri = new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
+            Uri tiledLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
 
             // Create a tiled layer using url
             ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(tiledLayerUri);
@@ -58,7 +58,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
             myMap.OperationalLayers.Add(tiledLayer);
 
             // Create the uri for the ArcGISMapImage layer
-            var imageLayerUri = new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
+            var imageLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer");
 
             // Create ArcGISMapImage layer using a url
             ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(imageLayerUri);
@@ -72,7 +72,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayLayerViewState
             myMap.OperationalLayers.Add(imageLayer);
 
             //Create Uri for feature layer
-            var featureLayerUri = new Uri("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0");
+            var featureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0");
 
             //Create a feature layer using url
             FeatureLayer myFeatureLayer = new FeatureLayer(featureLayerUri);

--- a/src/iOS/Xamarin.iOS/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.cs
@@ -71,7 +71,7 @@ namespace ArcGISRuntimeXamarin.Samples.RenderPictureMarkers
         {
             // Create uri to the used image
             var symbolUri = new Uri(
-                "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
+                "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
 
             // Create new symbol using asynchronous factory method from uri
             PictureMarkerSymbol campsiteSymbol = new PictureMarkerSymbol(symbolUri);


### PR DESCRIPTION
This is a pull request to update Urls in Ios samples to use SSL where possible or have in the case where no SSL url exists an explicit exceptions for the required domain added to the info.plist 