### PR TITLE
Updates to Android OAuth sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Security/OAuth/OAuth.csproj
+++ b/src/Android/Xamarin.Android/Samples/Security/OAuth/OAuth.csproj
@@ -20,7 +20,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
@@ -29,6 +29,15 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis>armeabi;armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
+    <Debugger>Xamarin</Debugger>
+    <AotAssemblies>False</AotAssemblies>
+    <EnableLLVM>False</EnableLLVM>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
+    <EnableProguard>False</EnableProguard>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -49,12 +58,24 @@
     </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="PCLCrypto, Version=0.5.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\PCLCrypto.0.5.0.14108\lib\monoandroid\PCLCrypto.dll</HintPath>
+    <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\PCLCrypto.2.0.147\lib\MonoAndroid23\PCLCrypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PCLCrypto.Abstractions, Version=0.5.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\PCLCrypto.0.5.0.14108\lib\monoandroid\PCLCrypto.Abstractions.dll</HintPath>
+    <Reference Include="PInvoke.BCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\PInvoke.BCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.BCrypt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PInvoke.Kernel32, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\PInvoke.Kernel32.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Kernel32.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PInvoke.NCrypt, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\PInvoke.NCrypt.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.NCrypt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PInvoke.Windows.Core, Version=0.3.0.0, Culture=neutral, PublicKeyToken=9e300f9f87f04a7a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\PInvoke.Windows.Core.0.3.2\lib\portable-net45+win+wpa81+MonoAndroid10+xamarinios10+MonoTouch10\PInvoke.Windows.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -62,8 +83,8 @@
     <Reference Include="System.Json" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="Validation, Version=2.0.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\..\packages\Validation.2.0.4.14103\lib\portable-windows8+net40+sl5+wp8+wpa81+wp81+MonoAndroid+MonoTouch\Validation.dll</HintPath>
+    <Reference Include="Validation, Version=2.2.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Validation.2.2.8\lib\dotnet\Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.Auth, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Android/Xamarin.Android/Samples/Security/OAuth/OpenMapOAuth.cs
+++ b/src/Android/Xamarin.Android/Samples/Security/OAuth/OpenMapOAuth.cs
@@ -31,6 +31,7 @@ namespace ArcGISRuntimeXamarin.Samples.OpenMapOAuth
         private TaskCompletionSource<IDictionary<string, string>> _taskCompletionSource;
         
         // Constants for OAuth-related values ...
+        // Note: the default values are subject to change, in which case the sample will not work 'out-of-the-box'       
         // TODO: URL of the portal to authenticate with
         private const string PortalUrl = "https://www.arcgis.com/sharing/rest";
 
@@ -45,7 +46,7 @@ namespace ArcGISRuntimeXamarin.Samples.OpenMapOAuth
 
         // TODO: Add URL for redirecting after a successful authorization
         //       Note - this must be a URL configured as a valid Redirect URI with your app
-        private const string OAuthRedirectUrl = "http://myapps.portalmapapp";
+        private const string OAuthRedirectUrl = "https://developers.arcgis.com";
 
         // URL used by the server for authorization
         private const string AuthorizeUrl = "https://www.arcgis.com/sharing/oauth2/authorize";

--- a/src/Android/Xamarin.Android/Samples/Security/OAuth/packages.config
+++ b/src/Android/Xamarin.Android/Samples/Security/OAuth/packages.config
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Esri.ArcGISRuntime.Xamarin.Android" version="100.0.0" targetFramework="monoandroid60" />
-  <package id="PCLCrypto" version="0.5.0.14108" targetFramework="monoandroid60" />
-  <package id="Validation" version="2.0.4.14103" targetFramework="monoandroid60" />
+  <package id="PCLCrypto" version="2.0.147" targetFramework="monoandroid60" />
+  <package id="PInvoke.BCrypt" version="0.3.2" targetFramework="monoandroid60" />
+  <package id="PInvoke.Kernel32" version="0.3.2" targetFramework="monoandroid60" />
+  <package id="PInvoke.NCrypt" version="0.3.2" targetFramework="monoandroid60" />
+  <package id="PInvoke.Windows.Core" version="0.3.2" targetFramework="monoandroid60" />
+  <package id="Validation" version="2.2.8" targetFramework="monoandroid60" />
   <package id="Xamarin.Auth" version="1.3.1.1" targetFramework="monoandroid60" />
 </packages>


### PR DESCRIPTION
 - Updated the default redirect URI value, as it had changed in the app settings (ArcGIS Online)
 - Updated Xamarin.Auth dependencies to newer versions (PCLCrypto, Validation, etc.)
 - Turned off Arm64 support for the project (known limitation that enabling this will cause Arm64 deployments to fail)