### PR TITLE
Fix to prevent GeoViewTapped from firing twice

### DIFF
--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.cs
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.cs
@@ -36,9 +36,9 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyGraphics
             Title = "Identify graphics";
         }
 
-        public override void ViewDidLayoutSubviews()
+        public override void ViewDidLoad()
         {
-            base.ViewDidLayoutSubviews();
+            base.ViewDidLoad();
 
             // Create the UI, setup the control references and execute initialization 
             CreateLayout();


### PR DESCRIPTION
Hook event in ViewDidLoad (which only fires once!).

Thanks @saratchandrakarumuri .. I only changed two lines