### PR TITLE
Update SDK name in Xamarin samples

### DIFF
--- a/src/Android/Xamarin.Android/MainActivity.cs
+++ b/src/Android/Xamarin.Android/MainActivity.cs
@@ -17,7 +17,7 @@ using Android.Content;
 
 namespace ArcGISRuntimeXamarin
 {
-    [Activity(Label = "ArcGIS Runtime SDK for Xamarin Android", MainLauncher = true, Icon = "@drawable/icon")]
+    [Activity(Label = "ArcGIS Runtime SDK for .NET", MainLauncher = true, Icon = "@drawable/icon")]
     public class MainActivity : Activity
     {
         List<TreeItem> _sampleCategories;

--- a/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
+++ b/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
@@ -5,5 +5,5 @@
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<application android:label="ArcGIS Runtime SDK for Xamarin Android" android:icon="@drawable/Icon"></application>
+	<application android:label="ArcGIS Runtime SDK for .NET" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/src/Forms/Android/MainActivity.cs
+++ b/src/Forms/Android/MainActivity.cs
@@ -13,7 +13,7 @@ using Android.OS;
 
 namespace ArcGISRuntimeXamarin.Droid
 {
-	[Activity (Label = "ArcGIS Runtime SDK for Xamarin Forms", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+	[Activity (Label = "ArcGIS Runtime SDK for .NET", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
 	public class MainActivity : Xamarin.Forms.Platform.Android.FormsApplicationActivity
 	{
 		protected override void OnCreate (Bundle bundle)

--- a/src/Forms/Android/Properties/AndroidManifest.xml
+++ b/src/Forms/Android/Properties/AndroidManifest.xml
@@ -5,5 +5,5 @@
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.INTERNET" />
-	<application android:label="ArcGIS Runtime SDK for Xamarin Android" android:icon="@drawable/Icon"></application>
+	<application android:label="ArcGIS Runtime SDK for .NET" android:icon="@drawable/Icon"></application>
 </manifest>

--- a/src/Forms/Shared/App.cs
+++ b/src/Forms/Shared/App.cs
@@ -18,7 +18,7 @@ namespace ArcGISRuntimeXamarin
             // The root page of your application
             var navigationPage = new NavigationPage(new CategoryListPage
             {
-                Title = "ArcGIS Runtime SDK for Xamarin Forms"
+                Title = "ArcGIS Runtime SDK for .NET"
             });
 
             MainPage = navigationPage;

--- a/src/Forms/UWP/Package.appxmanifest
+++ b/src/Forms/UWP/Package.appxmanifest
@@ -15,7 +15,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="FPCL.WIndows.App">
-      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for Xamarin Samples" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Viewer application to browse ArcGIS Runtime SDK for Xamarin samples." BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for .NET" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Viewer application to browse ArcGIS Runtime SDK for Xamarin samples." BackgroundColor="transparent">
         <uap:LockScreen Notification="badge" BadgeLogo="Assets\BadgeLogo.png" />
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" ShortName="ArcGIS Samples" Square310x310Logo="Assets\Square310x310Logo.png" Square71x71Logo="Assets\Square71x71Logo.png">
           <uap:ShowNameOnTiles>

--- a/src/iOS/Xamarin.iOS/Info.plist
+++ b/src/iOS/Xamarin.iOS/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>ArcGIS Runtime SDK for Xamarin iOS</string>
+	<string>ArcGIS Runtime SDK for .NET</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.esri.ArcGISRuntimeSDK_Xamarin_iOS</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Changes to replace all occurrences of "ArcGIS Runtime SDK for Xamarin *" with "ArcGIS Runtime SDK for .NET"

@mbranscomb please review.