### PR TITLE
Fixed duplicate file include in iOS sample project

### DIFF
--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -356,7 +356,6 @@
     <Compile Include="Samples\Layers\ChangeFeatureLayerRenderer\ChangeFeatureLayerRenderer.cs" />
     <Compile Include="Samples\GraphicsOverlay\IdentifyGraphics\IdentifyGraphics.cs" />
     <Compile Include="Samples\GraphicsOverlay\AddGraphicsRenderer\AddGraphicsRenderer.cs" />
-    <Compile Include="Samples\Layers\ArcGISMapImageLayerUrl\ArcGISMapImageLayerUrl.cs" />
     <Compile Include="Samples\Layers\ArcGISTiledLayerUrl\ArcGISTiledLayerUrl.cs" />
     <Compile Include="Samples\Layers\CreateFeatureCollectionLayer\CreateFeatureCollectionLayer.cs" />
     <Compile Include="Samples\Layers\FeatureCollectionLayerFromPortal\FeatureCollectionLayerFromPortal.cs" />


### PR DESCRIPTION
ArcGISMapImageLayerUrl.cs was listed twice in csproj file (lines 354 and 359), causing a build error.