### PR TITLE
Update sample viewer to skip unimplemented samples

### DIFF
--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
@@ -14,7 +14,6 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using System.Reflection;
 
 namespace ArcGISRuntime.Samples.Models
 {

--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
@@ -7,12 +7,14 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
 // language governing permissions and limitations under the License.
 
+using ArcGISRuntime.Samples.Managers;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Reflection;
 
 namespace ArcGISRuntime.Samples.Models
 {
@@ -141,6 +143,22 @@ namespace ArcGISRuntime.Samples.Models
         public DirectoryInfo SampleFolder { get; set; }
 
         /// <summary>
+        /// Gets the full namespace and typename for the VB sample
+        /// </summary>
+        [IgnoreDataMember]
+        public String SampleVbTypeName
+        {
+            get
+            {
+#if !NETFX_CORE
+                return String.Format("{0}.{1}VB, ArcGISRuntime.WPF.Samples.VB, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", SampleNamespace, SampleName);
+#else
+                return String.Format("{0}.{1}VB, ArcGISRuntime.UWP.Samples.VB, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", SampleNamespace, SampleName);
+#endif
+            }
+        }
+
+        /// <summary>
         /// Gets the namespace of the sample.
         /// </summary>
         /// <remarks>
@@ -202,6 +220,12 @@ namespace ArcGISRuntime.Samples.Models
                 sampleModel = serializer.ReadObject(stream) as SampleModel;
 
                 sampleModel.SampleFolder = metadataFile.Directory;
+            }
+
+            // Stop if the sample doesn't have a VB implementation (VB sample viewer only)
+            if (ApplicationManager.Current.SelectedLanguage == Language.VBNet && System.Type.GetType(sampleModel.SampleVbTypeName, false) == null)
+            {
+                return null;
             }
 
             return sampleModel;

--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
@@ -142,10 +142,10 @@ namespace ArcGISRuntime.Samples.Models
         public DirectoryInfo SampleFolder { get; set; }
 
         /// <summary>
-        /// Gets the (expected) assembly-qualified name for the VB sample
+        /// Gets the (expected) assembly-qualified name for the VB sample; useful when determining if VB implementation is present
         /// </summary>
         [IgnoreDataMember]
-        public String SampleVbTypeName
+        public String ExpectedVbAssemblyQualifiedType
         {
             get
             {
@@ -222,7 +222,7 @@ namespace ArcGISRuntime.Samples.Models
             }
 
             // Stop if the sample doesn't have a VB implementation (VB sample viewer only)
-            if (ApplicationManager.Current.SelectedLanguage == Language.VBNet && System.Type.GetType(sampleModel.SampleVbTypeName, false) == null)
+            if (ApplicationManager.Current.SelectedLanguage == Language.VBNet && System.Type.GetType(sampleModel.ExpectedVbAssemblyQualifiedType, false) == null)
             {
                 return null;
             }

--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
@@ -143,7 +143,7 @@ namespace ArcGISRuntime.Samples.Models
         public DirectoryInfo SampleFolder { get; set; }
 
         /// <summary>
-        /// Gets the full namespace and typename for the VB sample
+        /// Gets the (expected) assembly-qualified name for the VB sample
         /// </summary>
         [IgnoreDataMember]
         public String SampleVbTypeName

--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleModel.cs
@@ -150,10 +150,10 @@ namespace ArcGISRuntime.Samples.Models
         {
             get
             {
-#if !NETFX_CORE
-                return String.Format("{0}.{1}VB, ArcGISRuntime.WPF.Samples.VB, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", SampleNamespace, SampleName);
-#else
+#if NETFX_CORE
                 return String.Format("{0}.{1}VB, ArcGISRuntime.UWP.Samples.VB, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", SampleNamespace, SampleName);
+#else
+                return String.Format("{0}.{1}VB, ArcGISRuntime.WPF.Samples.VB, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", SampleNamespace, SampleName);
 #endif
             }
         }


### PR DESCRIPTION
The sample viewer needs to be updated as there are now samples that are implemented only for C# (and not VB). This PR accomplishes that by adding a new property to the `SampleModel` called `SampleVbTypeName` which provides the assembly-qualified name of the VB sample (should it exist). This is then passed to `System.Type.GetType` on sample creation; if the result is null, the sample model is not created. 