### PR TITLE
Changes Xamarin Android package name

### DIFF
--- a/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
+++ b/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto" package="ArcGISRuntimeXamarin_Android.ArcGISRuntimeXamarin_Android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto" package="ArcGISRuntimeXamarin_Android.AGR_Android">
 	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
+++ b/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto" package="ArcGISRuntimeXamarin_Android.AGR_Android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto" package="ArcGISRuntimeSDK_Xamarin_Android">
 	<uses-sdk android:minSdkVersion="16" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />


### PR DESCRIPTION
With this change, it will now be possible to use the native and the
Forms versions of the sample viewer side-by-side on Android without errors. This brings the experience up to par with that of iOS.