### PR TITLE
FeatureLayer Query sample -  Format search terms 

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
@@ -105,7 +105,7 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerQuery
                 QueryParameters queryParams = new QueryParameters();
 
                 // Construct and assign the where clause that will be used to query the feature table 
-                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + (stateName.ToUpper()) + "%'";
+                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + (stateName.Trim().ToUpper()) + "%'";
 
                 // Query the feature table 
                 FeatureQueryResult queryResult = await _featureTable.QueryFeaturesAsync(queryParams);

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -90,8 +90,11 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerQuery
                 // Create a query parameters that will be used to Query the feature table  
                 QueryParameters queryParams = new QueryParameters();
 
+                // Trim whitespace on the state name to prevent broken queries
+                String formattedStateName = stateName.Trim().ToUpper();
+
                 // Construct and assign the where clause that will be used to query the feature table 
-                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + (stateName.ToUpper()) + "%'";
+                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + formattedStateName + "%'";
 
                 // Query the feature table 
                 FeatureQueryResult queryResult = await _featureTable.QueryFeaturesAsync(queryParams);

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -90,8 +90,11 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerQuery
                 // Create a query parameters that will be used to Query the feature table  
                 QueryParameters queryParams = new QueryParameters();
 
+                // Trim whitespace on the state name to prevent broken queries
+                String formattedStateName = stateName.Trim().ToUpper();
+
                 // Construct and assign the where clause that will be used to query the feature table 
-                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + (stateName.ToUpper()) + "%'";
+                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + formattedStateName + "%'";
 
                 // Query the feature table 
                 FeatureQueryResult queryResult = await _featureTable.QueryFeaturesAsync(queryParams);

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
@@ -127,8 +127,11 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerQuery
                 // Create a query parameters that will be used to Query the feature table  
                 QueryParameters queryParams = new QueryParameters();
 
+                // Trim whitespace on the state name to prevent broken queries
+                String formattedStateName = stateName.Trim().ToUpper();
+
                 // Construct and assign the where clause that will be used to query the feature table 
-                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + (stateName.ToUpper()) + "%'";
+                queryParams.WhereClause = "upper(STATE_NAME) LIKE '%" + formattedStateName + "%'";
 
                 // Query the feature table 
                 FeatureQueryResult queryResult = await _featureTable.QueryFeaturesAsync(queryParams);


### PR DESCRIPTION
This is a small pull request to make sure that the search terms used in the Query FeatureLayer sample have any rogue white space removed. Issue was just for Droid but have made changes to other platforms while i was in there.  @nCastle1 can you give a once over please?