### PR TITLE
Added 'DataFileNames' attribute to the metadata.json files so the sample could be built by the SampleSolutionGenerator.exe

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/metadata.json
@@ -8,6 +8,7 @@
   "RequiresOfflineData": true,
   "RequiresLocalServer": false,
   "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
+  "DataFileNames": [ "AuroraCO.gpkg" ],
   "Image": "FeatureLayerGeoPackage.jpg",
   "Link": "",
   "TypeLink": [ "T:Esri.ArcGISRuntime.Data.GeoPackage", "T:Esri.ArcGISRuntime.Data.GeoPackageFeatureTable", "P:Esri.ArcGISRuntime.Data.GeoPackage.GeoPackageFeatureTables", "M:Esri.ArcGISRuntime.Data.GeoPackage.OpenAsync(System.String)" ],

--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/metadata.json
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/metadata.json
@@ -8,6 +8,7 @@
   "RequiresOfflineData": true,
   "RequiresLocalServer": false,
   "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
+  "DataFileNames": [ "AuroraCO.gpkg" ],
   "Image": "FeatureLayerGeoPackage.jpg",
   "Link": "",
   "TypeLink": [ "T:Esri.ArcGISRuntime.Data.GeoPackage", "T:Esri.ArcGISRuntime.Data.GeoPackageFeatureTable", "P:Esri.ArcGISRuntime.Data.GeoPackage.GeoPackageFeatureTables", "M:Esri.ArcGISRuntime.Data.GeoPackage.OpenAsync(System.String)" ],

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Data/FeatureLayerGeoPackage/metadata.json
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Data/FeatureLayerGeoPackage/metadata.json
@@ -6,8 +6,9 @@
   "Type": 0,
   "RequiresOnlineConnection": true,
   "RequiresOfflineData": true,
-  "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
   "RequiresLocalServer": false,
+  "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
+  "DataFileNames": [ "AuroraCO.gpkg" ],
   "Image": "FeatureLayerGeoPackage.jpg",
   "Link": "",
   "TypeLink": [ "T:Esri.ArcGISRuntime.Data.GeoPackage", "T:Esri.ArcGISRuntime.Data.GeoPackageFeatureTable", "P:Esri.ArcGISRuntime.Data.GeoPackage.GeoPackageFeatureTables", "M:Esri.ArcGISRuntime.Data.GeoPackage.OpenAsync(System.String)" ]

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Data/FeatureLayerGeoPackage/metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Data/FeatureLayerGeoPackage/metadata.json
@@ -7,6 +7,7 @@
   "RequiresOnlineConnection": true,
   "RequiresOfflineData": true,
   "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
+  "DataFileNames": [ "AuroraCO.gpkg" ],
   "RequiresLocalServer": false,
   "Image": "FeatureLayerGeoPackage.jpg",
   "Link": "",

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeoPackage/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeoPackage/metadata.json
@@ -8,6 +8,7 @@
   "RequiresOfflineData": true,
   "RequiresLocalServer": false,
   "DataItemIds": [ "68ec42517cdd439e81b036210483e8e7" ],
+  "DataFileNames": [ "AuroraCO.gpkg" ],
   "Image": "FeatureLayerGeoPackage.jpg",
   "Link": "",
   "TypeLink": [ "T:Esri.ArcGISRuntime.Data.GeoPackage", "T:Esri.ArcGISRuntime.Data.GeoPackageFeatureTable", "P:Esri.ArcGISRuntime.Data.GeoPackage.GeoPackageFeatureTables", "M:Esri.ArcGISRuntime.Data.GeoPackage.OpenAsync(System.String)" ],


### PR DESCRIPTION
@nCastle1 
Could you please code review another set of changes needed to get the SampleSolutionGenerator.exe to compile the samples for the LibRefAPI doc builds.
Thanks,
-don