### PR TITLE
Clear Analysis results before new run

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
@@ -71,6 +71,9 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeHotspots
 
         private async void OnRunAnalysisClicked(object sender, EventArgs e)
         {
+            // Clear any existing results
+            _myMapView.Map.OperationalLayers.Clear();
+
             // Show busy activity indication
             _myProgressBar.Visibility = ViewStates.Visible;
 

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -53,6 +53,9 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeHotspots
 
         private async void OnRunAnalysisClicked(object sender, EventArgs e)
         {
+            // Clear any existing results
+            MyMapView.Map.OperationalLayers.Clear();
+
             // Show busy activity indication
             MyActivityIndicator.IsVisible = true;
             MyActivityIndicator.IsRunning = true;

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -69,6 +69,9 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeHotspots
 
         private async void OnAnalyzeHotspotsClicked(object sender, RoutedEventArgs e)
         {
+            // Clear any existing results
+            MyMapView.Map.OperationalLayers.Clear();
+
             // Show the busyOverlay indication
             ShowBusyOverlay();
 

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspotsVB.xaml.vb
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspotsVB.xaml.vb
@@ -58,6 +58,9 @@ Namespace AnalyzeHotspots
 
         Private Async Sub OnAnalyzeHotspotsClicked(sender As Object, e As RoutedEventArgs)
 
+            ' Clear any existing results
+            MyMapView.Map.OperationalLayers.Clear()
+
             ' Show the busyOverlay indication
             ShowBusyOverlay()
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -50,6 +50,9 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeHotspots
 
         private async void OnAnalyzeHotspotsClicked(object sender, RoutedEventArgs e)
         {
+            // Clear any existing results
+            MyMapView.Map.OperationalLayers.Clear();
+
             // Show the busyOverlay indication
             ShowBusyOverlay();
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspotsVB.xaml.vb
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspotsVB.xaml.vb
@@ -49,6 +49,8 @@ Namespace AnalyzeHotspots
         End Sub
 
         Private Async Sub OnAnalyzeHotspotsClicked(ByVal sender As Object, ByVal e As RoutedEventArgs)
+            ' Clear any existing results
+            MyMapView.Map.OperationalLayers.Clear()
 
             ' Show the busyOverlay indication
             ShowBusyOverlay()

--- a/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
@@ -106,6 +106,9 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeHotspots
 
         private async void OnRunAnalysisClicked(object sender, EventArgs e)
         {
+            // Clear any existing results
+            _myMapView.Map.OperationalLayers.Clear();
+
             // Show the animating progress bar 
             _myProgressBar.StartAnimating();
 


### PR DESCRIPTION
Results of older analysis runs were not being cleared from the map
before new results were being shown.

This affects the 'Analyze Hotspots' sample only. 