### PR TITLE
Improves GeoViewSync

### DIFF
--- a/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
@@ -10,6 +10,7 @@
 using Android.App;
 using Android.OS;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
 
@@ -20,6 +21,7 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
     {
         // Hold references to the GeoViews
         private MapView _myMapView;
+
         private SceneView _mySceneView;
 
         protected override void OnCreate(Bundle bundle)
@@ -38,6 +40,11 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             // Initialize the MapView and SceneView with a basemap
             _myMapView.Map = new Map(Basemap.CreateImageryWithLabels());
             _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+
+            // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
+            //     animation on one view from competing with user interaction on the other
+            _mySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
+            _myMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
             // Subscribe to viewpoint change events for both views
             _myMapView.ViewpointChanged += view_viewpointChanged;

--- a/src/Forms/Shared/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -8,8 +8,9 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
-using System;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.Xamarin.Forms;
+using System;
 using Xamarin.Forms;
 
 namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
@@ -31,6 +32,11 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             // Initialize the MapView and SceneView with a basemap
             MyMapView.Map = new Map(Basemap.CreateImageryWithLabels());
             MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+
+            // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
+            //     animation on one view from competing with user interaction on the other
+            MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
+            MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
             // Subscribe to viewpoint change events for both views
             MyMapView.ViewpointChanged += view_viewpointChanged;

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
 
@@ -28,6 +29,11 @@ namespace ArcGISRuntime.UWP.Samples.GeoViewSync
             // Initialize the MapView and SceneView with a basemap
             MyMapView.Map = new Map(Basemap.CreateImageryWithLabels());
             MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+
+            // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
+            //     animation on one view from competing with user interaction on the other
+            MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
+            MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
             // Subscribe to viewpoint change events for both views
             MyMapView.ViewpointChanged += view_viewpointChanged;

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
 
@@ -28,6 +29,11 @@ namespace ArcGISRuntime.WPF.Samples.GeoViewSync
             // Initialize the MapView and SceneView with a basemap
             MyMapView.Map = new Map(Basemap.CreateImageryWithLabels());
             MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+
+            // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
+            //     animation on one view from competing with user interaction on the other
+            MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
+            MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
             // Subscribe to viewpoint change events for both views
             MyMapView.ViewpointChanged += view_viewpointChanged;

--- a/src/iOS/Xamarin.iOS/Samples/MapView/GeoViewSync/GeoViewSync.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/GeoViewSync/GeoViewSync.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using Foundation;
 using System;
@@ -33,6 +34,11 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             // Initialize the MapView and SceneView with a basemap
             _myMapView.Map = new Map(Basemap.CreateImageryWithLabels());
             _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+
+            // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
+            //     animation on one view from competing with user interaction on the other
+            _mySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
+            _myMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
             // Subscribe to viewpoint change events for both views
             _myMapView.ViewpointChanged += view_viewpointChanged;


### PR DESCRIPTION
This change disables the 'flick' gesture for both map and sceneview.
This gesture was problematic, because it was possible for the user to
start navigating on the scene, only to be fought when attempting to
navigate the map - the sceneview was still actively navigating.

With this change, the sample is now demonstrating similar behavior to
what is seen in ArcGIS pro when a map and a scene are linked.