### PR TITLE
Adds elevation source to scene layer sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Android.App;
@@ -22,13 +22,20 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
         // Create a new SceneView control
         private SceneView _mySceneView = new SceneView();
 
+        // URL for a service to use as an elevation source
+        private Uri _elevationSourceUrl = new Uri(@"https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer");
+
+        // URL for the scene layer
+        private Uri _serviceUri = new Uri(
+               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
 
             Title = "ArcGIS scene layer (URL)";
 
-            // Execute initialization 
+            // Execute initialization
             CreateLayout();
             Initialize();
         }
@@ -41,23 +48,23 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
             // Set Scene's base map property
             myScene.Basemap = Basemap.CreateImagery();
 
-            // Create uri to the scene layer
-            var serviceUri = new Uri(
-               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+            // Create and add an elevation source for the Scene
+            ArcGISTiledElevationSource elevationSrc = new ArcGISTiledElevationSource(_elevationSourceUrl);
+            myScene.BaseSurface.ElevationSources.Add(elevationSrc);
 
             // Create new scene layer from the url
-            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(serviceUri);
+            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(_serviceUri);
 
             // Add created layer to the operational layers collection
             myScene.OperationalLayers.Add(sceneLayer);
 
-            // Create a camera with coordinates showing layer data 
+            // Create a camera with coordinates showing layer data
             Camera camera = new Camera(48.378, -4.494, 200, 345, 65, 0);
 
             // Assign the Scene to the SceneView
             _mySceneView.Scene = myScene;
 
-            // Set view point of scene view using camera 
+            // Set view point of scene view using camera
             _mySceneView.SetViewpointCameraAsync(camera);
         }
 

--- a/src/Forms/Shared/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -15,13 +15,20 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
 {
     public partial class SceneLayerUrl : ContentPage
     {
+        // URL for a service to use as an elevation source
+        private Uri _elevationSourceUrl = new Uri(@"https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer");
+
+        // URL for the scene layer
+        private Uri _serviceUri = new Uri(
+               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+
         public SceneLayerUrl()
         {
             InitializeComponent();
 
             Title = "ArcGIS scene layer (URL)";
 
-            // Execute initialization 
+            // Execute initialization
             Initialize();
         }
 
@@ -33,23 +40,23 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
             // Set Scene's base map property
             myScene.Basemap = Basemap.CreateImagery();
 
-            // Create uri to the scene layer
-            var serviceUri = new Uri(
-               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+            // Create and add an elevation source for the Scene
+            ArcGISTiledElevationSource elevationSrc = new ArcGISTiledElevationSource(_elevationSourceUrl);
+            myScene.BaseSurface.ElevationSources.Add(elevationSrc);
 
             // Create new scene layer from the url
-            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(serviceUri);
+            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(_serviceUri);
 
             // Add created layer to the operational layers collection
             myScene.OperationalLayers.Add(sceneLayer);
 
-            // Create a camera with coordinates showing layer data 
+            // Create a camera with coordinates showing layer data
             Camera camera = new Camera(48.378, -4.494, 200, 345, 65, 0);
-       
+
             // Assign the Scene to the SceneView
             MySceneView.Scene = myScene;
 
-            // Set view point of scene view using camera 
+            // Set view point of scene view using camera
             MySceneView.SetViewpointCameraAsync(camera);
         }
     }

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -14,11 +14,18 @@ namespace ArcGISRuntime.UWP.Samples.SceneLayerUrl
 {
     public partial class SceneLayerUrl
     {
+        // URL for a service to use as an elevation source
+        private Uri _elevationSourceUrl = new Uri(@"https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer");
+
+        // URL for the scene layer
+        private Uri _serviceUri = new Uri(
+               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+
         public SceneLayerUrl()
         {
             InitializeComponent();
 
-            // Execute initialization 
+            // Execute initialization
             Initialize();
         }
 
@@ -30,25 +37,24 @@ namespace ArcGISRuntime.UWP.Samples.SceneLayerUrl
             // Set Scene's base map property
             myScene.Basemap = Basemap.CreateImagery();
 
-            // Create uri to the scene layer
-            var serviceUri = new Uri(
-               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+            // Create and add an elevation source for the Scene
+            ArcGISTiledElevationSource elevationSrc = new ArcGISTiledElevationSource(_elevationSourceUrl);
+            myScene.BaseSurface.ElevationSources.Add(elevationSrc);
 
             // Create new scene layer from the url
-            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(serviceUri);
+            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(_serviceUri);
 
             // Add created layer to the operational layers collection
             myScene.OperationalLayers.Add(sceneLayer);
 
-            // Create a camera with coordinates showing layer data 
+            // Create a camera with coordinates showing layer data
             Camera camera = new Camera(48.378, -4.494, 200, 345, 65, 0);
 
             // Assign the Scene to the SceneView
             MySceneView.Scene = myScene;
 
-            // Set view point of scene view using camera 
+            // Set view point of scene view using camera
             MySceneView.SetViewpointCameraAsync(camera);
-
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -14,11 +14,18 @@ namespace ArcGISRuntime.WPF.Samples.SceneLayerUrl
 {
     public partial class SceneLayerUrl
     {
+        // URL for a service to use as an elevation source
+        private Uri _elevationSourceUrl = new Uri(@"https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer");
+
+        // URL for the scene layer
+        private Uri _serviceUri = new Uri(
+               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+
         public SceneLayerUrl()
         {
             InitializeComponent();
 
-            // Execute initialization 
+            // Execute initialization
             Initialize();
         }
 
@@ -30,26 +37,24 @@ namespace ArcGISRuntime.WPF.Samples.SceneLayerUrl
             // Set Scene's base map property
             myScene.Basemap = Basemap.CreateImagery();
 
-            // Create uri to the scene layer
-            var serviceUri = new Uri(
-               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+            // Create and add an elevation source for the Scene
+            ArcGISTiledElevationSource elevationSrc = new ArcGISTiledElevationSource(_elevationSourceUrl);
+            myScene.BaseSurface.ElevationSources.Add(elevationSrc);
 
             // Create new scene layer from the url
-            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(serviceUri);
+            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(_serviceUri);
 
             // Add created layer to the operational layers collection
             myScene.OperationalLayers.Add(sceneLayer);
 
-            // Create a camera with coordinates showing layer data 
+            // Create a camera with coordinates showing layer data
             Camera camera = new Camera(48.378, -4.494, 200, 345, 65, 0);
 
             // Assign the Scene to the SceneView
             MySceneView.Scene = myScene;
 
-            // Set view point of scene view using camera 
+            // Set view point of scene view using camera
             MySceneView.SetViewpointCameraAsync(camera);
-
         }
-
     }
 }

--- a/src/iOS/Xamarin.iOS/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -24,6 +24,13 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
         // Create a new SceneView control
         private SceneView _mySceneView = new SceneView();
 
+        // URL for a service to use as an elevation source
+        private Uri _elevationSourceUrl = new Uri(@"https://scene.arcgis.com/arcgis/rest/services/BREST_DTM_1M/ImageServer");
+
+        // URL for the scene layer
+        private Uri _serviceUri = new Uri(
+               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+
         public SceneLayerUrl()
         {
             Title = "ArcGIS scene layer (URL)";
@@ -33,7 +40,7 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
         {
             base.ViewDidLoad();
 
-            // Execute initialization 
+            // Execute initialization
             CreateLayout();
             Initialize();
         }
@@ -54,24 +61,24 @@ namespace ArcGISRuntimeXamarin.Samples.SceneLayerUrl
             // Set Scene's base map property
             myScene.Basemap = Basemap.CreateImagery();
 
-            // Create uri to the scene layer
-            var serviceUri = new Uri(
-               "https://scene.arcgis.com/arcgis/rest/services/Hosted/Buildings_Brest/SceneServer/0");
+            // Create and add an elevation source for the Scene
+            ArcGISTiledElevationSource elevationSrc = new ArcGISTiledElevationSource(_elevationSourceUrl);
+            myScene.BaseSurface.ElevationSources.Add(elevationSrc);
 
             // Create new scene layer from the url
-            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(serviceUri);
+            ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(_serviceUri);
 
             // Add created layer to the operational layers collection
             myScene.OperationalLayers.Add(sceneLayer);
 
-            // Create a camera with coordinates showing layer data 
+            // Create a camera with coordinates showing layer data
             Camera camera = new Camera(48.378, -4.494, 200, 345, 65, 0);
 
             // Assign the Scene to the SceneView
             _mySceneView.Scene = myScene;
 
-            // Set view point of scene view using camera 
-            _mySceneView.SetViewpointCameraAsync(camera);        
+            // Set view point of scene view using camera
+            _mySceneView.SetViewpointCameraAsync(camera);
         }
 
         private void CreateLayout()


### PR DESCRIPTION
Previously there was no elevation source, so buildings appeared to be floating. Now, all buildings should appear flush with the ground (generally). This also makes the sample look nicer as the ground looks much more realistic (and accurate).

Note that automated code cleanup was run, so there are some extra
formatting changes.