### PR TITLE
Normalize geometry when querying

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Android.App;
@@ -28,12 +28,11 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
     [Activity]
     public class AnalyzeViewshed : Activity
     {
-
         // Create and hold reference to the used MapView
         private MapView _myMapView = new MapView();
 
         // Progress bar to show when the geoprocessing task is working
-        ProgressBar _myProgressBar;
+        private ProgressBar _myProgressBar;
 
         // Url for the geoprocessing service
         private const string _viewshedUrl =
@@ -51,7 +50,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
 
             Title = "Viewshed (Geoprocessing)";
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization
             CreateLayout();
             Initialize();
         }
@@ -80,19 +79,27 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
-            Graphic myInputGraphic = new Graphic(e.Location);
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Execute the geoprocessing task using the user click location 
-            await CalculateViewshed(e.Location);
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
+            if (_myMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
+            // Execute the geoprocessing task using the user click location
+            await CalculateViewshed(geometry);
         }
 
         private async Task CalculateViewshed(MapPoint location)
         {
-            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a 
+            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed 
+            // is a problem with the execution of the geoprocessing task an error message will be displayed
 
             // Create new geoprocessing task using the url defined in the member variables section
             var myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
@@ -164,7 +171,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
 
         private void CreateOverlays()
         {
-            // This function will create the overlays that show the user clicked location and the results of the 
+            // This function will create the overlays that show the user clicked location and the results of the
             // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
 
             // Create renderer for input graphic. Set the size and color properties for the simple renderer
@@ -185,7 +192,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer 
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -207,7 +214,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
 
         private void SetBusy(bool isBusy = true)
         {
-            // This function toggles running of the 'progress' control feedback status to denote if 
+            // This function toggles running of the 'progress' control feedback status to denote if
             // the viewshed analysis is executing as a result of the user click on the map
 
             if (isBusy)
@@ -244,6 +251,5 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
             // Show the layout in the app
             SetContentView(layout);
         }
-
     }
 }

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
@@ -94,9 +94,17 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerSelection
             // Convert the tolerance to map units
             double mapTolerance = tolerance * _myMapView.UnitsPerPixel;
 
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, querying may fail because wrapped-around coordinates are out of bounds.
+            if (_myMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
             // Define the envelope around the tap location for selecting features
-            var selectionEnvelope = new Envelope(e.Location.X - mapTolerance, e.Location.Y - mapTolerance, e.Location.X + mapTolerance,
-                e.Location.Y + mapTolerance, _myMapView.Map.SpatialReference);
+            var selectionEnvelope = new Envelope(geometry.X - mapTolerance, geometry.Y - mapTolerance, geometry.X + mapTolerance,
+                geometry.Y + mapTolerance, _myMapView.Map.SpatialReference);
 
             // Define the query parameters for selecting features
             var queryParams = new QueryParameters();

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -68,12 +68,20 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
             // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
-            Graphic myInputGraphic = new Graphic(e.Location);
+            Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
+            if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
             // Execute the geoprocessing task using the user click location 
-            await CalculateViewshed(e.Location);
+            await CalculateViewshed(geometry);
         }
 
         private async Task CalculateViewshed(MapPoint location)

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -94,9 +94,17 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerSelection
                 // Convert the tolerance to map units
                 double mapTolerance = tolerance * MyMapView.UnitsPerPixel;
 
+                // Get the tapped point
+                MapPoint geometry = e.Location;
+
+                // Normalize the geometry if wrap-around is enabled
+                //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+                //    Without this step, querying may fail because wrapped-around coordinates are out of bounds.
+                if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
                 // Define the envelope around the tap location for selecting features
-                var selectionEnvelope = new Envelope(e.Location.X - mapTolerance, e.Location.Y - mapTolerance, e.Location.X + mapTolerance,
-                    e.Location.Y + mapTolerance, MyMapView.Map.SpatialReference);
+                var selectionEnvelope = new Envelope(geometry.X - mapTolerance, geometry.Y - mapTolerance, geometry.X + mapTolerance,
+                    geometry.Y + mapTolerance, MyMapView.Map.SpatialReference);
 
                 // Define the query parameters for selecting features
                 var queryParams = new QueryParameters();

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -24,7 +24,7 @@ using Windows.UI.Xaml;
 
 namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
 {
-    public partial class AnalyzeViewshed 
+    public partial class AnalyzeViewshed
     {
         // Url for the geoprocessing service
         private const string _viewshedUrl =
@@ -43,7 +43,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
         {
             this.InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization
             Initialize();
         }
 
@@ -64,7 +64,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
 
         private async void OnMapViewTapped(object sender, GeoViewInputEventArgs e)
         {
-            // The geoprocessing task is still executing, don't do anything else (i.e. respond to 
+            // The geoprocessing task is still executing, don't do anything else (i.e. respond to
             // more user taps) until the processing is complete.
             if (_isExecutingGeoprocessing)
             {
@@ -78,19 +78,27 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
-            Graphic myInputGraphic = new Graphic(e.Location);
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Execute the geoprocessing task using the user click location 
-            await CalculateViewshed(e.Location);
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
+            if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
+            // Execute the geoprocessing task using the user click location
+            await CalculateViewshed(geometry);
         }
 
         private async Task CalculateViewshed(MapPoint location)
         {
-            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a 
+            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed 
+            // is a problem with the execution of the geoprocessing task an error message will be displayed
 
             // Create new geoprocessing task using the url defined in the member variables section
             var myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
@@ -158,7 +166,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
 
         private void CreateOverlays()
         {
-            // This function will create the overlays that show the user clicked location and the results of the 
+            // This function will create the overlays that show the user clicked location and the results of the
             // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
 
             // Create renderer for input graphic. Set the size and color properties for the simple renderer
@@ -177,7 +185,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer 
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -201,7 +209,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
         {
             // This function toggles the visibility of the 'busyOverlay' Grid control defined in xaml,
             // sets the 'progress' control feedback status and updates the _isExecutingGeoprocessing
-            // boolean to denote if the viewshed analysis is executing as a result of the user click 
+            // boolean to denote if the viewshed analysis is executing as a result of the user click
             // on the map
 
             if (isBusy)

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -88,9 +88,17 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerSelection
                 // Convert the tolerance to map units
                 double mapTolerance = tolerance * MyMapView.UnitsPerPixel;
 
+                // Get the tapped point
+                MapPoint geometry = e.Location;
+
+                // Normalize the geometry if wrap-around is enabled
+                //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+                //    Without this step, querying may fail because wrapped-around coordinates are out of bounds.
+                if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
                 // Define the envelope around the tap location for selecting features
-                var selectionEnvelope = new Envelope(e.Location.X - mapTolerance, e.Location.Y - mapTolerance, e.Location.X + mapTolerance,
-                    e.Location.Y + mapTolerance, MyMapView.Map.SpatialReference);
+                var selectionEnvelope = new Envelope(geometry.X - mapTolerance, geometry.Y - mapTolerance, geometry.X + mapTolerance,
+                    geometry.Y + mapTolerance, MyMapView.Map.SpatialReference);
 
                 // Define the query parameters for selecting features
                 var queryParams = new QueryParameters();

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -42,7 +42,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization
             Initialize();
         }
 
@@ -63,7 +63,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
 
         private async void OnMapViewTapped(object sender, GeoViewInputEventArgs e)
         {
-            // The geoprocessing task is still executing, don't do anything else (i.e. respond to 
+            // The geoprocessing task is still executing, don't do anything else (i.e. respond to
             // more user taps) until the processing is complete.
             if (_isExecutingGeoprocessing)
             {
@@ -77,20 +77,28 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
-            Graphic myInputGraphic = new Graphic(e.Location);
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Execute the geoprocessing task using the user click location 
-            await CalculateViewshed(e.Location);
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
+            if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
+            // Execute the geoprocessing task using the user click location
+            await CalculateViewshed(geometry);
         }
 
         private async Task CalculateViewshed(MapPoint location)
         {
-            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a 
+            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed 
-            
+            // is a problem with the execution of the geoprocessing task an error message will be displayed
+
             // Create new geoprocessing task using the url defined in the member variables section
             var myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
 
@@ -107,7 +115,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
             // Create the parameters that are passed to the used geoprocessing task
-            GeoprocessingParameters myViewshedParameters = 
+            GeoprocessingParameters myViewshedParameters =
                 new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute);
 
             // Request the output features to use the same SpatialReference as the map view
@@ -151,7 +159,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
 
         private void CreateOverlays()
         {
-            // This function will create the overlays that show the user clicked location and the results of the 
+            // This function will create the overlays that show the user clicked location and the results of the
             // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
 
             // Create renderer for input graphic. Set the size and color properties for the simple renderer
@@ -170,7 +178,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer 
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -194,7 +202,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         {
             // This function toggles the visibility of the 'busyOverlay' Grid control defined in xaml,
             // sets the 'progress' control feedback status and updates the _isExecutingGeoprocessing
-            // boolean to denote if the viewshed analysis is executing as a result of the user click 
+            // boolean to denote if the viewshed analysis is executing as a result of the user click
             // on the map
 
             if (isBusy)

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -89,9 +89,17 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerSelection
                 // Convert the tolerance to map units
                 double mapTolerance = tolerance * MyMapView.UnitsPerPixel;
 
+                // Get the tapped point
+                MapPoint geometry = e.Location;
+
+                // Normalize the geometry if wrap-around is enabled
+                //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+                //    Without this step, querying may fail because wrapped-around coordinates are out of bounds.
+                if (MyMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
                 // Define the envelope around the tap location for selecting features
-                var selectionEnvelope = new Envelope(e.Location.X - mapTolerance, e.Location.Y - mapTolerance, e.Location.X + mapTolerance,
-                    e.Location.Y + mapTolerance, MyMapView.Map.SpatialReference);
+                var selectionEnvelope = new Envelope(geometry.X - mapTolerance, geometry.Y - mapTolerance, geometry.X + mapTolerance,
+                    geometry.Y + mapTolerance, MyMapView.Map.SpatialReference);
 
                 // Define the query parameters for selecting features
                 var queryParams = new QueryParameters();

--- a/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -51,10 +51,11 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
         {
             base.ViewDidLoad();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization
             CreateLayout();
             Initialize();
         }
+
         public override void ViewDidLayoutSubviews()
         {
             // Setup the visual frame for the MapView
@@ -82,19 +83,27 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
-            Graphic myInputGraphic = new Graphic(e.Location);
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Execute the geoprocessing task using the user click location 
-            await CalculateViewshed(e.Location);
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
+            if (_myMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
+            // Execute the geoprocessing task using the user click location
+            await CalculateViewshed(geometry);
         }
 
         private async Task CalculateViewshed(MapPoint location)
         {
-            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a 
+            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed 
+            // is a problem with the execution of the geoprocessing task an error message will be displayed
 
             // Create new geoprocessing task using the url defined in the member variables section
             var myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
@@ -161,7 +170,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
 
         private void CreateOverlays()
         {
-            // This function will create the overlays that show the user clicked location and the results of the 
+            // This function will create the overlays that show the user clicked location and the results of the
             // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
 
             // Create renderer for input graphic. Set the size and color properties for the simple renderer
@@ -180,7 +189,7 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeViewshed
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer 
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
@@ -105,9 +105,17 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerSelection
             // Convert the tolerance to map units
             double mapTolerance = tolerance * _myMapView.UnitsPerPixel;
 
+            // Get the tapped point
+            MapPoint geometry = e.Location;
+
+            // Normalize the geometry if wrap-around is enabled
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            //    Without this step, querying may fail because wrapped-around coordinates are out of bounds.
+            if (_myMapView.IsWrapAroundEnabled) { geometry = GeometryEngine.NormalizeCentralMeridian(geometry) as MapPoint; }
+
             // Define the envelope around the tap location for selecting features
-            var selectionEnvelope = new Envelope(e.Location.X - mapTolerance, e.Location.Y - mapTolerance, e.Location.X + mapTolerance, 
-                e.Location.Y + mapTolerance, _myMapView.Map.SpatialReference);
+            var selectionEnvelope = new Envelope(geometry.X - mapTolerance, geometry.Y - mapTolerance, geometry.X + mapTolerance,
+                geometry.Y + mapTolerance, _myMapView.Map.SpatialReference);
 
             // Define the query parameters for selecting features
             var queryParams = new QueryParameters();


### PR DESCRIPTION
When wraparound is enabled on a map, the coordinates returned on tap are different when the map has been wrapped around. Because of this, panning the map and attempting to do a query will result in service exceptions.

Using the geometry engine to normalize the coordinates will prevent errors.

This only applies to situations where wraparound is enabled. Because of that, I chose to explicitly check if it is enabled, even though that is the default. That was a didactic decision rather than a practical one, but I think it is important for clarity. I did choose to put the condition check and normalization on one line;  this may be controversial, but I didn't want to divert emphasis from the intention of the sample.