### PR TITLE
Allows 'return' to dismiss keyboard on iOS

### DIFF
--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
@@ -171,6 +171,8 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureLayerQuery
             _queryTextView.Placeholder = "State name";
             _queryTextView.AdjustsFontSizeToFitWidth = true;
             _queryTextView.BackgroundColor = UIColor.White;
+            // Allow pressing 'return' to dismiss the keyboard
+            _queryTextView.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Create button to invoke the query
             _queryButton = new UIButton();

--- a/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
@@ -215,6 +215,8 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeHotspots
             _startDateTextField.Text = "1/01/98";
             _startDateTextField.AdjustsFontSizeToFitWidth = true;
             _startDateTextField.BackgroundColor = UIColor.White;
+            // Allow pressing 'return' to dismiss the keyboard
+            _startDateTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Create label for the end date
             _endDateLabel = new UILabel();
@@ -227,6 +229,8 @@ namespace ArcGISRuntimeXamarin.Samples.AnalyzeHotspots
             _endDateTextField.Text = "1/31/98";
             _endDateTextField.AdjustsFontSizeToFitWidth = true;
             _endDateTextField.BackgroundColor = UIColor.White;
+            // Allow pressing 'return' to dismiss the keyboard
+            _endDateTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Create button to invoke the geoprocessing request
             _runAnalysisButton = new UIButton();

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.cs
@@ -135,6 +135,8 @@ namespace ArcGISRuntimeXamarin.Samples.FeatureCollectionLayerFromPortal
             // Create a text input for the portal item Id
             _collectionItemIdTextBox = new UITextField();
             _collectionItemIdTextBox.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _collectionItemIdTextBox.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Create a button for adding features from a portal item
             _addFeaturesButton = new UIButton(UIButtonType.Custom);

--- a/src/iOS/Xamarin.iOS/Samples/Map/AuthorMap/AuthorMap.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/AuthorMap/AuthorMap.cs
@@ -644,6 +644,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorMap
             _clientIdTextField.Text = clientId;
             _clientIdTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _clientIdTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _clientIdTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -659,6 +661,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorMap
             _redirectUrlTextField.Text = redirectUrl;
             _redirectUrlTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _redirectUrlTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _redirectUrlTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -799,6 +803,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorMap
             _titleTextField.Placeholder = "Title";
             _titleTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _titleTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _titleTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -808,6 +814,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorMap
             _descriptionTextField.Placeholder = "Description";
             _descriptionTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _descriptionTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _descriptionTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -817,6 +825,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorMap
             _tagsTextField.Text = "ArcGIS Runtime, Web Map";
             _tagsTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _tagsTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _tagsTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;

--- a/src/iOS/Xamarin.iOS/Samples/Map/SearchPortalMaps/SearchPortalMaps.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SearchPortalMaps/SearchPortalMaps.cs
@@ -617,6 +617,8 @@ namespace ArcGISRuntimeXamarin.Samples.SearchPortalMaps
             _clientIdTextField.Text = clientId;
             _clientIdTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _clientIdTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _clientIdTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -632,6 +634,8 @@ namespace ArcGISRuntimeXamarin.Samples.SearchPortalMaps
             _redirectUrlTextField.Text = redirectUrl;
             _redirectUrlTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _redirectUrlTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _redirectUrlTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -768,6 +772,8 @@ namespace ArcGISRuntimeXamarin.Samples.SearchPortalMaps
             _searchTextField.Placeholder = "Search text";
             _searchTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _searchTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _searchTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Hide the keyboard when "Enter" is clicked
             _searchTextField.ShouldReturn += (input) =>

--- a/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
@@ -203,6 +203,10 @@ namespace ArcGISRuntimeXamarin.Samples.FindPlace
             _myLocationBox.Text = "Current Location";
             _mySearchBox.Text = "Coffee";
 
+            // Allow pressing 'return' to dismiss the keyboard
+            _myLocationBox.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
+            _mySearchBox.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
+
             // Gray out the buttons when they are disabled
             _mySearchButton.SetTitleColor(UIColor.Gray, UIControlState.Disabled);
             _mySearchRestrictedButton.SetTitleColor(UIColor.Gray, UIControlState.Disabled);

--- a/src/iOS/Xamarin.iOS/Samples/Tutorial/AuthorEditSaveMap/AuthorEditSaveMap.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Tutorial/AuthorEditSaveMap/AuthorEditSaveMap.cs
@@ -495,6 +495,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorEditSaveMap
             _titleTextField.Placeholder = "Title";
             _titleTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _titleTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _titleTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -504,6 +506,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorEditSaveMap
             _descriptionTextField.Placeholder = "Description";
             _descriptionTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _descriptionTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _descriptionTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;
@@ -513,6 +517,8 @@ namespace ArcGISRuntimeXamarin.Samples.AuthorEditSaveMap
             _tagsTextField.Text = "ArcGIS Runtime, Web Map";
             _tagsTextField.AutocapitalizationType = UITextAutocapitalizationType.None;
             _tagsTextField.BackgroundColor = UIColor.LightGray;
+            // Allow pressing 'return' to dismiss the keyboard
+            _tagsTextField.ShouldReturn += (textField) => { textField.ResignFirstResponder(); return true; };
 
             // Adjust the Y position for the next control
             controlY = controlY + controlHeight + rowSpace;


### PR DESCRIPTION
Previously, it was not possible to dismiss the keyboard once it was opened in a sample. This makes it very difficult to use samples on device or when there isn’t a hardware keyboard attached.

With this change, pressing ‘return’ will hide the keyboard. This will enable our samples to be used on device in addition to just on the
simulator.