### PR TITLE
Sets viewpoint consistently for raster layer file

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/RasterLayerFile/RasterLayerFile.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/RasterLayerFile/RasterLayerFile.cs
@@ -59,6 +59,12 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
 
         private async void Initialize()
         {
+            // Add an imagery basemap
+            Map myMap = new Map(Basemap.CreateImagery());
+
+            // Wait for the map to load
+            await myMap.LoadAsync();
+
             // Get the file name
             String filepath = GetRasterPath();
 
@@ -68,20 +74,17 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
             // Create the layer
             RasterLayer myRasterLayer = new RasterLayer(myRasterFile);
 
-            // Load the layer
+            // Add the layer to the map
+            myMap.OperationalLayers.Add(myRasterLayer);
+
+            // Wait for the layer to load
             await myRasterLayer.LoadAsync();
 
-            // Convert the layer's extent to the correct spatial reference
-            Geometry convertedExtent = GeometryEngine.Project(myRasterLayer.FullExtent, SpatialReferences.WebMercator);
-
-            // Get the raster's extent in a viewpoint
-            Viewpoint myFullRasterExtent = new Viewpoint(convertedExtent);
-
             // Set the viewpoint
-            _myMapView.SetViewpoint(myFullRasterExtent);
+            myMap.InitialViewpoint = new Viewpoint(myRasterLayer.FullExtent);
 
-            // Add the layer to the map
-            _myMapView.Map.OperationalLayers.Add(myRasterLayer);
+            // Add map to the mapview
+            _myMapView.Map = myMap;
         }
 
         private string GetRasterPath()

--- a/src/Forms/Shared/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -30,7 +30,10 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
         private async void Initialize()
         {
             // Add an imagery basemap
-            MyMapView.Map = new Map(Basemap.CreateImagery());
+            Map myMap = new Map(Basemap.CreateImagery());
+
+            // Wait for the map to load
+            await myMap.LoadAsync();
 
             // Get the file name
             String filepath = GetRasterPath();
@@ -41,20 +44,17 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
             // Create the layer
             RasterLayer myRasterLayer = new RasterLayer(myRasterFile);
 
-            // Load the layer
+            // Add the layer to the map
+            myMap.OperationalLayers.Add(myRasterLayer);
+
+            // Wait for the layer to load
             await myRasterLayer.LoadAsync();
 
-            // Convert the layer's extent to the correct spatial reference
-            Geometry convertedExtent = GeometryEngine.Project(myRasterLayer.FullExtent, SpatialReferences.WebMercator);
-
-            // Get the raster's extent in a viewpoint
-            Viewpoint myFullRasterExtent = new Viewpoint(convertedExtent);
-
             // Set the viewpoint
-            MyMapView.SetViewpoint(myFullRasterExtent);
+            myMap.InitialViewpoint = new Viewpoint(myRasterLayer.FullExtent);
 
-            // Add the layer to the map
-            MyMapView.Map.OperationalLayers.Add(myRasterLayer);
+            // Add map to the mapview
+            MyMapView.Map = myMap;
         }
 
         private string GetRasterPath()

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -29,8 +29,11 @@ namespace ArcGISRuntime.UWP.Samples.RasterLayerFile
 
         private async void Initialize()
         {
-            // Apply an imagery basemap
-            MyMapView.Map = new Map(Basemap.CreateImagery());
+            // Add an imagery basemap
+            Map myMap = new Map(Basemap.CreateImagery());
+
+            // Wait for the map to load
+            await myMap.LoadAsync();
 
             // Get the file name
             String filepath = await GetRasterPath();
@@ -41,20 +44,17 @@ namespace ArcGISRuntime.UWP.Samples.RasterLayerFile
             // Create the layer
             RasterLayer myRasterLayer = new RasterLayer(myRasterFile);
 
-            // Load the layer
+            // Add the layer to the map
+            myMap.OperationalLayers.Add(myRasterLayer);
+
+            // Wait for the layer to load
             await myRasterLayer.LoadAsync();
 
-            // Convert the layer's extent to the correct spatial reference
-            Geometry convertedExtent = GeometryEngine.Project(myRasterLayer.FullExtent, SpatialReferences.WebMercator);
-
-            // Get the raster's extent in a viewpoint
-            Viewpoint myFullRasterExtent = new Viewpoint(convertedExtent);
-
             // Set the viewpoint
-            MyMapView.SetViewpoint(myFullRasterExtent);
+            myMap.InitialViewpoint = new Viewpoint(myRasterLayer.FullExtent);
 
-            // Add the layer to the map
-            MyMapView.Map.OperationalLayers.Add(myRasterLayer);
+            // Add map to the mapview
+            MyMapView.Map = myMap;
         }
 
         private async Task<string> GetRasterPath()

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -29,8 +29,11 @@ namespace ArcGISRuntime.WPF.Samples.RasterLayerFile
 
         private async void Initialize()
         {
-            // Apply an imagery basemap
-            MyMapView.Map = new Map(Basemap.CreateImagery());
+            // Add an imagery basemap
+            Map myMap = new Map(Basemap.CreateImagery());
+
+            // Wait for the map to load
+            await myMap.LoadAsync();
 
             // Get the file name
             String filepath = await GetRasterPath();
@@ -41,20 +44,17 @@ namespace ArcGISRuntime.WPF.Samples.RasterLayerFile
             // Create the layer
             RasterLayer myRasterLayer = new RasterLayer(myRasterFile);
 
-            // Load the layer
+            // Add the layer to the map
+            myMap.OperationalLayers.Add(myRasterLayer);
+
+            // Wait for the layer to load
             await myRasterLayer.LoadAsync();
 
-            // Convert the layer's extent to the correct spatial reference
-            Geometry convertedExtent = GeometryEngine.Project(myRasterLayer.FullExtent, SpatialReferences.WebMercator);
-
-            // Get the raster's extent in a viewpoint
-            Viewpoint myFullRasterExtent = new Viewpoint(convertedExtent);
-
             // Set the viewpoint
-            MyMapView.SetViewpoint(myFullRasterExtent);
+            myMap.InitialViewpoint = new Viewpoint(myRasterLayer.FullExtent);
 
-            // Add the layer to the map
-            MyMapView.Map.OperationalLayers.Add(myRasterLayer);
+            // Add map to the mapview
+            MyMapView.Map = myMap;
         }
 
         private async Task<string> GetRasterPath()

--- a/src/iOS/Xamarin.iOS/Samples/Layers/RasterLayerFile/RasterLayerFile.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/RasterLayerFile/RasterLayerFile.cs
@@ -51,6 +51,12 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
 
         private async void Initialize()
         {
+            // Add an imagery basemap
+            Map myMap = new Map(Basemap.CreateImagery());
+
+            // Wait for the map to load
+            await myMap.LoadAsync();
+
             // Get the file name
             String filepath = GetRasterPath();
 
@@ -60,20 +66,17 @@ namespace ArcGISRuntimeXamarin.Samples.RasterLayerFile
             // Create the layer
             RasterLayer myRasterLayer = new RasterLayer(myRasterFile);
 
-            // Load the layer
+            // Add the layer to the map
+            myMap.OperationalLayers.Add(myRasterLayer);
+
+            // Wait for the layer to load
             await myRasterLayer.LoadAsync();
 
-            // Convert the layer's extent to the correct spatial reference
-            Geometry convertedExtent = GeometryEngine.Project(myRasterLayer.FullExtent, SpatialReferences.WebMercator);
-
-            // Get the raster's extent in a viewpoint
-            Viewpoint myFullRasterExtent = new Viewpoint(convertedExtent);
-
             // Set the viewpoint
-            _myMapView.SetViewpoint(myFullRasterExtent);
+            myMap.InitialViewpoint = new Viewpoint(myRasterLayer.FullExtent);
 
-            // Add the layer to the map
-            _myMapView.Map.OperationalLayers.Add(myRasterLayer);
+            // Add map to the mapview
+            _myMapView.Map = myMap;
         }
 
         private void CreateLayout()


### PR DESCRIPTION
The Raster Layer File sample was having an issue where the viewpoint
wasn't being set consistently on load. There were also reports of a
crash that may have been due to a race condition. That issue should be
fixed as well.