### PR TITLE
re-enable iOS magnifier sample

### DIFF
--- a/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -9,6 +9,7 @@
 
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI.Controls;
+using Esri.ArcGISRuntime.UI;
 using Foundation;
 using UIKit;
 
@@ -51,7 +52,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowMagnifier
             Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
 
             // Enable magnifier
-            _myMapView.InteractionOptions.IsMagnifierEnabled = true;
+            _myMapView.InteractionOptions = new MapViewInteractionOptions { IsMagnifierEnabled = true };
 
             // Assign the map to the MapView
             _myMapView.Map = myMap;

--- a/src/iOS/Xamarin.iOS/groups.json
+++ b/src/iOS/Xamarin.iOS/groups.json
@@ -30,6 +30,10 @@
               "Path": "Samples/MapView/TakeScreenshot"
             },
             {
+              "SampleName": "ShowMagnifier",
+              "Path": "Samples/MapView/ShowMagnifier"
+            },
+            {
               "SampleName": "ShowCallout",
               "Path": "Samples/MapView/ShowCallout"
             },


### PR DESCRIPTION
This sample is not currently being shown in the sample viewer due to a groups.json omission. This PR fixes that. 