### PR TITLE
Enhance local server sample reliability

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
@@ -32,27 +32,6 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
 
             // Create the UI, setup the control references and execute initialization
             Initialize();
-
-            // Listen for the shutdown and unloaded events so that the local server can be shut down
-            this.Dispatcher.ShutdownStarted += ShutdownSample;
-            this.Unloaded += ShutdownSample;
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
-            {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
-            }
         }
 
         private async void Initialize()
@@ -62,28 +41,18 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
 
             try
             {
-                // Handle the StatusChanged event to react when the server is started
-                LocalServer.Instance.StatusChanged += ServerStatusChanged;
-
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
 
                 // Load the sample data
                 await LoadRasterPaths();
+
+                // Enable the 'choose Raster' button
+                MyChooseButton.IsEnabled = true;
             }
             catch (InvalidOperationException ex)
             {
                 MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message));
-            }
-        }
-
-        private void ServerStatusChanged(object sender, StatusChangedEventArgs e)
-        {
-            // Check if the server started successfully
-            if (e.Status == LocalServerStatus.Started)
-            {
-                // Enable the 'choose Raster' button
-                MyChooseButton.IsEnabled = true;
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
@@ -34,58 +34,27 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceShapefile
 
             // Create the UI, setup the control references and execute initialization
             Initialize();
-
-            // Listen for the shutdown and unloaded events so that the local server can be shut down
-            this.Dispatcher.ShutdownStarted += ShutdownSample;
-            this.Unloaded += ShutdownSample;
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
-            {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
-            }
         }
 
         private async void Initialize()
         {
             // Create a map and add it to the view
             MyMapView.Map = new Map(BasemapType.Topographic, 39.7294, -104.8319, 12);
-            
+
             try
             {
-                // Handle the StatusChanged event to react when the server is started
-                LocalServer.Instance.StatusChanged += ServerStatusChanged;
-
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
 
                 // Load the sample data
                 await LoadShapefilePaths();
+
+                // Enable the 'choose shapefile' button
+                MyChooseButton.IsEnabled = true;
             }
             catch (InvalidOperationException ex)
             {
                 MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message));
-            }
-        }
-
-        private void ServerStatusChanged(object sender, StatusChangedEventArgs e)
-        {
-            // Check if the server started successfully
-            if (e.Status == LocalServerStatus.Started)
-            {
-                // Enable the 'choose shapefile' button
-                MyChooseButton.IsEnabled = true;
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
@@ -33,10 +33,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
 
         private async void Initialize()
         {
-            // Listen for the shutdown and unloaded events so that the local server can be shut down when sample is closed
-            this.Dispatcher.ShutdownStarted += ShutdownSample;
-            this.Unloaded += ShutdownSample;
-
             // Create a map and add it to the view
             MyMapView.Map = new Map(Basemap.CreateStreetsWithReliefVector());
 
@@ -116,23 +112,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
             return filepath;
 
             #endregion offlinedata
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
-            {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
-            }
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
@@ -74,10 +74,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             // Try to start Local Server
             try
             {
-                // Listen for the shutdown and unloaded events so that the local server can be shut down
-                this.Dispatcher.ShutdownStarted += ShutdownSample;
-                this.Unloaded += ShutdownSample;
-
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
             }
@@ -161,14 +157,14 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             // Return if not succeeded
             if (_gpJob.Status != JobStatus.Succeeded) { return; }
 
-            // Get the URL to the map service 
+            // Get the URL to the map service
             string gpServiceResultUrl = _gpService.Url.ToString();
 
             // Get the URL segment for the specific job results
             string jobSegment = "MapServer/jobs/" + _gpJob.ServerJobId;
 
             // Update the URL to point to the specific job from the service
-            gpServiceResultUrl = gpServiceResultUrl.Replace("GPServer", jobSegment); 
+            gpServiceResultUrl = gpServiceResultUrl.Replace("GPServer", jobSegment);
 
             // Create a map image layer to show the results
             ArcGISMapImageLayer myMapImageLayer = new ArcGISMapImageLayer(new Uri(gpServiceResultUrl));
@@ -191,23 +187,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
                 // Enable the reset button
                 MyResetButton.IsEnabled = true;
             });
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
-            {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
-            }
         }
 
         private async Task<string> GetRasterPath()

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
@@ -26,7 +26,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
         {
             InitializeComponent();
 
-            // set up the sample 
+            // set up the sample
             Initialize();
         }
 
@@ -46,27 +46,9 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
                 // Create the Map Service from the data
                 _localMapService = new LocalMapService(datapath);
 
-                // Be notified when the map service is loaded
-                _localMapService.StatusChanged += _localMapService_StatusChanged;
-
                 // Start the feature service
                 await _localMapService.StartAsync();
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message, "Local Server failed to start");
-            }
 
-            // Listen for the shutdown and unloaded events so that the local server can be shut down
-            this.Dispatcher.ShutdownStarted += ShutdownSample;
-            this.Unloaded += ShutdownSample;
-        }
-
-        private async void _localMapService_StatusChanged(object sender, StatusChangedEventArgs e)
-        {
-            // Load a MapImageLayer from the service once it has started
-            if (e.Status == LocalServerStatus.Started)
-            {
                 // Get the url to the map service
                 Uri myServiceUri = _localMapService.Url;
 
@@ -82,22 +64,9 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
                 // Set the viewpoint on the map to show the data
                 MyMapView.SetViewpoint(new Viewpoint(myImageLayer.FullExtent));
             }
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
+            catch (Exception ex)
             {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
+                MessageBox.Show(ex.Message, "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
@@ -40,10 +40,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
         {
             // Subscribe to event notification for the local server instance
             LocalServer.Instance.StatusChanged += (o, e) => { UpdateUiWithServiceUpdate("Local Server", e.Status); };
-
-            // Listen for the shutdown and unloaded events so that the local server can be shut down
-            this.Dispatcher.ShutdownStarted += ShutdownSample;
-            this.Unloaded += ShutdownSample;
         }
 
         private void UpdateUiWithServiceUpdate(string server, LocalServerStatus status)
@@ -68,7 +64,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
                 string featureServicePath = await GetFeatureLayerPath();
                 string geoprocessingPath = await GetGpPath();
 
-                // Create each service but don't start any 
+                // Create each service but don't start any
                 _localMapService = new LocalMapService(mapServicePath);
                 _localFeatureService = new LocalFeatureService(featureServicePath);
                 _localGeoprocessingService = new LocalGeoprocessingService(geoprocessingPath);
@@ -86,8 +82,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
                 MessageBox.Show(ex.Message, "Failed to create services");
             }
         }
-
-        
 
         private void Selector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
@@ -297,23 +291,6 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, "Couldn't navigate to service");
-            }
-        }
-
-        private async void ShutdownSample(object sender, EventArgs e)
-        {
-            try
-            {
-                // Shut down the local server if it has started
-                if (LocalServer.Instance.Status == LocalServerStatus.Started)
-                {
-                    await LocalServer.Instance.StopAsync();
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // Local server isn't installed, just return
-                return;
             }
         }
     }


### PR DESCRIPTION
Shutting down local server after each sample run was leading to reliability problems and was not realistic.

Now, the server will be left running. This makes starting another local server sample smoother (no popup). 