### PR TITLE
Local Server deployment fixes

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Samples/Readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Readme.md
@@ -1,0 +1,17 @@
+﻿# ArcGIS Runtime SDK - WPF Sample Viewer
+
+The WPF sample viewer includes samples that depend on Local Server. 
+If you would like to use those samples, you must install Local Server. 
+See https://developers.arcgis.com/net/latest/wpf/guide/local-server.htm 
+for details and instructions.
+
+If you do not want to install Local Server, you may proceed without it. 
+When you try to build the project, you will get a build error:
+
+> ArcGIS Runtime Local Server SDK v100.2 component not installed. 
+> Local Server is required to build this project. Download and install 
+> Local Server from http://links.esri.com/arcgis-runtime-local-server-sdk-v100
+> ArcGISRuntime.WPF.Viewer			
+
+Click 'Start' or press F5 again and the project will start despite the build
+error. 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
@@ -52,7 +52,7 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
@@ -52,7 +52,7 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message));
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceShapefile
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceShapefile
             }
             catch (InvalidOperationException ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message));
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
@@ -43,7 +43,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
             }
             catch (Exception ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
                 return;
             }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
@@ -43,7 +43,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Local Server load failed");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
                 return;
             }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             }
             catch (Exception ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
                 return;
             }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Local Server failed to start, ending sample load.");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
                 return;
             }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
             }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message, "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
             }
             catch (Exception ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
             }
             catch (Exception ex)
             {
-                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.md or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
             }
             catch (Exception ex)
             {
-                MessageBox.Show(String.Format("Please ensure that Local Server is installed prior to loading this sample. See the readme or metadata.json for more info. Message: {0}", ex.Message), "Local Server failed to start");
+                MessageBox.Show(String.Format("Please ensure that local server is installed prior to using the sample. See instructions in readme.me or metadata.json. Message: {0}", ex.Message), "Local Server failed to start");
             }
         }
 

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/LocalServer/LocalServerServices/LocalServerServices.xaml.cs
@@ -38,8 +38,18 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
 
         private void Initialize()
         {
-            // Subscribe to event notification for the local server instance
-            LocalServer.Instance.StatusChanged += (o, e) => { UpdateUiWithServiceUpdate("Local Server", e.Status); };
+            try
+            {
+                // Subscribe to event notification for the local server instance
+                LocalServer.Instance.StatusChanged += (o, e) =>
+                {
+                    UpdateUiWithServiceUpdate("Local Server", e.Status);
+                };
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(String.Format("Please ensure that Local Server is installed prior to loading this sample. See the readme or metadata.json for more info. Message: {0}", ex.Message), "Local Server failed to start");
+            }
         }
 
         private void UpdateUiWithServiceUpdate(string server, LocalServerStatus status)

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer.AGSDeployment
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer.AGSDeployment
@@ -7,47 +7,47 @@ Only include these if your setup is not installing the Microsoft redistribution 
   <!--The Local Server comprises a set of components which enable the use of local dynamic map and feature services based on Map Packages plus core components required for searching and querying data.
 It also provides core support for geocoding and geoprocessing.-->
   <!--Map and tile packages must be created with ArcGIS Runtime support enabled.-->
-  <Package name="Local Server" enabled="true">
+  <Package name="Local Server" enabled="false">
     <ChildPackages>
       <!--Provides the ability to perform geoprocessing tasks via geoprocessing packages.-->
       <!--Geoprocessing packages must be created with ArcGIS Runtime support enabled.-->
-      <Package name="Geoprocessing" enabled="true">
+      <Package name="Geoprocessing" enabled="false">
         <ChildPackages>
           <!--Adds 3D Analyst geoprocessing tools.-->
-          <Package name="3D Analyst" enabled="true" />
+          <Package name="3D Analyst" enabled="false" />
           <!--Provides the ability to use ArcGIS Locators-->
           <Package name="Geocoding" enabled="false" />
           <!--Adds data consolidation, map packaging and create runtime content tools.-->
-          <Package name="Map Packaging" enabled="true" />
+          <Package name="Map Packaging" enabled="false" />
           <!--Adds the ability to produce results as Map Services.-->
-          <Package name="Map Server Results" enabled="true" />
+          <Package name="Map Server Results" enabled="false" />
           <!--Adds Network Analyst geoprocessing tools.-->
-          <Package name="Network Analyst" enabled="true" />
+          <Package name="Network Analyst" enabled="false" />
           <!--Adds Spatial Analyst geoprocessing tools.-->
-          <Package name="Spatial Analyst" enabled="true" />
+          <Package name="Spatial Analyst" enabled="false" />
         </ChildPackages>
       </Package>
       <!--Provides the ability to use Python scripts.-->
-      <Package name="Python Scripting" enabled="true">
+      <Package name="Python Scripting" enabled="false">
         <ChildPackages>
           <!--Provides support for Geoprocessing tools that use python-->
-          <Package name="Python Geoprocessing tools" enabled="true" />
+          <Package name="Python Geoprocessing tools" enabled="false" />
         </ChildPackages>
       </Package>
       <!--Provides additional vector and raster data format support.-->
-      <Package name="Additional Data Formats" enabled="true">
+      <Package name="Additional Data Formats" enabled="false">
         <ChildPackages>
           <!--Provides additional raster file data format support.-->
-          <Package name="Raster" enabled="true">
+          <Package name="Raster" enabled="false">
             <ChildPackages>
               <!--Provides support for ECW format Raster.-->
-              <Package name="ECW Rasters" enabled="true" />
+              <Package name="ECW Rasters" enabled="false" />
               <!--Provides support for Raster Mosaic Layers.-->
-              <Package name="Mosaic Rasters" enabled="true" />
+              <Package name="Mosaic Rasters" enabled="false" />
             </ChildPackages>
           </Package>
           <!--Provides additional vector file data format support.-->
-          <Package name="Vector" enabled="true" />
+          <Package name="Vector" enabled="false" />
           <!--Adds support for direct connect to DBMS system that Esri supports. This option must be selected in conjunction with at least one of the following DBMS(s): DB2, Informix, Oracle, PostgreSQL, SQL Server, Netezza, HANA, Teradata or Alitbase.-->
           <!--SDE direct connect deployed. Specific database drivers also required.-->
           <Package name="SDE" enabled="false">

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer.AGSDeployment
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer.AGSDeployment
@@ -11,7 +11,7 @@ It also provides core support for geocoding and geoprocessing.-->
     <ChildPackages>
       <!--Provides the ability to perform geoprocessing tasks via geoprocessing packages.-->
       <!--Geoprocessing packages must be created with ArcGIS Runtime support enabled.-->
-      <Package name="Geoprocessing" enabled="false">
+      <Package name="Geoprocessing" enabled="true">
         <ChildPackages>
           <!--Adds 3D Analyst geoprocessing tools.-->
           <Package name="3D Analyst" enabled="false" />
@@ -20,11 +20,11 @@ It also provides core support for geocoding and geoprocessing.-->
           <!--Adds data consolidation, map packaging and create runtime content tools.-->
           <Package name="Map Packaging" enabled="false" />
           <!--Adds the ability to produce results as Map Services.-->
-          <Package name="Map Server Results" enabled="false" />
+          <Package name="Map Server Results" enabled="true" />
           <!--Adds Network Analyst geoprocessing tools.-->
           <Package name="Network Analyst" enabled="false" />
           <!--Adds Spatial Analyst geoprocessing tools.-->
-          <Package name="Spatial Analyst" enabled="false" />
+          <Package name="Spatial Analyst" enabled="true" />
         </ChildPackages>
       </Package>
       <!--Provides the ability to use Python scripts.-->
@@ -35,10 +35,10 @@ It also provides core support for geocoding and geoprocessing.-->
         </ChildPackages>
       </Package>
       <!--Provides additional vector and raster data format support.-->
-      <Package name="Additional Data Formats" enabled="false">
+      <Package name="Additional Data Formats" enabled="true">
         <ChildPackages>
           <!--Provides additional raster file data format support.-->
-          <Package name="Raster" enabled="false">
+          <Package name="Raster" enabled="true">
             <ChildPackages>
               <!--Provides support for ECW format Raster.-->
               <Package name="ECW Rasters" enabled="false" />
@@ -47,7 +47,7 @@ It also provides core support for geocoding and geoprocessing.-->
             </ChildPackages>
           </Package>
           <!--Provides additional vector file data format support.-->
-          <Package name="Vector" enabled="false" />
+          <Package name="Vector" enabled="true" />
           <!--Adds support for direct connect to DBMS system that Esri supports. This option must be selected in conjunction with at least one of the following DBMS(s): DB2, Informix, Oracle, PostgreSQL, SQL Server, Netezza, HANA, Teradata or Alitbase.-->
           <!--SDE direct connect deployed. Specific database drivers also required.-->
           <Package name="SDE" enabled="false">

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -127,6 +127,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="Readme.md" />
     <Resource Include="Assets\ApplicationIcons\windows-desktop-128.png" />
     <Resource Include="Assets\ApplicationIcons\windows-desktop-16.png" />
     <Resource Include="Assets\ApplicationIcons\windows-desktop-256.ico" />

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Readme.md
@@ -1,0 +1,17 @@
+﻿# ArcGIS Runtime SDK - WPF Sample Viewer
+
+The WPF sample viewer includes samples that depend on Local Server. 
+If you would like to use those samples, you must install Local Server. 
+See https://developers.arcgis.com/net/latest/wpf/guide/local-server.htm 
+for details and instructions.
+
+If you do not want to install Local Server, you may proceed without it. 
+When you try to build the project, you will get a build error:
+
+> ArcGIS Runtime Local Server SDK v100.2 component not installed. 
+> Local Server is required to build this project. Download and install 
+> Local Server from http://links.esri.com/arcgis-runtime-local-server-sdk-v100
+> ArcGISRuntime.WPF.Viewer			
+
+Click 'Start' or press F5 again and the project will start despite the build
+error. 


### PR DESCRIPTION
This PR addresses two issues:
* The AGSDeployment file was improperly configured. Disabling all packages defined in the file allows all Local Server samples to run when the SDK is installed. When the local server SDK isn't installed, the sample viewer will build and run. 
* Individual samples were sometimes checking for the presence of Local Server after making calls that would cause a crash in its absence. Now, Local Server samples will not crash the sample viewer if Local Server is not installed. 
* The error message format was inconsistent between samples. Now all samples show an error message with a friendly error that directs the user to resources for installing Local Server. 