### PR TITLE
Update URLs to point to latest vector map services

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
@@ -24,10 +24,10 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISVectorTiledLayerUrl
         // Create and hold reference to the used MapView
         private MapView _myMapView = new MapView();
 
-        private string _navigationUrl = "http://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "http://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "http://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "http://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=63c47b7177f946b49902c24129b87252";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=5e9b3685f4c24d8781073dd928ebda50";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/Forms/Shared/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
@@ -15,10 +15,10 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISVectorTiledLayerUrl
 {
     public partial class ArcGISVectorTiledLayerUrl : ContentPage
     {
-        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=63c47b7177f946b49902c24129b87252";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=5e9b3685f4c24d8781073dd928ebda50";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
@@ -15,10 +15,10 @@ namespace ArcGISRuntime.UWP.Samples.ArcGISVectorTiledLayerUrl
 {
     public partial class ArcGISVectorTiledLayerUrl
     {
-        private string _navigationUrl = "http://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "http://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "http://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "http://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=63c47b7177f946b49902c24129b87252";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=5e9b3685f4c24d8781073dd928ebda50";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.xaml.cs
@@ -15,10 +15,10 @@ namespace ArcGISRuntime.WPF.Samples.ArcGISVectorTiledLayerUrl
 {
     public partial class ArcGISVectorTiledLayerUrl
     {
-        private string _navigationUrl = "http://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "http://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "http://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "http://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=63c47b7177f946b49902c24129b87252";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=5e9b3685f4c24d8781073dd928ebda50";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
@@ -25,10 +25,10 @@ namespace ArcGISRuntimeXamarin.Samples.ArcGISVectorTiledLayerUrl
         private UIToolbar _toolbar = new UIToolbar();
         private UISegmentedControl _segmentControl = new UISegmentedControl();
 
-        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=dcbbba0edf094eaa81af19298b9c6247";
-        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=4e1133c28ac04cca97693cf336cd49ad";
-        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=bf79e422e9454565ae0cbe9553cf6471";
-        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=850db44b9eb845d3bd42b19e8aa7a024";
+        private string _navigationUrl = "https://www.arcgis.com/home/item.html?id=63c47b7177f946b49902c24129b87252";
+        private string _streetUrl = "https://www.arcgis.com/home/item.html?id=de26a3cf4cc9451298ea173c4b324736";
+        private string _nightUrl = "https://www.arcgis.com/home/item.html?id=86f556a2d1fd468181855a35e344567f";
+        private string _darkGrayUrl = "https://www.arcgis.com/home/item.html?id=5e9b3685f4c24d8781073dd928ebda50";
 
         private string _vectorTiledLayerUrl;
         private ArcGISVectorTiledLayer _vectorTiledLayer;


### PR DESCRIPTION
The ArcGISVectorTiledLayerUrl sample was pointing to old beta vector basemaps. This change updates the samples to use the latest v2 vector basemaps. 