### PR TITLE
Fix GeoView Sync sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
@@ -46,12 +46,36 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             _mySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
             _myMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
-            // Subscribe to viewpoint change events for both views
-            _myMapView.ViewpointChanged += view_viewpointChanged;
-            _mySceneView.ViewpointChanged += view_viewpointChanged;
+            // Subscribe to viewpoint change events for both views - event raised on click+drag
+            _myMapView.ViewpointChanged += OnViewpointChanged;
+            _mySceneView.ViewpointChanged += OnViewpointChanged;
+            
+            // Subscribe to the navigation completed events - raised on flick
+            _myMapView.NavigationCompleted += OnNavigationComplete;
+            _mySceneView.NavigationCompleted += OnNavigationComplete;
         }
 
-        private void view_viewpointChanged(object sender, EventArgs e)
+        private void OnNavigationComplete(object sender, EventArgs eventArgs)
+        {
+            // Get a reference to the MapView or SceneView that raised the event
+            GeoView sendingView = (GeoView)sender;
+
+            // Get a reference to the other view
+            GeoView otherView;
+            if (sendingView is MapView)
+            {
+                otherView = _mySceneView;
+            }
+            else
+            {
+                otherView = _myMapView;
+            }
+
+            // Update the viewpoint on the other view
+            otherView.SetViewpoint(sendingView.GetCurrentViewpoint(ViewpointType.CenterAndScale));
+        }
+
+        private void OnViewpointChanged(object sender, EventArgs e)
         {
             // Get the MapView or SceneView that sent the event
             GeoView sendingView = sender as GeoView;

--- a/src/Forms/Shared/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -38,12 +38,36 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
             MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
-            // Subscribe to viewpoint change events for both views
-            MyMapView.ViewpointChanged += view_viewpointChanged;
-            MySceneView.ViewpointChanged += view_viewpointChanged;
+            // Subscribe to viewpoint change events for both views - event raised on click+drag
+            MyMapView.ViewpointChanged += OnViewpointChanged;
+            MySceneView.ViewpointChanged += OnViewpointChanged;
+            
+            // Subscribe to the navigation completed events - raised on flick
+            MyMapView.NavigationCompleted += OnNavigationComplete;
+            MySceneView.NavigationCompleted += OnNavigationComplete;
         }
 
-        private void view_viewpointChanged(object sender, EventArgs e)
+        private void OnNavigationComplete(object sender, EventArgs eventArgs)
+        {
+            // Get a reference to the MapView or SceneView that raised the event
+            GeoView sendingView = (GeoView)sender;
+
+            // Get a reference to the other view
+            GeoView otherView;
+            if (sendingView is MapView)
+            {
+                otherView = MySceneView;
+            }
+            else
+            {
+                otherView = MyMapView;
+            }
+
+            // Update the viewpoint on the other view
+            otherView.SetViewpoint(sendingView.GetCurrentViewpoint(ViewpointType.CenterAndScale));
+        }
+
+        private void OnViewpointChanged(object sender, EventArgs e)
         {
             // Get the MapView or SceneView that sent the event
             GeoView sendingView = sender as GeoView;

--- a/src/UWP/ArcGISRuntime.UWP.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -35,12 +35,36 @@ namespace ArcGISRuntime.UWP.Samples.GeoViewSync
             MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
             MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
-            // Subscribe to viewpoint change events for both views
-            MyMapView.ViewpointChanged += view_viewpointChanged;
-            MySceneView.ViewpointChanged += view_viewpointChanged;
+            // Subscribe to viewpoint change events for both views - event raised on click+drag
+            MyMapView.ViewpointChanged += OnViewpointChanged;
+            MySceneView.ViewpointChanged += OnViewpointChanged;
+            
+            // Subscribe to the navigation completed events - raised on flick
+            MyMapView.NavigationCompleted += OnNavigationComplete;
+            MySceneView.NavigationCompleted += OnNavigationComplete;
         }
 
-        private void view_viewpointChanged(object sender, EventArgs e)
+        private void OnNavigationComplete(object sender, EventArgs eventArgs)
+        {
+            // Get a reference to the MapView or SceneView that raised the event
+            GeoView sendingView = (GeoView)sender;
+
+            // Get a reference to the other view
+            GeoView otherView;
+            if (sendingView is MapView)
+            {
+                otherView = MySceneView;
+            }
+            else
+            {
+                otherView = MyMapView;
+            }
+
+            // Update the viewpoint on the other view
+            otherView.SetViewpoint(sendingView.GetCurrentViewpoint(ViewpointType.CenterAndScale));
+        }
+
+        private void OnViewpointChanged(object sender, EventArgs e)
         {
             // Get the MapView or SceneView that sent the event
             GeoView sendingView = sender as GeoView;

--- a/src/WPF/ArcGISRuntime.WPF.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Samples/Samples/MapView/GeoViewSync/GeoViewSync.xaml.cs
@@ -35,12 +35,36 @@ namespace ArcGISRuntime.WPF.Samples.GeoViewSync
             MySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
             MyMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
-            // Subscribe to viewpoint change events for both views
-            MyMapView.ViewpointChanged += view_viewpointChanged;
-            MySceneView.ViewpointChanged += view_viewpointChanged;
+            // Subscribe to viewpoint change events for both views - event raised on click+drag
+            MyMapView.ViewpointChanged += OnViewpointChanged;
+            MySceneView.ViewpointChanged += OnViewpointChanged;
+            
+            // Subscribe to the navigation completed events - raised on flick
+            MyMapView.NavigationCompleted += OnNavigationComplete;
+            MySceneView.NavigationCompleted += OnNavigationComplete;
         }
 
-        private void view_viewpointChanged(object sender, EventArgs e)
+        private void OnNavigationComplete(object sender, EventArgs eventArgs)
+        {
+            // Get a reference to the MapView or SceneView that raised the event
+            GeoView sendingView = (GeoView)sender;
+
+            // Get a reference to the other view
+            GeoView otherView;
+            if (sendingView is MapView)
+            {
+                otherView = MySceneView;
+            }
+            else
+            {
+                otherView = MyMapView;
+            }
+
+            // Update the viewpoint on the other view
+            otherView.SetViewpoint(sendingView.GetCurrentViewpoint(ViewpointType.CenterAndScale));
+        }
+
+        private void OnViewpointChanged(object sender, EventArgs e)
         {
             // Get the MapView or SceneView that sent the event
             GeoView sendingView = sender as GeoView;

--- a/src/iOS/Xamarin.iOS/Samples/MapView/GeoViewSync/GeoViewSync.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/GeoViewSync/GeoViewSync.cs
@@ -40,21 +40,39 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
             _mySceneView.InteractionOptions = new SceneViewInteractionOptions { IsFlickEnabled = false };
             _myMapView.InteractionOptions = new MapViewInteractionOptions { IsFlickEnabled = false };
 
-            // Subscribe to viewpoint change events for both views
-            _myMapView.ViewpointChanged += view_viewpointChanged;
-            _mySceneView.ViewpointChanged += view_viewpointChanged;
+            // Subscribe to viewpoint change events for both views - event raised on click+drag
+            _myMapView.ViewpointChanged += OnViewpointChanged;
+            _mySceneView.ViewpointChanged += OnViewpointChanged;
+            
+            // Subscribe to the navigation completed events - raised on flick
+            _myMapView.NavigationCompleted += OnNavigationComplete;
+            _mySceneView.NavigationCompleted += OnNavigationComplete;
         }
 
-        private void CreateLayout()
+        private void OnNavigationComplete(object sender, EventArgs eventArgs)
         {
-            // Add GeoViews to the page
-            View.AddSubviews(_myMapView, _mySceneView);
+            // Get a reference to the MapView or SceneView that raised the event
+            GeoView sendingView = (GeoView)sender;
+
+            // Get a reference to the other view
+            GeoView otherView;
+            if (sendingView is MapView)
+            {
+                otherView = _mySceneView;
+            }
+            else
+            {
+                otherView = _myMapView;
+            }
+
+            // Update the viewpoint on the other view
+            otherView.SetViewpoint(sendingView.GetCurrentViewpoint(ViewpointType.CenterAndScale));
         }
 
-        private void view_viewpointChanged(object sender, EventArgs e)
+        private void OnViewpointChanged(object sender, EventArgs e)
         {
             // Get the MapView or SceneView that sent the event
-            GeoView sendingView = sender as GeoView;
+            GeoView sendingView = (GeoView)sender;
 
             // Only take action if this geoview is the one that the user is navigating.
             // Viewpoint changed events are fired when SetViewpoint is called; This check prevents a feedback loop
@@ -78,6 +96,12 @@ namespace ArcGISRuntimeXamarin.Samples.GeoViewSync
                     _myMapView.SetViewpoint(updateViewpoint);
                 }
             }
+        }
+
+        private void CreateLayout()
+        {
+            // Add GeoViews to the page
+            View.AddSubviews(_myMapView, _mySceneView);
         }
 
         public override void ViewDidLoad()


### PR DESCRIPTION
This changes the GeoView Synchronization sample to also respond to navigation completed events. This will keep the views in sync even when the user flicks or uses shift+click+drag to zoom to an envelope on the map. 