### PR TITLE
Removes reference to preview package in iOS project

### DIFF
--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -132,9 +132,6 @@
       <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.2.1\lib\Xamarin.iOS10\Esri.ArcGISRuntime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Esri.ArcGISRuntime.Preview, Version=100.2.1.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.2.1\lib\Xamarin.iOS10\Esri.ArcGISRuntime.Preview.dll</HintPath>
-    </Reference>
     <Reference Include="MonoTouch.Dialog-1" />
     <Reference Include="OpenTK-1.0" />
     <Reference Include="PCLCrypto, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d4421c8a4786956c, processorArchitecture=MSIL">


### PR DESCRIPTION
The iOS project never used the preview NuGet package; it appears to have been introduced to the .csproj unintentionally. Because the functionality was never referenced, the unnecessary reference never broke the build. 