### PR TITLE
Fixes UI issue in WPF viewer

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml
@@ -6,6 +6,7 @@
              xmlns:converters="clr-namespace:ArcGISRuntime.WPF.Viewer.Converters"
              xmlns:models="clr-namespace:ArcGISRuntime.Samples.Shared.Models"
              mc:Ignorable="d"
+             Background="{StaticResource PrimaryBackgroundColor}"
              d:DesignHeight="300" d:DesignWidth="300" d:DataContext="{d:DesignInstance models:SampleInfo }">
 
     <UserControl.Resources>


### PR DESCRIPTION
Previously, if you switched between samples while on the description tag, the description would be shown (with a transparent background) on top of the sample.

Now, the description will consistently have the right background.