### PR TITLE
Fix UWP search

### DIFF
--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml
@@ -189,10 +189,12 @@
                        Text="{Binding ElementName=Categories, Path=SelectedItem.Name}"
                        Foreground="{StaticResource PrimaryColor}"
                        FontSize="24"></TextBlock>
-            <SearchBox x:Name="SearchBox" RelativePanel.AlignRightWithPanel="True" 
+            <AutoSuggestBox x:Name="SearchBox" RelativePanel.AlignRightWithPanel="True" 
                             RelativePanel.AlignVerticalCenterWith="CategoryTitle" 
                             Width="240" PlaceholderText="i.e. ArcGISTileLayer" Margin="20,0"
-                            QueryChanged="OnSearchQuerySubmitted"></SearchBox>
+                            TextChanged="OnSearchQuerySubmitted"
+                            QueryIcon="Find"
+                            />
             <ToggleButton Style="{StaticResource SearchToggleButtonStyle}" x:Name="SearchToggleButton"
                           Visibility="Collapsed"
                           Width="60"

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
@@ -175,7 +175,7 @@ namespace ArcGISRuntime.UWP.Viewer
             e.Handled = true;
         }
 
-        private void OnSearchQuerySubmitted(SearchBox searchBox, SearchBoxQueryChangedEventArgs searchBoxQueryChangedEventArgs)
+        private void OnSearchQuerySubmitted(AutoSuggestBox searchBox, AutoSuggestBoxTextChangedEventArgs searchBoxQueryChangedEventArgs)
         {
             if (SearchToggleButton.IsChecked == true)
             {
@@ -211,7 +211,7 @@ namespace ArcGISRuntime.UWP.Viewer
 
         private bool SampleSearchFunc(SampleInfo sample)
         {
-            return SampleManager.Current.SampleSearchFunc(sample, SearchBox.QueryText);
+            return SampleManager.Current.SampleSearchFunc(sample, SearchBox.Text);
         }
 
     }


### PR DESCRIPTION
There was an issue where the search box wouldn't render properly when returning from a sample. This was a result of using SearchBox for search, which has been deprecated in favor of AutoSuggestBox.

Behavior seen below:

![uwpviewer](https://user-images.githubusercontent.com/29742178/38889047-4cf607c0-4232-11e8-9b45-a1b207bda717.gif)

@dkemlage Can you please review this? Thanks!
