### PR TITLE
Don't use the roaming folder for large data

### DIFF
--- a/src/ArcGISRuntime.Samples.Shared/Managers/DataManager.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Managers/DataManager.cs
@@ -133,6 +133,8 @@ namespace ArcGISRuntime.Samples.Managers
         {
 #if NETFX_CORE
             string appDataFolder  = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+#elif XAMARIN
+            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 #else
             string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #endif

--- a/src/ArcGISRuntime.Samples.Shared/Managers/DataManager.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Managers/DataManager.cs
@@ -134,7 +134,7 @@ namespace ArcGISRuntime.Samples.Managers
 #if NETFX_CORE
             string appDataFolder  = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
 #else
-            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 #endif
             string sampleDataFolder = Path.Combine(appDataFolder, "ArcGISRuntimeSampleData");
 


### PR DESCRIPTION
This changes data folders to to use the local folder, instead of Roaming. Roaming folders shouldn't be used for large amounts of data, as this could significantly slow down users who have roaming profiles