### PR TITLE
Updates samples involving jobs to follow best practice

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -10,6 +10,8 @@
 using Android.App;
 using Android.OS;
 using Android.Widget;
+using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.ArcGISServices;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -18,18 +20,17 @@ using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
-using Esri.ArcGISRuntime.ArcGISServices;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using ArcGISRuntime.Samples.Managers;
+using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.EditAndSyncFeatures
 {
     [Activity]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Edit and sync features",
         "Data",
@@ -37,42 +38,42 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     public class EditAndSyncFeatures : Activity
     {
-        // Enumeration to track which phase of the workflow the sample is in
+        // Enumeration to track which phase of the workflow the sample is in.
         private enum EditState
         {
-            NotReady, // Geodatabase has not yet been generated
-            Editing, // A feature is in the process of being moved
-            Ready // The geodatabase is ready for synchronization or further edits
+            NotReady, // Geodatabase has not yet been generated.
+            Editing, // A feature is in the process of being moved.
+            Ready // The geodatabase is ready for synchronization or further edits.
         }
 
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Flag to indicate which stage of the edit process we're in
+        // Flag to indicate which stage of the edit process the sample is in.
         private EditState _readyForEdits = EditState.NotReady;
 
-        // Hold a reference to the generated geodatabase
+        // Hold a reference to the generated geodatabase.
         private Geodatabase _resultGdb;
 
-        // Mapview
+        // Mapview.
         private MapView myMapView;
 
-        // Generate Button
+        // Generate Button.
         private Button myGenerateButton;
 
-        // Sync Button
+        // Sync Button.
         private Button mySyncButton;
 
-        // Progress bar
+        // Progress bar.
         private ProgressBar myProgressBar;
 
-        // Help label
+        // Help label.
         private TextView myHelpLabel;
 
         protected override void OnCreate(Bundle bundle)
@@ -80,229 +81,238 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             base.OnCreate(bundle);
             Title = "Edit and Sync Features";
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             CreateLayout();
             Initialize();
         }
 
         private void CreateLayout()
         {
-            // Create the layout
+            // Create the layout.
             LinearLayout layout = new LinearLayout(this);
             layout.Orientation = Orientation.Vertical;
 
-            // Add the help label
+            // Add the help label.
             myHelpLabel = new TextView(this) { Text = "1. Click 'Generate'" };
             layout.AddView(myHelpLabel);
 
-            // Add the progress bar
+            // Add the progress bar.
             myProgressBar = new ProgressBar(this);
             myProgressBar.Visibility = Android.Views.ViewStates.Gone;
             layout.AddView(myProgressBar);
 
-            // Add the generate button
+            // Add the generate button.
             myGenerateButton = new Button(this);
             myGenerateButton.Text = "Generate";
             myGenerateButton.Enabled = false;
             myGenerateButton.Click += GenerateButton_Clicked;
             layout.AddView(myGenerateButton);
 
-            // Add the sync button
+            // Add the sync button.
             mySyncButton = new Button(this);
             mySyncButton.Text = "Synchronize";
             mySyncButton.Click += SyncButton_Click;
             mySyncButton.Enabled = false;
             layout.AddView(mySyncButton);
 
-            // Add the mapview
+            // Add the mapview.
             myMapView = new MapView(this);
             layout.AddView(myMapView);
 
-            // Add the layout to the view
+            // Add the layout to the view.
             SetContentView(layout);
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache tileCache = new TileCache(GetTpkPath());
+            // Create a tile cache and load it with the SanFrancisco streets tpk.
+            TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-            // Create the corresponding layer based on the tile cache
+            // Create the corresponding layer based on the tile cache.
             ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-            // Create the basemap based on the tile cache
+            // Create the basemap based on the tile cache.
             Basemap sfBasemap = new Basemap(tileLayer);
 
-            // Create the map with the tile-based basemap
+            // Create the map with the tile-based basemap.
             Map myMap = new Map(sfBasemap);
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             myMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
+            // Create a new symbol for the extent graphic.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+            // Create graphics overlay for the extent graphic and apply a renderer.
+            GraphicsOverlay extentOverlay = new GraphicsOverlay
+            {
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
 
-            // Add graphics overlay to the map view
+            // Add graphics overlay to the map view.
             myMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Set up an event handler for when the viewpoint (extent) changes
+            // Set up an event handler for when the viewpoint (extent) changes.
             myMapView.ViewpointChanged += MapViewExtentChanged;
 
-            // Set up event handler for mapview taps
+            // Set up event handler for mapview taps.
             myMapView.GeoViewTapped += GeoViewTapped;
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Add all graphics from the service to the map
+            // Add all graphics from the service to the map.
             foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
             {
-                // Get the Uri for this particular layer
+                // Get the Uri for this particular layer.
                 Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
 
-                // Create the ServiceFeatureTable
+                // Create the ServiceFeatureTable.
                 ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
 
-                // Wait for the table to load
+                // Wait for the table to load.
                 await onlineTable.LoadAsync();
 
-                // Add the layer to the map's operational layers if load succeeds
+                // Add the layer to the map's operational layers if load succeeds.
                 if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
                 {
                     myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
                 }
             }
 
-            // Update the graphic - in case user doesn't interact with the map
+            // Update the graphic - in case user doesn't interact with the map.
             UpdateMapExtent();
 
-            // Enable the generate button now that the sample is ready
+            // Enable the generate button now that the sample is ready.
             myGenerateButton.Enabled = true;
         }
 
         private async void GeoViewTapped(object sender, GeoViewInputEventArgs e)
         {
-            // Disregard if not ready for edits
-            if (_readyForEdits == EditState.NotReady) { return; }
-
-            // If an edit is in process, finish it
-            if (_readyForEdits == EditState.Editing)
+            // Disregard if not ready for edits.
+            try
             {
-                // Hold a list of any selected features
-                List<Feature> selectedFeatures = new List<Feature>();
+                if (_readyForEdits == EditState.NotReady) { return; }
 
-                // Get all selected features then clear selection
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                // If an edit is in process, finish it.
+                if (_readyForEdits == EditState.Editing)
                 {
-                    // Get the selected features
-                    FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
+                    // Hold a list of any selected features.
+                    List<Feature> selectedFeatures = new List<Feature>();
 
-                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features
-                    selectedFeatures.AddRange(layerFeatures);
+                    // Get all selected features then clear selection.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                    {
+                        // Get the selected features.
+                        FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
 
-                    // Clear the selection
-                    layer.ClearSelection();
+                        // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features.
+                        selectedFeatures.AddRange(layerFeatures);
+
+                        // Clear the selection.
+                        layer.ClearSelection();
+                    }
+
+                    // Update all selected features' geometry.
+                    foreach (Feature feature in selectedFeatures)
+                    {
+                        // Get a reference to the correct feature table for the feature.
+                        GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+
+                        // Ensure the geometry type of the table is point.
+                        if (table.GeometryType != GeometryType.Point)
+                        {
+                            continue;
+                        }
+
+                        // Set the new geometry.
+                        feature.Geometry = e.Location;
+
+                        try
+                        {
+                            // Update the feature in the table.
+                            await table.UpdateFeatureAsync(feature);
+                        }
+                        catch (Esri.ArcGISRuntime.ArcGISException)
+                        {
+                            ShowStatusMessage("Feature must be within extent of geodatabase.");
+                        }
+                    }
+
+                    // Update the edit state.
+                    _readyForEdits = EditState.Ready;
+
+                    // Enable the sync button.
+                    mySyncButton.Enabled = true;
+
+                    // Update the help label.
+                    myHelpLabel.Text = "4. Click 'Synchronize' or edit more features";
                 }
-
-                // Update all selected features' geometry
-                foreach (Feature feature in selectedFeatures)
+                // Otherwise, start an edit.
+                else
                 {
-                    // Get a reference to the correct feature table for the feature
-                    GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+                    // Define a tolerance for use with identifying the feature.
+                    double tolerance = 15 * myMapView.UnitsPerPixel;
 
-                    // Ensure the geometry type of the table is point
-                    if (table.GeometryType != GeometryType.Point)
+                    // Define the selection envelope.
+                    Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
+
+                    // Define query parameters for feature selection.
+                    QueryParameters query = new QueryParameters()
                     {
-                        continue;
+                        Geometry = selectionEnvelope
+                    };
+
+                    // Select the feature in all applicable tables.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                    {
+                        await layer.SelectFeaturesAsync(query, SelectionMode.New);
                     }
 
-                    // Set the new geometry
-                    feature.Geometry = e.Location;
+                    // Set the edit state.
+                    _readyForEdits = EditState.Editing;
 
-                    try
-                    {
-                        // Update the feature in the table
-                        await table.UpdateFeatureAsync(feature);
-                    }
-                    catch (Esri.ArcGISRuntime.ArcGISException)
-                    {
-                        ShowStatusMessage("Feature must be within extent of geodatabase.");
-                    }
+                    // Update the help label.
+                    myHelpLabel.Text = "3. Tap on the map to move the point";
                 }
-
-                // Update the edit state
-                _readyForEdits = EditState.Ready;
-
-                // Enable the sync button
-                mySyncButton.Enabled = true;
-
-                // Update the help label
-                myHelpLabel.Text = "4. Click 'Synchronize' or edit more features";
             }
-            // Otherwise, start an edit
-            else
+            catch (Exception ex)
             {
-                // Define a tolerance for use with identifying the feature
-                double tolerance = 15 * myMapView.UnitsPerPixel;
-
-                // Define the selection envelope
-                Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
-
-                // Define query parameters for feature selection
-                QueryParameters query = new QueryParameters()
-                {
-                    Geometry = selectionEnvelope
-                };
-
-                // Select the feature in all applicable tables
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
-                {
-                    await layer.SelectFeaturesAsync(query, SelectionMode.New);
-                }
-
-                // Set the edit state
-                _readyForEdits = EditState.Editing;
-
-                // Update the help label
-                myHelpLabel.Text = "3. Tap on the map to move the point";
+                ShowStatusMessage(ex.ToString());
             }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -310,294 +320,254 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the (only) graphic in the map view
+            // Get the (only) graphic in the map view.
             Graphic redPreviewBox = myMapView.GraphicsOverlays.First().Graphics.First();
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = redPreviewBox.Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             GenerateGeodatabaseJob generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event with an inline (lambda) function to show the progress bar
+            // Handle the progress changed event with an inline (lambda) function to show the progress bar.
             generateGdbJob.ProgressChanged += ((sender, e) =>
             {
-                // Get the job
+                // Get the job.
                 GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
 
-                // Update the progress bar
+                // Update the progress bar.
                 UpdateProgressBar(job.Progress);
             });
 
-            // Start the job
+            // Show the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Visible;
+
+            // Start the job.
             generateGdbJob.Start();
+
+            // Wait for the result.
+            _resultGdb = await generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Gone;
+
+            // Do the rest of the work.
+            HandleGenerationCompleted(generateGdbJob);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private void HandleGenerationCompleted(GenerateGeodatabaseJob job)
         {
             JobStatus status = job.Status;
 
-            // If the job completed successfully, add the geodatabase data to the map
+            // If the job completed successfully, add the geodatabase data to the map.
             if (status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                _resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(layer);
                 }
 
-                // Enable editing features
+                // Enable editing features.
                 _readyForEdits = EditState.Ready;
 
-                // Update the help label
+                // Update the help label.
                 myHelpLabel.Text = "2. Tap a point feature to select";
             }
 
-            // See if the job failed
+            // See if the job failed.
             if (status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
+                // Show the message.
                 ShowStatusMessage(message);
             }
         }
 
-        private void HandleSyncStatusChange(SyncGeodatabaseJob job)
+        private void HandleSyncCompleted(SyncGeodatabaseJob job)
         {
             JobStatus status = job.Status;
 
-            // Tell the user about job completion
+            // Tell the user about job completion.
             if (status == JobStatus.Succeeded)
             {
                 ShowStatusMessage("Sync task completed");
             }
 
-            // See if the job failed
+            // See if the job failed.
             if (status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Sync geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
+                // Show the message.
                 ShowStatusMessage(message);
             }
         }
 
-        private void SyncGeodatabase()
+        private async Task SyncGeodatabase()
         {
-            // Return if not ready
+            // Return if not ready.
             if (_readyForEdits != EditState.Ready) { return; }
 
-            // Create parameters for the sync task
+            // Disable the sync button.
+            mySyncButton.Enabled = false;
+
+            // Create parameters for the sync task.
             SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
             {
                 GeodatabaseSyncDirection = SyncDirection.Bidirectional,
                 RollbackOnFailure = false
             };
 
-            // Get the layer Id for each feature table in the geodatabase, then add to the sync job
+            // Get the layer Id for each feature table in the geodatabase, then add to the sync job.
             foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
             {
-                // Get the ID for the layer
+                // Get the ID for the layer.
                 long id = table.ServiceLayerId;
 
-                // Create the SyncLayerOption
+                // Create the SyncLayerOption.
                 SyncLayerOption option = new SyncLayerOption(id);
 
-                // Add the option
+                // Add the option.
                 parameters.LayerOptions.Add(option);
             }
 
-            // Create job
+            // Create job.
             SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
 
-            // Subscribe to status updates
-            job.JobChanged += Job_JobChanged;
+            // Subscribe to progress updates.
+            job.ProgressChanged += (o, e) =>
+            {
+                // Update the progress bar.
+                UpdateProgressBar(job.Progress);
+            };
 
-            // Subscribe to progress updates
-            job.ProgressChanged += Job_ProgressChanged;
+            // Show the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Visible;
 
-            // Start the sync
+            // Start the sync.
             job.Start();
-        }
 
-        private void Job_ProgressChanged(object sender, EventArgs e)
-        {
-            // Get the job object
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
+            // Wait for the job to finish.
+            await job.GetResultAsync();
 
-            // Update the progress bar
-            UpdateProgressBar(job.Progress);
-        }
+            // Hide the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Gone;
 
-        // Get the path to the tile package used for the basemap
-        // (this is plumbing for the sample viewer)
-        private string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
+            // Do the rest of the work.
+            HandleSyncCompleted(job);
 
-        private string GetGdbPath()
-        {
-            // Return a path
-            return $"{Path.GetTempFileName()}.geodatabase";
+            // Re-enable the sync button.
+            mySyncButton.Enabled = true;
         }
 
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             var builder = new AlertDialog.Builder(this);
             builder.SetMessage(message).SetTitle("Alert").Show();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            // Disable the generate button
-            myGenerateButton.Enabled = false;
+            // Disable the generate button.
+            try
+            {
+                myGenerateButton.Enabled = false;
 
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            RunOnUiThread(() =>
-            {
-                // Update progress bar visibility
-                if (job.Status == JobStatus.Started)
-                {
-                    myProgressBar.Visibility = Android.Views.ViewStates.Visible;
-                }
-                else
-                {
-                    myProgressBar.Visibility = Android.Views.ViewStates.Gone;
-                }
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar(int progress)
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
+            //     the dispatcher needs to be used to interact with the UI.
+            // The dispatcher takes an Action, provided here as a lambda function.
             RunOnUiThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = progress;
             });
         }
 
-        private void SyncButton_Click(object sender, EventArgs e)
+        private async void SyncButton_Click(object sender, EventArgs e)
         {
-            SyncGeodatabase();
-        }
-
-        private void Job_JobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            RunOnUiThread(() =>
+            try
             {
-                // Update the progress bar as appropriate
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(0);
-
-                    // Hide the progress bar
-                    myProgressBar.Visibility = Android.Views.ViewStates.Gone;
-                }
-                else
-                {
-                    // Show the progress bar
-                    myProgressBar.Visibility = Android.Views.ViewStates.Visible;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleSyncStatusChange(job);
-            });
+                await SyncGeodatabase();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
     }
 }

--- a/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "Edit and sync features",
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
-        "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
+        "1. Pan and zoom to the area you would like to download point features for, ensuring that all point features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     public class EditAndSyncFeatures : Activity
     {
         // Enumeration to track which phase of the workflow the sample is in.

--- a/src/Android/Xamarin.Android/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,10 +7,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using System.Drawing;
-using System.Linq;
-using System.IO;
 using Android.App;
 using Android.OS;
 using Android.Widget;
@@ -23,11 +19,16 @@ using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.GenerateGeodatabase
 {
     [Activity]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Generate geodatabase",
         "Data",
@@ -35,25 +36,25 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap on the button. This will start the process of generating the offline geodatabase.\n3. Observe that the sample unregisters the geodatabase. This is best practice when changes won't be edited and synced back to the service.\n\nNote that the basemap will be automatically downloaded from an ArcGIS Online portal.")]
     public class GenerateGeodatabase : Activity
     {
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Job used to generate the geodatabase
+        // Job used to generate the geodatabase.
         private GenerateGeodatabaseJob _generateGdbJob;
 
-        // Mapview
+        // Mapview.
         private MapView myMapView;
 
-        // Generate Button
+        // Generate Button.
         private Button myGenerateButton;
 
-        // Progress bar
+        // Progress bar.
         private ProgressBar myProgressBar;
 
         protected override void OnCreate(Bundle bundle)
@@ -61,124 +62,131 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             base.OnCreate(bundle);
             Title = "Generate geodatabase";
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             CreateLayout();
             Initialize();
         }
 
         private void CreateLayout()
         {
-            // Create the layout
+            // Create the layout.
             LinearLayout layout = new LinearLayout(this);
             layout.Orientation = Orientation.Vertical;
 
-            // Add the progress bar
+            // Add the progress bar.
             myProgressBar = new ProgressBar(this);
             myProgressBar.Visibility = Android.Views.ViewStates.Gone;
             layout.AddView(myProgressBar);
 
-            // Add the generate button
+            // Add the generate button.
             myGenerateButton = new Button(this);
             myGenerateButton.Text = "Generate";
             myGenerateButton.Enabled = false;
             myGenerateButton.Click += GenerateButton_Clicked;
             layout.AddView(myGenerateButton);
 
-            // Add the mapview
+            // Add the mapview.
             myMapView = new MapView(this);
             layout.AddView(myMapView);
 
-            // Add the layout to the view
+            // Add the layout to the view.
             SetContentView(layout);
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache _tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap _sfBasemap = new Basemap(_tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(_sfBasemap);
-
-            // Assign the map to the MapView
-            myMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            myMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            myMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            // Create a tile cache and load it with the SanFrancisco streets tpk.
+            try
             {
-                // Create the ServiceFeatureTable for this particular layer
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+                TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the basemap based on the tile cache.
+                Basemap sfBasemap = new Basemap(tileLayer);
+
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(sfBasemap);
+
+                // Assign the map to the MapView.
+                myMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+
+                // Add graphics overlay to the map view.
+                myMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                myMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all graphics from the service to the map.
+                foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    // Create the ServiceFeatureTable for this particular layer.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - in case user doesn't interact with the map.
+                UpdateMapExtent();
+
+                // Enable the generate button now that the sample is ready.
+                myGenerateButton.Enabled = true;
             }
-
-            // Update the graphic - in case user doesn't interact with the map
-            UpdateMapExtent();
-
-            // Enable the generate button now that the sample is ready
-            myGenerateButton.Enabled = true;
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -186,166 +194,141 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update the geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update the geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = myMapView.GraphicsOverlays.First().Graphics.First().Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             _generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            _generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event (to show progress bar)
+            // Handle the progress changed event (to show progress bar).
             _generateGdbJob.ProgressChanged += ((sender, e) =>
             {
                 UpdateProgressBar();
             });
 
-            // Start the job
+            // Show the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Visible;
+
+            // Start the job.
             _generateGdbJob.Start();
+
+            // Wait for the geodatabase.
+            Geodatabase resultGdb = await _generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            myProgressBar.Visibility = Android.Views.ViewStates.Gone;
+
+            // Do the rest of the work.
+            await HandleGenerationCompleted(_generateGdbJob, resultGdb);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private async Task HandleGenerationCompleted(GenerateGeodatabaseJob job, Geodatabase resultGdb)
         {
             JobStatus status = job.Status;
 
-            // If the job completed successfully, add the geodatabase data to the map
+            // If the job completed successfully, add the geodatabase data to the map.
             if (status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                Geodatabase resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer _layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(_layer);
                 }
-                // Best practice is to unregister the geodatabase
+                // Best practice is to unregister the geodatabase.
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
-                // Tell the user that the geodatabase was unregistered
+                // Tell the user that the geodatabase was unregistered.
                 ShowStatusMessage("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
 
-                // Re-enable the generate button
+                // Re-enable the generate button.
                 myGenerateButton.Enabled = true;
             }
 
-            // See if the job failed
+            // See if the job failed.
             if (status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     var m = from msg in job.Messages select msg.Message;
                     message += ": " + string.Join<string>("\n", m);
                 }
 
-                // Show error message
+                // Show error message.
                 ShowStatusMessage(message);
 
-                // Re-enable the generate button
+                // Re-enable the generate button.
                 myGenerateButton.Enabled = true;
             }
         }
 
-        // Get the path to the tile package used for the basemap
-        private string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
-
-        private string GetGdbPath()
-        {
-            // Return a path
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             var builder = new AlertDialog.Builder(this);
             builder.SetMessage(message).SetTitle("Alert").Show();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            // Disable generate button
-            myGenerateButton.Enabled = false;
+            try
+            {
+                // Disable the generate button.
+                myGenerateButton.Enabled = false;
 
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            RunOnUiThread(() =>
-            {
-                // Update progress bar visibility
-                if (job.Status == JobStatus.Started)
-                {
-                    myProgressBar.Visibility = Android.Views.ViewStates.Visible;
-                }
-                else
-                {
-                    myProgressBar.Visibility = Android.Views.ViewStates.Gone;
-                }
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar()
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
+            //     the dispatcher needs to be used to interact with the UI.
             RunOnUiThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = _generateGdbJob.Progress;
             });
         }

--- a/src/Android/Xamarin.Android/Samples/Layers/ExportTiles/ExportTiles.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ExportTiles/ExportTiles.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -9,8 +9,8 @@
 
 using Android.App;
 using Android.OS;
-using Android.Widget;
 using Android.Views;
+using Android.Widget;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
@@ -20,6 +20,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 using System;
 using System.Drawing;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.ExportTiles
 {
@@ -31,34 +32,34 @@ namespace ArcGISRuntime.Samples.ExportTiles
         "1. Pan and zoom until the area you want tiles for is within the red box.\n2. Click 'Export Tiles'.\n3. Pan and zoom to see the area covered by the downloaded tiles in the preview box.")]
     public class ExportTiles : Activity
     {
-        // Reference to the MapView used in the sample
+        // Reference to the MapView used in the sample.
         private MapView _myMapView;
 
-        // Reference to the base tiled map
+        // Reference to the base tiled map.
         private Map _basemap;
 
-        // Reference to the viewpoint (for previewing)
+        // Reference to the viewpoint (for previewing).
         private Viewpoint _originalViewpoint;
 
-        // Reference to the progress bar
+        // Reference to the progress bar.
         private ProgressBar _myProgressBar;
 
-        // Reference to the 'export' button
+        // Reference to the 'export' button.
         private Button _myExportButton;
 
-        // URL to the service tiles will be exported from
+        // URL to the service tiles will be exported from.
         private Uri _serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
 
-        // Path to the tile cache
+        // Path to the tile cache.
         private string _tilePath;
 
-        // Flag to indicate if an exported cache is being previewed
+        // Flag to indicate if an exported cache is being previewed.
         private bool _previewOpen = false;
 
-        // Layout container for setting a margin on the mapview
+        // Layout container for setting a margin on the mapview.
         private RelativeLayout _layoutContainer;
 
-        // Hold the graphics overlay so that overlay graphic can be added and removed
+        // Hold the graphics overlay so that overlay graphic can be added and removed.
         private GraphicsOverlay _overlay;
 
         protected override void OnCreate(Bundle bundle)
@@ -67,93 +68,100 @@ namespace ArcGISRuntime.Samples.ExportTiles
 
             Title = "Export tiles";
 
-            // Create the layout
+            // Create the layout.
             CreateLayout();
 
-            // Initialize the app
+            // Initialize the app.
             Initialize();
         }
 
         private void CreateLayout()
         {
-            // Create a stack layout
+            // Create a stack layout.
             LinearLayout layout = new LinearLayout(this) { Orientation = Orientation.Vertical };
 
             layout.LayoutParameters = new ViewGroup.MarginLayoutParams(ViewGroup.MarginLayoutParams.MatchParent, ViewGroup.MarginLayoutParams.MatchParent);
 
-            // Create the mapview
+            // Create the mapview.
             _myMapView = new MapView();
 
-            // Create the mapview's container
+            // Create the mapview's container.
             _layoutContainer = new RelativeLayout(this);
             _layoutContainer.AddView(_myMapView);
 
-            // Create the progress bar
+            // Create the progress bar.
             _myProgressBar = new ProgressBar(this)
             {
-                Indeterminate = true, // Set the progress bar to be indeterminate (no value)
-                Visibility = Android.Views.ViewStates.Gone
+                Indeterminate = true, // Set the progress bar to be indeterminate (no value).
+                Visibility = ViewStates.Gone
             };
 
-            // Create the export button (disabled until sample is ready)
+            // Create the export button (disabled until sample is ready).
             _myExportButton = new Button(this)
             {
                 Text = "Export Tiles",
                 Enabled = false
             };
 
-            // Get notified of button taps
+            // Get notified of button taps.
             _myExportButton.Click += MyExportButton_Click;
 
-            // Add views to the layout
+            // Add views to the layout.
             layout.AddView(_myProgressBar);
             layout.AddView(_myExportButton);
             layout.AddView(_layoutContainer);
 
-            // Set the layout background color
+            // Set the layout background color.
             layout.SetBackgroundColor(Android.Graphics.Color.MediumVioletRed);
 
-            // Set the layout as the sample view
+            // Set the layout as the sample view.
             SetContentView(layout);
         }
 
         private async void Initialize()
         {
-            // Create the tile layer
-            ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
+            try
+            {
+                // Create the tile layer.
+                ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
 
-            // Load the layer
-            await myLayer.LoadAsync();
+                // Load the layer.
+                await myLayer.LoadAsync();
 
-            // Create the basemap with the layer
-            _basemap = new Map(new Basemap(myLayer));
+                // Create the basemap with the layer.
+                _basemap = new Map(new Basemap(myLayer));
 
-            // Set the min and max scale - export task fails if the scale is too big or small
-            _basemap.MaxScale = 5000000;
-            _basemap.MinScale = 10000000;
+                // Set the min and max scale - export task fails if the scale is too big or small.
+                _basemap.MaxScale = 5000000;
+                _basemap.MinScale = 10000000;
 
-            // Assign the map to the mapview
-            _myMapView.Map = _basemap;
+                // Assign the map to the mapview.
+                _myMapView.Map = _basemap;
 
-            // Create a new symbol for the extent graphic
-            //     This is the red box that visualizes the extent for which tiles will be exported
-            SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+                // Create a new symbol for the extent graphic.
+                //     This is the red box that visualizes the extent for which tiles will be exported.
+                SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
 
-            // Add graphics overlay to the map view
-            _myMapView.GraphicsOverlays.Add(extentOverlay);
+                // Add the graphics overlay to the map view.
+                _myMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position
-            _myMapView.ViewpointChanged += MyMapView_ViewpointChanged;
+                // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position.
+                _myMapView.ViewpointChanged += MyMapView_ViewpointChanged;
 
-            // Update the graphic - in case user doesn't interact with the map
-            UpdateMapExtentGraphic();
+                // Update the graphic - in case user doesn't interact with the map.
+                UpdateMapExtentGraphic();
 
-            // Enable export button now that sample is ready
-            _myExportButton.Enabled = true;
+                // Enable export button now that sample is ready.
+                _myExportButton.Enabled = true;
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void MyMapView_ViewpointChanged(object sender, EventArgs e)
@@ -164,39 +172,39 @@ namespace ArcGISRuntime.Samples.ExportTiles
         /// <summary>
         /// Function used to keep the overlaid preview area marker in position.
         /// This is called by MyMapView_ViewpointChanged every time the user pans/zooms
-        ///     and updates the red box graphic to outline 80% of the current view
+        ///     and updates the red box graphic to outline 80% of the current view.
         /// </summary>
         private void UpdateMapExtentGraphic()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (_myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = _myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = _myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist and we're not in preview
+            // Create the extent graphic and add it to the overlay if it doesn't exist and the sample is not in preview.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -204,220 +212,183 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private string GetTilePath()
+        private async Task StartExport()
         {
-            // Return a path
-            return $"{System.IO.Path.GetTempFileName()}.tpk";
-        }
+            // Update the path to the tile cache.
+            _tilePath = $"{System.IO.Path.GetTempFileName()}.tpk";
 
-        /// <summary>
-        /// Starts the export job and registers callbacks to be notified of changes to job status
-        /// </summary>
-        private async void StartExport()
-        {
-            // Update the path to the tile cache
-            _tilePath = GetTilePath();
-
-            // Get the parameters for the job
+            // Get the parameters for the job.
             ExportTileCacheParameters parameters = GetExportParameters();
 
-            // Create the task
+            // Create the task.
             ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
 
-            // Create the export job
+            // Create the export job.
             ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
 
-            // Subscribe to notifications for status updates
-            job.JobChanged += Job_JobChanged;
-
-            // Start the export job
+            // Start the export job.
             job.Start();
+
+            // Wait for the tile cache.
+            TileCache resultTileCache = await job.GetResultAsync();
+
+            // Do the rest of the work.
+            await HandleExportCompleted(job, resultTileCache);
         }
 
-        /// <summary>
-        /// Constructs and returns parameters for the Export Tile Cache Job
-        /// </summary>
-        /// <returns></returns>
         private ExportTileCacheParameters GetExportParameters()
         {
-            // Create a new parameters instance
+            // Create a new parameters instance.
             ExportTileCacheParameters parameters = new ExportTileCacheParameters();
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = _myMapView.GraphicsOverlays.First();
 
-            // Get the area selection graphic's extent
+            // Get the area selection graphic's extent.
             Graphic extentGraphic = extentOverlay.Graphics.First();
 
-            // Set the area for the export
+            // Set the area for the export.
             parameters.AreaOfInterest = extentGraphic.Geometry;
 
-            // Get the highest possible export quality
+            // Get the highest possible export quality.
             parameters.CompressionQuality = 100;
 
-            // Add level IDs 1-9
-            //     Note: Failing to add at least one Level ID will result in job failure
+            // Add level IDs 1-9.
+            //     Note: Failing to add at least one Level ID will result in job failure.
             for (int x = 1; x < 10; x++)
             {
                 parameters.LevelIds.Add(x);
             }
 
-            // Return the parameters
+            // Return the parameters.
             return parameters;
         }
 
-        /// <summary>
-        /// Called by the ExportTileCacheJob on any status changes
-        /// </summary>
-        private void Job_JobChanged(object sender, EventArgs e)
+        private async Task HandleExportCompleted(ExportTileCacheJob job, TileCache cache)
         {
-            // Get reference to the job
-            ExportTileCacheJob job = sender as ExportTileCacheJob;
-
-            // Update the view if the job is complete
+            // Update the view if the job is complete.
             if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
             {
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                RunOnUiThread(() =>
-                {
-                    // Store the original map viewpoint
-                    _originalViewpoint = _myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
+                // Store the original map viewpoint.
+                _originalViewpoint = _myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-                    // Show the exported tiles on the preview map
-                    UpdatePreviewMap();
+                // Show the exported tiles on the preview map.
+                await UpdatePreviewMap(cache);
 
-                    // Hide the progress bar
-                    _myProgressBar.Visibility = ViewStates.Gone;
+                // Hide the progress bar.
+                _myProgressBar.Visibility = ViewStates.Gone;
 
-                    // Change the export button text
-                    _myExportButton.Text = "Close Preview";
+                // Change the export button text.
+                _myExportButton.Text = "Close Preview";
 
-                    // Re-enable the button
-                    _myExportButton.Enabled = true;
+                // Re-enable the button.
+                _myExportButton.Enabled = true;
 
-                    // Set the preview open flag
-                    _previewOpen = true;
+                // Set the preview open flag.
+                _previewOpen = true;
 
-                    // Store the graphics overlay and then hide it
-                    _overlay = _myMapView.GraphicsOverlays.FirstOrDefault();
-                    _myMapView.GraphicsOverlays.Clear();
-                });
+                // Store the graphics overlay and then hide it.
+                _overlay = _myMapView.GraphicsOverlays.FirstOrDefault();
+                _myMapView.GraphicsOverlays.Clear();
             }
             else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
-                // Notify the user
+                // Notify the user.
                 ShowStatusMessage("Job failed");
 
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                RunOnUiThread(() =>
-                {
-                    // Hide the progress bar
-                    _myProgressBar.Visibility = ViewStates.Gone;
+                // Hide the progress bar.
+                _myProgressBar.Visibility = ViewStates.Gone;
 
-                    // Change the export button text
-                    _myExportButton.Text = "Export tiles";
+                // Change the export button text.
+                _myExportButton.Text = "Export tiles";
 
-                    // Re-enable the export button
-                    _myExportButton.Enabled = true;
+                // Re-enable the export button.
+                _myExportButton.Enabled = true;
 
-                    // Set the preview open flag
-                    _previewOpen = false;
-                });
+                // Set the preview open flag.
+                _previewOpen = false;
             }
         }
 
-        /// <summary>
-        /// Loads the tile cache from disk and displays it in the preview map
-        /// </summary>
-        private async void UpdatePreviewMap()
+        private async Task UpdatePreviewMap(TileCache cache)
         {
-            // Load the saved tile cache
-            TileCache cache = new TileCache(_tilePath);
-
-            // Load the cache
+            // Load the cache.
             await cache.LoadAsync();
 
-            // Create a tile layer with the cache
+            // Create a tile layer with the cache.
             ArcGISTiledLayer myLayer = new ArcGISTiledLayer(cache);
 
-            // Create a new map with the layer as basemap
-            Map previewMap = new Map(new Basemap(myLayer));
+            // Show the tiles in a new map.
+            _myMapView.Map = new Map(new Basemap(myLayer));
 
-            // Apply the map to the mapview
-            _myMapView.Map = previewMap;
-
-            // Set the margin
+            // Set the margin.
             SetMapviewMargin(40);
         }
 
-        /// <summary>
-        /// Begins the export process
-        /// </summary>
-        private void MyExportButton_Click(object sender, EventArgs e)
+        private async void MyExportButton_Click(object sender, EventArgs e)
         {
-            // If preview isn't open, start an export
-            if (!_previewOpen)
+            try
             {
-                // Disable the export button
-                _myExportButton.Enabled = false;
+                // If preview isn't open, start an export.
+                if (!_previewOpen)
+                {
+                    // Disable the export button.
+                    _myExportButton.Enabled = false;
 
-                // Show the progress bar
-                _myProgressBar.Visibility = ViewStates.Visible;
+                    // Show the progress bar.
+                    _myProgressBar.Visibility = ViewStates.Visible;
 
-                // Start the export
-                StartExport();
+                    // Start the export.
+                    await StartExport();
+                }
+                else // Otherwise, close the preview.
+                {
+                    // Apply the old basemap.
+                    _myMapView.Map = _basemap;
+
+                    // Apply the old viewpoint.
+                    _myMapView.SetViewpoint(_originalViewpoint);
+
+                    // Reset the margin.
+                    SetMapviewMargin(0);
+
+                    // Change the button text.
+                    _myExportButton.Text = "Export Tiles";
+
+                    // Clear the preview open flag.
+                    _previewOpen = false;
+
+                    // Re-show the graphics overlay.
+                    _myMapView.GraphicsOverlays.Add(_overlay);
+                }
             }
-            else // Otherwise, close the preview
+            catch (Exception ex)
             {
-                // Apply the old basemap
-                _myMapView.Map = _basemap;
-
-                // Apply the old viewpoint
-                _myMapView.SetViewpoint(_originalViewpoint);
-
-                // Reset the margin
-                SetMapviewMargin(0);
-
-                // Change the button text
-                _myExportButton.Text = "Export Tiles";
-
-                // Clear the preview open flag
-                _previewOpen = false;
-
-                // Re-show the graphics overlay
-                _myMapView.GraphicsOverlays.Add(_overlay);
+                ShowStatusMessage(ex.ToString());
             }
         }
 
-        /// <summary>
-        /// Abstraction of platform-specific functionality to maximize re-use of common code
-        /// </summary>
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             var builder = new AlertDialog.Builder(this);
             builder.SetMessage(message).SetTitle("Alert").Show();
         }
 
-        /// <summary>
-        /// Helper method applies the specified margin to the mapview's container
-        /// </summary>
         private void SetMapviewMargin(int margin)
         {
-            // Get the layout parameters for the container
+            // Get the layout parameters for the container.
             ViewGroup.MarginLayoutParams parameters = (ViewGroup.MarginLayoutParams)_layoutContainer.LayoutParameters;
 
-            // Set the margins
+            // Set the margins.
             parameters.SetMargins(margin, margin, margin, margin);
 
-            // Apply the layout
+            // Apply the layout.
             _layoutContainer.LayoutParameters = parameters;
         }
     }

--- a/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "Edit and sync features",
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
-        "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
+        "1. Pan and zoom to the area you would like to download point features for, ensuring that all point features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures : ContentPage
     {

--- a/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,20 +7,21 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.ArcGISServices;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
-using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
+using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.Xamarin.Forms;
-using Esri.ArcGISRuntime.ArcGISServices;
-using ArcGISRuntime.Samples.Managers;
 using System;
-using System.Linq;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 using Colors = System.Drawing.Color;
 
@@ -31,218 +32,225 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures : ContentPage
     {
-        // Enumeration to track which phase of the workflow the sample is in
+        // Enumeration to track which phase of the workflow the sample is in.
         private enum EditState
         {
-            NotReady, // Geodatabase has not yet been generated
-            Editing, // A feature is in the process of being moved
-            Ready // The geodatabase is ready for synchronization or further edits
+            NotReady, // Geodatabase has not yet been generated.
+            Editing, // A feature is in the process of being moved.
+            Ready // The geodatabase is ready for synchronization or further edits.
         }
 
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Flag to indicate which stage of the edit process we're in
+        // Flag to indicate which stage of the edit process the sample is in.
         private EditState _readyForEdits = EditState.NotReady;
 
-        // Hold a reference to the generated geodatabase
+        // Hold a reference to the generated geodatabase.
         private Geodatabase _resultGdb;
 
         public EditAndSyncFeatures()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap sfBasemap = new Basemap(tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(sfBasemap);
-
-            // Assign the map to the MapView
-            myMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            myMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            myMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            // Create a tile cache and load it with the SanFrancisco streets tpk.
+            try
             {
-                // Get the Uri for this particular layer
-                Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
+                TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Create the ServiceFeatureTable
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the basemap based on the tile cache.
+                Basemap sfBasemap = new Basemap(tileLayer);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(sfBasemap);
+
+                // Assign the map to the MapView.
+                myMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
+
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+
+                // Add the graphics overlay to the map view.
+                myMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                myMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all layers from the service to the map.
+                foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    // Get the URL for this layer.
+                    Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
+
+                    // Create the ServiceFeatureTable.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtent();
+
+                // Enable the generate button now that sample is ready.
+                myGenerateButton.IsEnabled = true;
             }
-
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtent();
-
-            // Enable the generate button now that sample is ready
-            myGenerateButton.IsEnabled = true;
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
         private async void GeoViewTapped(object sender, GeoViewInputEventArgs e)
         {
-            // Disregard if not ready for edits
-            if (_readyForEdits == EditState.NotReady) { return; }
-
-            // If an edit is in process, finish it
-            if (_readyForEdits == EditState.Editing)
+            try
             {
-                // Hold a list of any selected features
-                List<Feature> selectedFeatures = new List<Feature>();
+                // Disregard if not ready for edits.
+                if (_readyForEdits == EditState.NotReady) { return; }
 
-                // Get all selected features then clear selection
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                // If an edit is in process, finish it.
+                if (_readyForEdits == EditState.Editing)
                 {
-                    // Get the selected features
-                    FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
+                    // Hold a list of any selected features.
+                    List<Feature> selectedFeatures = new List<Feature>();
 
-                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features
-                    selectedFeatures.AddRange(layerFeatures);
-
-                    // Clear the selection
-                    layer.ClearSelection();
-                }
-
-                // Update all selected features' geometry
-                foreach (Feature feature in selectedFeatures)
-                {
-                    // Get a reference to the correct feature table for the feature
-                    GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
-
-                    // Ensure the geometry type of the table is point
-                    if (table.GeometryType != GeometryType.Point)
+                    // Get all selected features then clear selection.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
                     {
-                        continue;
+                        // Get the selected features.
+                        FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
+
+                        // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features.
+                        selectedFeatures.AddRange(layerFeatures);
+
+                        // Clear the selection.
+                        layer.ClearSelection();
                     }
 
-                    // Set the new geometry
-                    feature.Geometry = e.Location;
-
-                    try
+                    // Update all selected features' geometry.
+                    foreach (Feature feature in selectedFeatures)
                     {
-                        // Update the feature in the table
+                        // Get a reference to the correct feature table for the feature.
+                        GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+
+                        // Ensure the geometry type of the table is point.
+                        if (table.GeometryType != GeometryType.Point)
+                        {
+                            continue;
+                        }
+
+                        // Set the new geometry.
+                        feature.Geometry = e.Location;
+
+                        // Update the feature in the table.
                         await table.UpdateFeatureAsync(feature);
                     }
-                    catch (Esri.ArcGISRuntime.ArcGISRuntimeException)
+
+                    // Update the edit state.
+                    _readyForEdits = EditState.Ready;
+
+                    // Enable the sync button.
+                    mySyncButton.IsEnabled = true;
+
+                    // Update the help label.
+                    MyHelpLabel.Text = "4. Click 'Synchronize' or edit more features";
+                }
+                // Otherwise, start an edit.
+                else
+                {
+                    // Define a tolerance for use with identifying the feature.
+                    double tolerance = 15 * myMapView.UnitsPerPixel;
+
+                    // Define the selection envelope.
+                    Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
+
+                    // Define query parameters for feature selection.
+                    QueryParameters query = new QueryParameters()
                     {
-                        ShowStatusMessage("Feature must be within the generated geodatabase's extent");
+                        Geometry = selectionEnvelope
+                    };
+
+                    // Select the feature in all applicable tables.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                    {
+                        await layer.SelectFeaturesAsync(query, SelectionMode.New);
                     }
+
+                    // Set the edit state.
+                    _readyForEdits = EditState.Editing;
+
+                    // Update the help label.
+                    MyHelpLabel.Text = "3. Tap on the map to move the point";
                 }
-
-                // Update the edit state
-                _readyForEdits = EditState.Ready;
-
-                // Enable the sync button
-                mySyncButton.IsEnabled = true;
-
-                // Update the help label
-                MyHelpLabel.Text = "4. Click 'Sync' or edit more features";
             }
-            // Otherwise, start an edit
-            else
+            catch (Exception ex)
             {
-                // Define a tolerance for use with identifying the feature
-                double tolerance = 15 * myMapView.UnitsPerPixel;
-
-                // Define the selection envelope
-                Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
-
-                // Define query parameters for feature selection
-                QueryParameters query = new QueryParameters()
-                {
-                    Geometry = selectionEnvelope
-                };
-
-                // Select the feature in all applicable tables
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
-                {
-                    await layer.SelectFeaturesAsync(query, SelectionMode.New);
-                }
-
-                // Set the edit state
-                _readyForEdits = EditState.Editing;
-
-                // Update the help label
-                MyHelpLabel.Text = "3. Tap on the map to move the point";
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -250,297 +258,240 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update the geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update the geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the (only) graphic in the map view
+            // Get the (only) graphic in the map view.
             Graphic redPreviewBox = myMapView.GraphicsOverlays.First().Graphics.First();
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = redPreviewBox.Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             GenerateGeodatabaseJob generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            generateGdbJob.JobChanged += GenerateGdbJobChanged;
+            // Show the progress bar.
+            myProgressBar.IsVisible = true;
 
-            // Handle the progress changed event with an inline (lambda) function to show the progress bar
+            // Handle the progress changed event with an inline (lambda) function to show the progress bar.
             generateGdbJob.ProgressChanged += ((sender, e) =>
             {
-                // Get the job
-                GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
+                    // Get the job.
+                    GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
 
-                // Update the progress bar
-                UpdateProgressBar(job.Progress);
+                    // Update the progress bar.
+                    UpdateProgressBar(job.Progress);
             });
 
-            // Start the job
+            // Start the job.
             generateGdbJob.Start();
+
+            // Get the result.
+            _resultGdb = await generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            myProgressBar.IsVisible = false;
+
+            // Handle the job completion.
+            HandleGenerationStatusChange(generateGdbJob);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
         {
-            JobStatus status = job.Status;
-
-            // If the job completed successfully, add the geodatabase data to the map
-            if (status == JobStatus.Succeeded)
+            // If the job completed successfully, add the geodatabase data to the map.
+            if (job.Status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                _resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(layer);
                 }
 
-                // Enable editing features
+                // Enable editing features.
                 _readyForEdits = EditState.Ready;
 
-                // Update the help label
+                // Update the help label.
                 MyHelpLabel.Text = "2. Tap a point feature to select";
             }
-
-            // See if the job failed
-            if (status == JobStatus.Failed)
+            // See if the job failed.
+            else if (job.Status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
-                ShowStatusMessage(message);
+                // Show the message.
+                DisplayAlert("Error", message, "OK");
             }
         }
 
-        private void HandleSyncStatusChange(SyncGeodatabaseJob job)
+        private async Task SyncGeodatabase()
         {
-            JobStatus status = job.Status;
-
-            // Tell the user about job completion
-            if (status == JobStatus.Succeeded)
-            {
-                ShowStatusMessage("Sync task completed");
-            }
-
-            // See if the job failed
-            if (status == JobStatus.Failed)
-            {
-                // Create a message to show the user
-                string message = "Sync geodatabase job failed";
-
-                // Show an error message (if there is one)
-                if (job.Error != null)
-                {
-                    message += ": " + job.Error.Message;
-                }
-                else
-                {
-                    // If no error, show messages from the job
-                    foreach (JobMessage m in job.Messages)
-                    {
-                        // Get the text from the JobMessage and add it to the output string
-                        message += "\n" + m.Message;
-                    }
-                }
-
-                // Show the message
-                ShowStatusMessage(message);
-            }
-        }
-
-        private void SyncGeodatabase()
-        {
-            // Return if not ready
+            // Return if not ready.
             if (_readyForEdits != EditState.Ready) { return; }
 
-            // Create parameters for the sync task
+            // Create parameters for the sync task.
             SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
             {
                 GeodatabaseSyncDirection = SyncDirection.Bidirectional,
                 RollbackOnFailure = false
             };
 
-            // Get the layer Id for each feature table in the geodatabase, then add to the sync job
+            // Get the layer ID for each feature table in the geodatabase, then add to the sync job.
             foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
             {
-                // Get the ID for the layer
+                // Get the ID for the layer.
                 long id = table.ServiceLayerId;
 
-                // Create the SyncLayerOption
+                // Create the SyncLayerOption.
                 SyncLayerOption option = new SyncLayerOption(id);
 
-                // Add the option
+                // Add the option.
                 parameters.LayerOptions.Add(option);
             }
 
-            // Create job
+            // Create job.
             SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
 
-            // Subscribe to status updates
-            job.JobChanged += Job_JobChanged;
+            // Subscribe to progress updates.
+            job.ProgressChanged += (o, e) =>
+            {
+                UpdateProgressBar(job.Progress);
+            };
 
-            // Subscribe to progress updates
-            job.ProgressChanged += Job_ProgressChanged;
+            // Show the progress bar.
+            myProgressBar.IsVisible = true;
 
-            // Start the sync
+            // Disable the sync button.
+            mySyncButton.IsEnabled = false;
+
+            // Start the sync.
             job.Start();
+
+            // Wait for the result.
+            await job.GetResultAsync();
+
+            // Hide the progress bar.
+            myProgressBar.IsVisible = false;
+
+            // Do the rest of the work.
+            HandleSyncCompleted(job);
+
+            // Re-enable the sync button.
+            mySyncButton.IsEnabled = true;
         }
 
-        private void Job_ProgressChanged(object sender, EventArgs e)
+        private void HandleSyncCompleted(SyncGeodatabaseJob job)
         {
-            // Get the job object
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
+            // Tell the user about job completion.
+            if (job.Status == JobStatus.Succeeded)
+            {
+                DisplayAlert("Alert", "Geodatabase synchronization succeeded.", "OK");
+            }
+            // See if the job failed.
+            else if (job.Status == JobStatus.Failed)
+            {
+                // Create a message to show the user.
+                string message = "Sync geodatabase job failed";
 
-            // Update the progress bar
-            UpdateProgressBar(job.Progress);
+                // Show an error message (if there is one).
+                if (job.Error != null)
+                {
+                    message += ": " + job.Error.Message;
+                }
+                else
+                {
+                    // If no error, show messages from the job.
+                    foreach (JobMessage m in job.Messages)
+                    {
+                        // Get the text from the JobMessage and add it to the output string.
+                        message += "\n" + m.Message;
+                    }
+                }
+
+                // Show the message.
+                DisplayAlert("Error", message, "OK");
+            }
         }
 
-        // Get the path to the tile package used for the basemap
-        // (this is plumbing for the sample viewer)
-        private string GetTpkPath()
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
+            // Disable the generate button.
+            try
+            {
+                myGenerateButton.IsEnabled = false;
+
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
-        private string GetGdbPath()
-        {
-            // Return a new temporary path
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
-        private void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            DisplayAlert("Alert", message, "OK");
-        }
-
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
-        {
-            // Disable the generate button
-            myGenerateButton.IsEnabled = false;
-
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
-        }
-
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                // Hide the progress bar if the job is finished
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    myProgressBar.IsVisible = false;
-                }
-                else // Show it otherwise
-                {
-                    myProgressBar.IsVisible = true;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar(int progress)
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
+            //     the dispatcher needs to be used to interact with the UI.
+            // The dispatcher takes an Action, provided here as a lambda function.
             Device.BeginInvokeOnMainThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = progress / 100.0;
             });
         }
 
-        private void SyncButton_Click(object sender, EventArgs e)
+        private async void SyncButton_Click(object sender, EventArgs e)
         {
-            SyncGeodatabase();
-        }
-
-        private void Job_JobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            Device.BeginInvokeOnMainThread(() =>
+            try
             {
-                // Update the progress bar as appropriate
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(0);
-
-                    // Hide the progress bar
-                    myProgressBar.IsVisible = false;
-                }
-                else
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(job.Progress);
-
-                    // Show the progress bar
-                    myProgressBar.IsVisible = true;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleSyncStatusChange(job);
-            });
+                await SyncGeodatabase();
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Alert", ex.ToString(), "OK");
+            }
         }
     }
 }

--- a/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,17 +7,18 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
-using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
-using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.UI;
 using System;
-using System.Linq;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 using Colors = System.Drawing.Color;
 
@@ -28,19 +29,19 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
         "Data",
         "This sample demonstrates how to take a feature service offline by generating a geodatabase.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap on the button. This will start the process of generating the offline geodatabase.\n3. Observe that the sample unregisters the geodatabase. This is best practice when changes won't be edited and synced back to the service.\n\nNote that the basemap will be automatically downloaded from an ArcGIS Online portal.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class GenerateGeodatabase : ContentPage
     {
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Job used to generate the geodatabase
+        // Job used to generate the geodatabase.
         private GenerateGeodatabaseJob _generateGdbJob;
 
         public GenerateGeodatabase()
@@ -49,97 +50,106 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
 
             Title = "Generate geodatabase";
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache _tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap _sfBasemap = new Basemap(_tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(_sfBasemap);
-
-            // Assign the map to the MapView
-            myMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            myMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            myMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            try
             {
-                // Create the ServiceFeatureTable for this particular layer
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+                // Create a tile cache and load it with the SanFrancisco streets tpk.
+                TileCache _tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the basemap based on the tile cache.
+                Basemap _sfBasemap = new Basemap(_tileLayer);
+
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(_sfBasemap);
+
+                // Assign the map to the MapView.
+                myMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
+
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                myMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                myMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all graphics from the service to the map.
+                foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+                {
+                    // Create the ServiceFeatureTable for this particular layer.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtent();
+
+                // Enable the generate button now that the sample is ready.
+                myGenerateButton.IsEnabled = true;
             }
-
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtent();
-
-            // Enable the generate button now that the sample is ready
-            myGenerateButton.IsEnabled = true;
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -147,162 +157,128 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update the geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update the geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the current extent of the red preview box
-            Envelope extent = myMapView.GraphicsOverlays.First().Graphics.First().Geometry as Envelope;
+            // Get the current extent of the red preview box.
+            Envelope extent = myMapView.GraphicsOverlays[0].Graphics.First().Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             _generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            _generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event (to show progress bar)
+            // Handle the progress changed event (to show progress bar).
             _generateGdbJob.ProgressChanged += ((sender, e) =>
             {
                 UpdateProgressBar();
             });
 
-            // Start the job
+            // Show the progress bar.
+            myProgressBar.IsVisible = true;
+
+            // Start the job.
             _generateGdbJob.Start();
+
+            // Get the result.
+            Geodatabase resultGdb = await _generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            myProgressBar.IsVisible = false;
+
+            // Do the rest of the work.
+            await HandleGenerationStatusChange(_generateGdbJob, resultGdb);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private async Task HandleGenerationStatusChange(GenerateGeodatabaseJob job, Geodatabase resultGdb)
         {
-            JobStatus status = job.Status;
-
-            // If the job completed successfully, add the geodatabase data to the map
-            if (status == JobStatus.Succeeded)
+            // If the job completed successfully, add the geodatabase data to the map.
+            if (job.Status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                Geodatabase resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer _layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(_layer);
                 }
-                // Best practice is to unregister the geodatabase
+                // Best practice is to unregister the geodatabase.
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
-                // Tell the user that the geodatabase was unregistered
-                ShowStatusMessage("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
+                // Tell the user that the geodatabase was unregistered.
+                await DisplayAlert("Alert", "Since no edits will be made, the local geodatabase has been unregistered per best practice.", "OK");
 
-                // Re-enable generate button
+                // Re-enable generate button.
                 myGenerateButton.IsEnabled = true;
             }
 
-            // See if the job failed
-            if (status == JobStatus.Failed)
+            // See if the job failed.
+            if (job.Status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     var m = from msg in job.Messages select msg.Message;
                     message += ": " + string.Join<string>("\n", m);
                 }
 
-                ShowStatusMessage(message);
+                await DisplayAlert("Alert", message, "OK");
             }
         }
 
-        // Get the path to the tile package used for the basemap
-        private string GetTpkPath()
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
+            // Disable the generate button.
+            try
+            {
+                myGenerateButton.IsEnabled = false;
+
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
-        private string GetGdbPath()
-        {
-            // Return a new temporary path
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
-        private void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            DisplayAlert("Alert", message, "OK");
-        }
-
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
-        {
-            // Disable the generate button
-            myGenerateButton.IsEnabled = false;
-
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
-        }
-
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                // Hide the progress bar if the job is finished
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    myProgressBar.IsVisible = false;
-                }
-                else // Show it otherwise
-                {
-                    myProgressBar.IsVisible = true;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar()
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
+            //     the dispatcher needs to be used to interact with the UI.
             Device.BeginInvokeOnMainThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = _generateGdbJob.Progress / 100.0;
             });
         }

--- a/src/Forms/Shared/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -13,9 +13,10 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using System;
-using System.Linq;
-using Xamarin.Forms;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms;
 using Colors = System.Drawing.Color;
 
 namespace ArcGISRuntime.Samples.ExportTiles
@@ -27,69 +28,78 @@ namespace ArcGISRuntime.Samples.ExportTiles
         "1. Pan and zoom until the area you want tiles for is within the red box.\n2. Click 'Export Tiles'.\n3. Pan and zoom to see the area covered by the downloaded tiles in the preview box.")]
     public partial class ExportTiles : ContentPage
     {
-        // URL to the service tiles will be exported from
+        // URL to the service tiles will be exported from.
         private Uri _serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
 
-        // Path to exported tile cache
+        // Path to exported tile cache.
         private string _tilePath;
 
-        // Flag to indicate whether an exported tile cache is being previewed
+        // Flag to indicate whether an exported tile cache is being previewed.
         private bool _previewOpen = false;
 
-        // Reference to the original basemap
+        // Reference to the original basemap.
         private Map _basemap;
 
-        // Reference to the original viewpoint (when previewing)
+        // Reference to the original viewpoint (when previewing).
         private Viewpoint _originalView;
 
-        // Holder for the Graphics Overlay (so that it can be hidden and re-added for preview/non-preview state)
+        // Holder for the Graphics Overlay (so that it can be hidden and re-added for preview/non-preview state).
         private GraphicsOverlay _overlay;
 
         public ExportTiles()
         {
             InitializeComponent();
 
-            // Call a function to set up the map
+            // Call a function to set up the sample.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create the tile layer
-            ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
+            // Create the tile layer.
+            try
+            {
+                ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
 
-            // Load the layer
-            await myLayer.LoadAsync();
+                // Load the layer.
+                await myLayer.LoadAsync();
 
-            // Create the basemap with the layer
-            _basemap = new Map(new Basemap(myLayer));
+                // Create the basemap with the layer.
+                _basemap = new Map(new Basemap(myLayer));
 
-            // Set the min and max scale - export task fails if the scale is too big or small
-            _basemap.MaxScale = 5000000;
-            _basemap.MinScale = 10000000;
+                // Set the min and max scale - export task fails if the scale is too big or small.
+                _basemap.MaxScale = 5000000;
+                _basemap.MinScale = 10000000;
 
-            // Assign the map to the mapview
-            MyMapView.Map = _basemap;
+                // Assign the map to the mapview.
+                MyMapView.Map = _basemap;
 
-            // Create a new symbol for the extent graphic
-            //     This is the red box that visualizes the extent for which tiles will be exported
-            SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
+                // Create a new symbol for the extent graphic.
+                //     This is the red box that visualizes the extent for which tiles will be exported.
+                SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
+                {
+                    Renderer = new SimpleRenderer(myExtentSymbol)
+                };
 
-            // Add graphics overlay to the map view
-            MyMapView.GraphicsOverlays.Add(extentOverlay);
+                // Add graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position
-            MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
+                // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position.
+                MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
 
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtentGraphic();
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtentGraphic();
 
-            // Enable the export button once sample is ready
-            MyExportPreviewButton.IsEnabled = true;
+                // Enable the export button once the sample is ready.
+                MyExportPreviewButton.IsEnabled = true;
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
         private void MyMapView_ViewpointChanged(object sender, EventArgs e)
@@ -104,35 +114,35 @@ namespace ArcGISRuntime.Samples.ExportTiles
         /// </summary>
         private void UpdateMapExtentGraphic()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if there is none (in preview, the overlay shouldn't be there)
+            // Return if there is none (in preview, the overlay shouldn't be there).
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -140,210 +150,177 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private string GetTilePath()
+        private async Task StartExport()
         {
-            // Return a new temporary path
-            return $"{Path.GetTempFileName()}.tpk";
+            try
+            {
+                // Update the tile cache path.
+                _tilePath = $"{Path.GetTempFileName()}.tpk";
+
+                // Get the parameters for the job.
+                ExportTileCacheParameters parameters = GetExportParameters();
+
+                // Create the task.
+                ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
+
+                // Create the export job.
+                ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
+
+                // Show the progress bar.
+                MyProgressBar.IsVisible = true;
+
+                // Start the export job.
+                job.Start();
+
+                // Get the tile cache result.
+                TileCache resultTileCache = await job.GetResultAsync();
+
+                // Hide the progress bar.
+                MyProgressBar.IsVisible = false;
+
+                // Do the rest of the work.
+                await HandleJobCompletion(job, resultTileCache);
+            }
+            catch (Exception ex)
+            {
+                await DisplayAlert("Error", ex.ToString(), "OK");
+            }
         }
 
-        /// <summary>
-        /// Starts the export job and registers callbacks to be notified of changes to job status
-        /// </summary>
-        private async void StartExport()
-        {
-            // Update the tile cache path
-            _tilePath = GetTilePath();
-
-            // Get the parameters for the job
-            ExportTileCacheParameters parameters = GetExportParameters();
-
-            // Create the task
-            ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
-
-            // Create the export job
-            ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
-
-            // Subscribe to notifications for status updates
-            job.JobChanged += Job_JobChanged;
-
-            // Start the export job
-            job.Start();
-        }
-
-        /// <summary>
-        /// Constructs and returns parameters for the Export Tile Cache Job
-        /// </summary>
-        /// <returns></returns>
         private ExportTileCacheParameters GetExportParameters()
         {
-            // Create a new parameters instance
+            // Create a new parameters instance.
             ExportTileCacheParameters parameters = new ExportTileCacheParameters();
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.First();
 
-            // Get the area selection graphic's extent
+            // Get the area selection graphic's extent.
             Graphic extentGraphic = extentOverlay.Graphics.First();
 
-            // Set the area for the export
+            // Set the area for the export.
             parameters.AreaOfInterest = extentGraphic.Geometry;
 
-            // Get the highest possible export quality
+            // Set the highest possible export quality.
             parameters.CompressionQuality = 100;
 
-            // Add level IDs 1-9
-            //     Note: Failing to add at least one Level ID will result in job failure
+            // Add level IDs 1-9.
+            //     Note: Failing to add at least one Level ID will result in job failure.
             for (int x = 1; x < 10; x++)
             {
                 parameters.LevelIds.Add(x);
             }
 
-            // Return the parameters
+            // Return the parameters.
             return parameters;
         }
 
-        /// <summary>
-        /// Called by the ExportTileCacheJob on any status changes
-        /// </summary>
-        private void Job_JobChanged(object sender, EventArgs e)
+        private async Task HandleJobCompletion(ExportTileCacheJob job, TileCache cache)
         {
-            // Get reference to the job
-            ExportTileCacheJob job = sender as ExportTileCacheJob;
-
-            // Update the view if the job is complete
+            // Update the view if the job is complete.
             if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
             {
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    // Show the exported tiles on the preview map
-                    UpdatePreviewMap();
+                // Show the exported tiles on the preview map.
+                await UpdatePreviewMap(cache);
 
-                    // Hide the progress bar
-                    MyProgressBar.IsVisible = false;
+                // Change the export button text.
+                MyExportPreviewButton.Text = "Close Preview";
 
-                    // Change the export button text
-                    MyExportPreviewButton.Text = "Close Preview";
+                // Re-enable the button.
+                MyExportPreviewButton.IsEnabled = true;
 
-                    // Re-enable the button
-                    MyExportPreviewButton.IsEnabled = true;
+                // Set the preview open flag.
+                _previewOpen = true;
 
-                    // Set the preview open flag
-                    _previewOpen = true;
+                // Store the overlay for later.
+                _overlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-                    // Store the overlay for later
-                    _overlay = MyMapView.GraphicsOverlays.FirstOrDefault();
-
-                    // Then hide it
-                    MyMapView.GraphicsOverlays.Clear();
-                });
+                // Then hide it.
+                MyMapView.GraphicsOverlays.Clear();
             }
             else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
-                // Notify the user
-                ShowStatusMessage("Job failed");
+                // Notify the user.
+                await DisplayAlert("Error", "Job Failed", "OK");
 
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    // Hide the progress bar
-                    MyProgressBar.IsVisible = false;
+                // Change the export button text.
+                MyExportPreviewButton.Text = "Export Tiles";
 
-                    // Change the export button text
-                    MyExportPreviewButton.Text = "Export Tiles";
+                // Re-enable the export button.
+                MyExportPreviewButton.IsEnabled = true;
 
-                    // Re-enable the export button
-                    MyExportPreviewButton.IsEnabled = true;
-
-                    // Set the preview open flag
-                    _previewOpen = false;
-                });
+                // Set the preview open flag.
+                _previewOpen = false;
             }
         }
 
-        /// <summary>
-        /// Loads the tile cache from disk and displays it in the preview map
-        /// </summary>
-        private async void UpdatePreviewMap()
+        private async Task UpdatePreviewMap(TileCache cache)
         {
-            // Load the saved tile cache
-            TileCache cache = new TileCache(_tilePath);
-
-            // Load the cache
+            // Load the cache.
             await cache.LoadAsync();
 
-            // Create a tile layer with the cache
+            // Create a tile layer with the cache.
             ArcGISTiledLayer myLayer = new ArcGISTiledLayer(cache);
 
-            // Create a new map with the layer as basemap
-            Map previewMap = new Map(new Basemap(myLayer));
+            // Show the layer in a new map.
+            MyMapView.Map = new Map(new Basemap(myLayer));
 
-            // Apply the map to the preview mapview
-            MyMapView.Map = previewMap;
-
-            // Re-size the mapview
+            // Re-size the mapview.
             MyMapView.Margin = new Thickness(40);
         }
 
-        /// <summary>
-        /// Begins the export process
-        /// </summary>
-        private void MyExportPreviewButton_Clicked(object sender, EventArgs e)
+        private async void MyExportPreviewButton_Clicked(object sender, EventArgs e)
         {
-            // If preview isn't open, start an export
-            if (!_previewOpen)
+            // If preview isn't open, start an export.
+            try
             {
-                // Disable the export button
-                MyExportPreviewButton.IsEnabled = false;
+                if (!_previewOpen)
+                {
+                    // Disable the export button.
+                    MyExportPreviewButton.IsEnabled = false;
 
-                // Show the progress bar
-                MyProgressBar.IsVisible = true;
+                    // Show the progress bar.
+                    MyProgressBar.IsVisible = true;
 
-                // Save the map viewpoint
-                _originalView = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
+                    // Save the map viewpoint.
+                    _originalView = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-                // Start the export
-                StartExport();
+                    // Start the export.
+                    await StartExport();
+                }
+                else // Otherwise, close the preview.
+                {
+                    // Change the button text.
+                    MyExportPreviewButton.Text = "Export Tiles";
+
+                    // Clear the preview open flag.
+                    _previewOpen = false;
+
+                    // Re-size the mapview.
+                    MyMapView.Margin = new Thickness(0);
+
+                    // Re-apply the original map.
+                    MyMapView.Map = _basemap;
+
+                    // Re-apply the original viewpoint.
+                    MyMapView.SetViewpoint(_originalView);
+
+                    // Re-show the overlay.
+                    MyMapView.GraphicsOverlays.Add(_overlay);
+
+                    // Update the graphic.
+                    UpdateMapExtentGraphic();
+                }
             }
-            else // Otherwise, close the preview
+            catch (Exception ex)
             {
-                // Change the button text
-                MyExportPreviewButton.Text = "Export Tiles";
-
-                // Clear the preview open flag
-                _previewOpen = false;
-
-                // Re-size the mapview
-                MyMapView.Margin = new Thickness(0);
-
-                // Re-apply the original map
-                MyMapView.Map = _basemap;
-
-                // Re-apply the original viewpoint
-                MyMapView.SetViewpoint(_originalView);
-
-                // Re-show the overlay
-                MyMapView.GraphicsOverlays.Add(_overlay);
-
-                // Update the graphic
-                UpdateMapExtentGraphic();
+                await DisplayAlert("Error", ex.ToString(), "OK");
             }
-        }
-
-        /// <summary>
-        /// Abstraction of platform-specific functionality to maximize re-use of common code
-        /// </summary>
-        private async void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            await DisplayAlert("Alert", message, "OK");
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.UWP.Samples.EditAndSyncFeatures
         "Edit and sync features",
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
-        "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
+        "1. Pan and zoom to the area you would like to download point features for, ensuring that all point features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures
     {

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.ArcGISServices;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -15,13 +16,12 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
-using Esri.ArcGISRuntime.ArcGISServices;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Drawing;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 
@@ -32,218 +32,227 @@ namespace ArcGISRuntime.UWP.Samples.EditAndSyncFeatures
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures
     {
-        // Enumeration to track which phase of the workflow the sample is in
+        // Enumeration to track which phase of the workflow the sample is in.
         private enum EditState
         {
-            NotReady, // Geodatabase has not yet been generated
-            Editing, // A feature is in the process of being moved
-            Ready // The geodatabase is ready for synchronization or further edits
+            NotReady, // Geodatabase has not yet been generated.
+            Editing, // A feature is in the process of being moved.
+            Ready // The geodatabase is ready for synchronization or further edits.
         }
 
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Flag to indicate which stage of the edit process we're in
+        // Flag to indicate which stage of the edit process we're in.
         private EditState _readyForEdits = EditState.NotReady;
 
-        // Hold a reference to the generated geodatabase
+        // Hold a reference to the generated geodatabase.
         private Geodatabase _resultGdb;
 
         public EditAndSyncFeatures()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache tileCache = new TileCache(GetTpkPath());
+            // Create a tile cache and load it with the SanFrancisco streets tpk.
+            TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-            // Create the corresponding layer based on the tile cache
+            // Create the corresponding layer based on the tile cache.
             ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-            // Create the basemap based on the tile cache
+            // Create the basemap based on the tile cache.
             Basemap sfBasemap = new Basemap(tileLayer);
 
-            // Create the map with the tile-based basemap
+            // Create the map with the tile-based basemap.
             Map myMap = new Map(sfBasemap);
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
+            // Create a new symbol for the extent graphic.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+            // Create graphics overlay for the extent graphic and apply a renderer.
+            GraphicsOverlay extentOverlay = new GraphicsOverlay
+            {
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
 
-            // Add graphics overlay to the map view
+            // Add graphics overlay to the map view.
             MyMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Set up an event handler for when the viewpoint (extent) changes
+            // Set up an event handler for when the viewpoint (extent) changes.
             MyMapView.ViewpointChanged += MapViewExtentChanged;
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Add all graphics from the service to the map
+            // Add all layers from the service to the map.
             foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
             {
-                // Get the Uri for this particular layer
+                // Get the URL for this particular layer.
                 Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
 
-                // Create the ServiceFeatureTable
+                // Create the ServiceFeatureTable.
                 ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
 
-                // Wait for the table to load
+                // Wait for the table to load.
                 await onlineTable.LoadAsync();
 
-                // Add the layer to the map's operational layers if load succeeds
+                // Add the layer to the map's operational layers if load succeeds.
                 if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
                 {
                     myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
                 }
             }
 
-            // Update the extent graphic so that it is valid before user interaction
+            // Update the extent graphic so that it is valid before user interaction.
             UpdateMapExtent();
 
-            // Enable the generate button now that the sample is ready
+            // Enable the generate button now that the sample is ready.
             MyGenerateButton.IsEnabled = true;
         }
 
         private async void GeoViewTapped(object sender, Esri.ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
-            // Disregard if not ready for edits
-            if (_readyForEdits == EditState.NotReady) { return; }
-
-            // If an edit is in process, finish it
-            if (_readyForEdits == EditState.Editing)
+            try
             {
-                // Hold a list of any selected features
-                List<Feature> selectedFeatures = new List<Feature>();
+                // Disregard if not ready for edits.
+                if (_readyForEdits == EditState.NotReady) { return; }
 
-                // Get all selected features then clear selection
-                foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
+                // If an edit is in process, finish it.
+                if (_readyForEdits == EditState.Editing)
                 {
-                    // Get the selected features
-                    FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
+                    // Hold a list of any selected features.
+                    List<Feature> selectedFeatures = new List<Feature>();
 
-                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features
-                    selectedFeatures.AddRange(layerFeatures);
+                    // Get all selected features then clear selection.
+                    foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
+                    {
+                        // Get the selected features.
+                        FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
 
-                    // Clear the selection
-                    layer.ClearSelection();
+                        // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features.
+                        selectedFeatures.AddRange(layerFeatures);
+
+                        // Clear the selection.
+                        layer.ClearSelection();
+                    }
+
+                    // Update all selected feature geometry.
+                    foreach (Feature feature in selectedFeatures)
+                    {
+                        // Get a reference to the correct feature table for the feature.
+                        GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+
+                        // Ensure the geometry type of the table is point.
+                        if (table.GeometryType != GeometryType.Point)
+                        {
+                            continue;
+                        }
+
+                        // Set the new geometry.
+                        feature.Geometry = e.Location;
+
+                        try
+                        {
+                            // Update the feature in the table.
+                            await table.UpdateFeatureAsync(feature);
+                        }
+                        catch (Esri.ArcGISRuntime.ArcGISException)
+                        {
+                            ShowStatusMessage("Feature must be within extent of geodatabase.");
+                        }
+                    }
+
+                    // Update the edit state.
+                    _readyForEdits = EditState.Ready;
+
+                    // Enable the sync button.
+                    MySyncButton.IsEnabled = true;
+
+                    // Update the help label.
+                    MyHelpLabel.Text = "4. Click 'Sync' or edit more features";
                 }
-
-                // Update all selected features' geometry
-                foreach (Feature feature in selectedFeatures)
+                // Otherwise, start an edit.
+                else
                 {
-                    // Get a reference to the correct feature table for the feature
-                    GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+                    // Define a tolerance for use with identifying the feature.
+                    double tolerance = 15 * MyMapView.UnitsPerPixel;
 
-                    // Ensure the geometry type of the table is point
-                    if (table.GeometryType != GeometryType.Point)
+                    // Define the selection envelope.
+                    Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
+
+                    // Define query parameters for feature selection.
+                    QueryParameters query = new QueryParameters()
                     {
-                        continue;
+                        Geometry = selectionEnvelope
+                    };
+
+                    // Select the feature in all applicable tables.
+                    foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
+                    {
+                        await layer.SelectFeaturesAsync(query, SelectionMode.New);
                     }
 
-                    // Set the new geometry
-                    feature.Geometry = e.Location;
+                    // Set the edit state.
+                    _readyForEdits = EditState.Editing;
 
-                    try
-                    {
-                        // Update the feature in the table
-                        await table.UpdateFeatureAsync(feature);
-                    }
-                    catch (Esri.ArcGISRuntime.ArcGISException)
-                    {
-                        ShowStatusMessage("Feature must be within extent of geodatabase.");
-                    }
+                    // Update the help label.
+                    MyHelpLabel.Text = "3. Tap on the map to move the point";
                 }
-
-                // Update the edit state
-                _readyForEdits = EditState.Ready;
-
-                // Enable the sync button
-                MySyncButton.IsEnabled = true;
-
-                // Update the help label
-                MyHelpLabel.Text = "4. Click 'Sync' or edit more features";
             }
-            // Otherwise, start an edit
-            else
+            catch (Exception ex)
             {
-                // Define a tolerance for use with identifying the feature
-                double tolerance = 15 * MyMapView.UnitsPerPixel;
-
-                // Define the selection envelope
-                Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
-
-                // Define query parameters for feature selection
-                QueryParameters query = new QueryParameters()
-                {
-                    Geometry = selectionEnvelope
-                };
-
-                // Select the feature in all applicable tables
-                foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
-                {
-                    await layer.SelectFeaturesAsync(query, SelectionMode.New);
-                }
-
-                // Set the edit state
-                _readyForEdits = EditState.Editing;
-
-                // Update the help label
-                MyHelpLabel.Text = "3. Tap on the map to move the point";
+                ShowStatusMessage(ex.ToString());
             }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -251,295 +260,249 @@ namespace ArcGISRuntime.UWP.Samples.EditAndSyncFeatures
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update the geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update the geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the (only) graphic in the map view
+            // Get the (only) graphic in the map view.
             Graphic redPreviewBox = MyMapView.GraphicsOverlays.First().Graphics.First();
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = redPreviewBox.Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             GenerateGeodatabaseJob generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event with an inline (lambda) function to show the progress bar
+            // Handle the progress changed event with an inline (lambda) function to show the progress bar.
             generateGdbJob.ProgressChanged += ((sender, e) =>
             {
-                // Get the job
-                GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-                // Update the progress bar
-                UpdateProgressBar(job.Progress);
+                // Update the progress bar.
+                UpdateProgressBar(generateGdbJob.Progress);
             });
 
-            // Start the job
+            // Show the progress bar.
+            MyProgressBar.Visibility = Visibility.Visible;
+
+            // Start the job.
             generateGdbJob.Start();
+
+            // Get the result of the job.
+            _resultGdb = await generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            MyProgressBar.Visibility = Visibility.Collapsed;
+
+            // Do the rest of the work.
+            HandleGenerationStatusChange(generateGdbJob);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
         {
-            JobStatus status = job.Status;
-
-            // If the job completed successfully, add the geodatabase data to the map
-            if (status == JobStatus.Succeeded)
+            // If the job completed successfully, add the geodatabase data to the map.
+            if (job.Status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 MyMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                _resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     MyMapView.Map.OperationalLayers.Add(layer);
                 }
 
-                // Enable editing features
+                // Enable editing features.
                 _readyForEdits = EditState.Ready;
 
-                // Update the help label
+                // Update the help label.
                 MyHelpLabel.Text = "2. Tap a point feature to select";
             }
 
-            // See if the job failed
-            if (status == JobStatus.Failed)
+            // See if the job failed.
+            if (job.Status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
+                // Show the message.
                 ShowStatusMessage(message);
             }
         }
 
-        private void HandleSyncStatusChange(SyncGeodatabaseJob job)
+        private async Task SyncGeodatabase()
         {
-            JobStatus status = job.Status;
-
-            // Tell the user about job completion
-            if (status == JobStatus.Succeeded)
-            {
-                ShowStatusMessage("Sync task completed");
-            }
-
-            // See if the job failed
-            if (status == JobStatus.Failed)
-            {
-                // Create a message to show the user
-                string message = "Sync geodatabase job failed";
-
-                // Show an error message (if there is one)
-                if (job.Error != null)
-                {
-                    message += ": " + job.Error.Message;
-                }
-                else
-                {
-                    // If no error, show messages from the job
-                    foreach (JobMessage m in job.Messages)
-                    {
-                        // Get the text from the JobMessage and add it to the output string
-                        message += "\n" + m.Message;
-                    }
-                }
-
-                // Show the message
-                ShowStatusMessage(message);
-            }
-        }
-
-        private void SyncGeodatabase()
-        {
-            // Return if not ready
+            // Return if not ready.
             if (_readyForEdits != EditState.Ready) { return; }
 
-            // Create parameters for the sync task
+            // Disable the sync button.
+            MySyncButton.IsEnabled = false;
+
+            // Create parameters for the sync task.
             SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
             {
                 GeodatabaseSyncDirection = SyncDirection.Bidirectional,
                 RollbackOnFailure = false
             };
 
-            // Get the layer Id for each feature table in the geodatabase, then add to the sync job
+            // Get the layer ID for each feature table in the geodatabase, then add to the sync job.
             foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
             {
-                // Get the ID for the layer
+                // Get the ID for the layer.
                 long id = table.ServiceLayerId;
 
-                // Create the SyncLayerOption
+                // Create the SyncLayerOption.
                 SyncLayerOption option = new SyncLayerOption(id);
 
-                // Add the option
+                // Add the option.
                 parameters.LayerOptions.Add(option);
             }
 
-            // Create job
+            // Create job.
             SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
 
-            // Subscribe to status updates
-            job.JobChanged += Job_JobChanged;
+            // Subscribe to progress updates.
+            job.ProgressChanged += (o, e) =>
+            {
+                // Update the progress bar.
+                UpdateProgressBar(job.Progress);
+            };
 
-            // Subscribe to progress updates
-            job.ProgressChanged += Job_ProgressChanged;
+            // Show the progress bar.
+            MyProgressBar.Visibility = Visibility.Visible;
 
-            // Start the sync
+            // Start the sync.
             job.Start();
+
+            // Wait for the result.
+            await job.GetResultAsync();
+
+            // Hide the progress bar.
+            MyProgressBar.Visibility = Visibility.Collapsed;
+
+            // Do the remainder of the work.
+            HandleSyncCompleted(job);
+
+            // Re-enable the sync button.
+            MySyncButton.IsEnabled = true;
         }
 
-        private void Job_ProgressChanged(object sender, EventArgs e)
+        private void HandleSyncCompleted(SyncGeodatabaseJob job)
         {
-            // Get the job object
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
+            JobStatus status = job.Status;
 
-            // Update the progress bar
-            UpdateProgressBar(job.Progress);
-        }
+            // Tell the user about job completion.
+            if (status == JobStatus.Succeeded)
+            {
+                ShowStatusMessage("Sync task completed");
+            }
 
-        // Get the path to the tile package used for the basemap
-        // (this is plumbing for the sample viewer)
-        private static string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
+            // See if the job failed.
+            if (status == JobStatus.Failed)
+            {
+                // Create a message to show the user.
+                string message = "Sync geodatabase job failed";
 
-        private string GetGdbPath()
-        {
-            // Get the local data path for the geodatabase file
-            return $"{Path.GetTempFileName()}.geodatabase";
+                // Show an error message (if there is one).
+                if (job.Error != null)
+                {
+                    message += ": " + job.Error.Message;
+                }
+                else
+                {
+                    // If no error, show messages from the job.
+                    foreach (JobMessage m in job.Messages)
+                    {
+                        // Get the text from the JobMessage and add it to the output string.
+                        message += "\n" + m.Message;
+                    }
+                }
+
+                // Show the message.
+                ShowStatusMessage(message);
+            }
         }
 
         private async void ShowStatusMessage(string message)
         {
-            // Display the message to the user
-            MessageDialog dialog = new MessageDialog(message);
-            await dialog.ShowAsync();
+            // Display the message to the user.
+            await new MessageDialog(message).ShowAsync();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, RoutedEventArgs e)
+        private async void GenerateButton_Clicked(object sender, RoutedEventArgs e)
         {
-            // Disable the generate button
-            MyGenerateButton.IsEnabled = false;
+            try
+            {
+                // Disable the generate button.
+                MyGenerateButton.IsEnabled = false;
 
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
+        // Handler for the MapView Extent Changed event.
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the cross-platform map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private async void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-            {
-                // Hide the progress bar if the job is finished
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                }
-                else // Show it otherwise
-                {
-                    MyProgressBar.Visibility = Visibility.Visible;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private async void UpdateProgressBar(int progress)
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
+            //     the dispatcher needs to be used to interact with the UI.
+            // The dispatcher takes an Action, provided here as a lambda function.
             await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 MyProgressBar.Value = progress;
             });
         }
 
-        private void SyncButton_Click(object sender, RoutedEventArgs e)
+        private async void SyncButton_Click(object sender, RoutedEventArgs e)
         {
-            SyncGeodatabase();
-        }
-
-        private async void Job_JobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            try
             {
-                // Update the progress bar as appropriate
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(0);
-
-                    // Hide the progress bar
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                }
-                else
-                {
-                    // Show the progress bar
-                    MyProgressBar.Visibility = Visibility.Visible;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleSyncStatusChange(job);
-            });
+                await SyncGeodatabase();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,10 +7,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using System.Linq;
-using System.IO;
-using System.Threading.Tasks;
+using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -18,8 +15,11 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
-using ArcGISRuntime.Samples.Managers;
+using System;
 using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 
@@ -30,19 +30,19 @@ namespace ArcGISRuntime.UWP.Samples.GenerateGeodatabase
         "Data",
         "This sample demonstrates how to take a feature service offline by generating a geodatabase.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap on the button. This will start the process of generating the offline geodatabase.\n3. Observe that the sample unregisters the geodatabase. This is best practice when changes won't be edited and synced back to the service.\n\nNote that the basemap will be automatically downloaded from an ArcGIS Online portal.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class GenerateGeodatabase
     {
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Job used to generate the geodatabase
+        // Job used to generate the geodatabase.
         private GenerateGeodatabaseJob _generateGdbJob;
 
         public GenerateGeodatabase()
@@ -55,91 +55,100 @@ namespace ArcGISRuntime.UWP.Samples.GenerateGeodatabase
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache _tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap _sfBasemap = new Basemap(_tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(_sfBasemap);
-
-            // Assign the map to the MapView
-            MyMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            MyMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            MyMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            try
             {
-                // Create the ServiceFeatureTable for this particular layer
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+                // Create a tile cache and load it with the SanFrancisco streets tpk.
+                TileCache _tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the basemap based on the tile cache.
+                Basemap _sfBasemap = new Basemap(_tileLayer);
+
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(_sfBasemap);
+
+                // Assign the map to the MapView.
+                MyMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                MyMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all layers from the service to the map.
+                foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+                {
+                    // Create the ServiceFeatureTable for this particular layer.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the extent graphic so that it is valid before user interaction.
+                UpdateMapExtent();
+
+                // Enable the generate button now that the sample is ready.
+                MyGenerateButton.IsEnabled = true;
             }
-
-            // Update the extent graphic so that it is valid before user interaction
-            UpdateMapExtent();
-
-            // Enable the generate button now that the sample is ready
-            MyGenerateButton.IsEnabled = true;
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -147,88 +156,92 @@ namespace ArcGISRuntime.UWP.Samples.GenerateGeodatabase
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update the geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update the geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the current extent of the red preview box
-            Envelope extent = MyMapView.GraphicsOverlays.First().Graphics.First().Geometry as Envelope;
+            // Get the current extent of the red preview box.
+            Envelope extent = MyMapView.GraphicsOverlays[0].Graphics.First().Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             _generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            _generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event (to show progress bar)
+            // Handle the progress changed event (to show progress bar).
             _generateGdbJob.ProgressChanged += ((sender, e) =>
             {
                 UpdateProgressBar();
             });
 
-            // Start the job
+            // Show the progress bar.
+            MyProgressBar.Visibility = Visibility.Visible;
+
+            // Start the job.
             _generateGdbJob.Start();
+
+            // Get the result.
+            Geodatabase resultGdb = await _generateGdbJob.GetResultAsync();
+
+            // Hide the progress bar.
+            MyProgressBar.Visibility = Visibility.Collapsed;
+
+            // Do the rest of the work.
+            await HandleGenerationCompleted(resultGdb);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private async Task HandleGenerationCompleted(Geodatabase resultGdb)
         {
-            JobStatus status = job.Status;
-
-            // If the job completed successfully, add the geodatabase data to the map
-            if (status == JobStatus.Succeeded)
+            // If the job completed successfully, add the geodatabase data to the map.
+            if (_generateGdbJob.Status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 MyMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                Geodatabase resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer _layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     MyMapView.Map.OperationalLayers.Add(_layer);
                 }
-                // Best practice is to unregister the geodatabase
+                // Best practice is to unregister the geodatabase.
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
-                // Tell the user that the geodatabase was unregistered
+                // Tell the user that the geodatabase was unregistered.
                 ShowStatusMessage("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
 
-                // Re-enabled the generate button
+                // Re-enable the generate button.
                 MyGenerateButton.IsEnabled = true;
             }
 
-            // See if the job failed
-            if (status == JobStatus.Failed)
+            // See if the job failed.
+            if (_generateGdbJob.Status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
-                if (job.Error != null)
+                // Show an error message (if there is one).
+                if (_generateGdbJob.Error != null)
                 {
-                    message += ": " + job.Error.Message;
+                    message += ": " + _generateGdbJob.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
-                    var m = from msg in job.Messages select msg.Message;
+                    // If no error, show messages from the job.
+                    var m = from msg in _generateGdbJob.Messages select msg.Message;
                     message += ": " + string.Join<string>("\n", m);
                 }
 
@@ -236,74 +249,41 @@ namespace ArcGISRuntime.UWP.Samples.GenerateGeodatabase
             }
         }
 
-        // Get the path to the tile package used for the basemap
-        private static string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
-
-        private string GetGdbPath()
-        {
-            // Get the UWP-specific path for storing the geodatabase
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
         private async void ShowStatusMessage(string message)
         {
-            // Display the message to the user
-            MessageDialog dialog = new MessageDialog(message);
-            await dialog.ShowAsync();
+            // Display the message to the user.
+            await new MessageDialog(message).ShowAsync();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, RoutedEventArgs e)
+        private async void GenerateButton_Clicked(object sender, RoutedEventArgs e)
         {
-            // Disable the generate button
-            MyGenerateButton.IsEnabled = false;
+            // Disable the generate button.
+            try
+            {
+                MyGenerateButton.IsEnabled = false;
 
-            // Call the geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private async void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-            {
-                // Hide the progress bar if the job is finished
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                }
-                else // Show it otherwise
-                {
-                    MyProgressBar.Visibility = Visibility.Visible;
-                }
-
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private async void UpdateProgressBar()
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
+            //     the dispatcher needs to be used to interact with the UI.
             await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 MyProgressBar.Value = _generateGdbJob.Progress / 1.0;
             });
         }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -13,10 +13,10 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Drawing;
-using Windows.UI.Core;
+using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 
@@ -29,57 +29,64 @@ namespace ArcGISRuntime.UWP.Samples.ExportTiles
         "1. Pan and zoom until the area you want tiles for is within the red box.\n2. Click 'Export Tiles'.\n3. Pan and zoom to see the area covered by the downloaded tiles in the preview box.")]
     public partial class ExportTiles
     {
-        // URL to the service tiles will be exported from
+        // URL to the service that tiles will be exported from.
         private Uri _serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
 
-        // Path to the tile package on disk
+        // Path to the tile package on disk.
         private string _tilePath;
 
         public ExportTiles()
         {
             InitializeComponent();
 
-            // Call a function to set up the map
+            // Call a function to set up the map.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create the tile layer
-            ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
+            // Create the tile layer.
+            try
+            {
+                ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
 
-            // Load the layer
-            await myLayer.LoadAsync();
+                // Load the layer.
+                await myLayer.LoadAsync();
 
-            // Create the basemap with the layer
-            Map myMap = new Map(new Basemap(myLayer));
+                // Create the basemap with the layer.
+                Map myMap = new Map(new Basemap(myLayer));
 
-            // Set the min and max scale - export task fails if the scale is too big or small
-            myMap.MaxScale = 5000000;
-            myMap.MinScale = 10000000;
+                // Set the min and max scale - export task fails if the scale is too big or small.
+                myMap.MaxScale = 5000000;
+                myMap.MinScale = 10000000;
 
-            // Assign the map to the mapview
-            MyMapView.Map = myMap;
+                // Assign the map to the mapview.
+                MyMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
-            //     This is the red box that visualizes the extent for which tiles will be exported
-            SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+                // Create a new symbol for the extent graphic.
+                //     This is the red box that visualizes the extent for which tiles will be exported.
+                SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
 
-            // Add graphics overlay to the map view
-            MyMapView.GraphicsOverlays.Add(extentOverlay);
+                // Add the graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position
-            MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
+                // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position.
+                MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
 
-            // Update the extent graphic so that it is valid before user interaction
-            UpdateMapExtentGraphic();
+                // Update the extent graphic so that it is valid before user interaction.
+                UpdateMapExtentGraphic();
 
-            // Enable the export tile button once sample is ready
-            MyExportButton.IsEnabled = true;
+                // Enable the export tile button once sample is ready.
+                MyExportButton.IsEnabled = true;
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void MyMapView_ViewpointChanged(object sender, EventArgs e)
@@ -94,35 +101,35 @@ namespace ArcGISRuntime.UWP.Samples.ExportTiles
         /// </summary>
         private void UpdateMapExtentGraphic()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -130,186 +137,150 @@ namespace ArcGISRuntime.UWP.Samples.ExportTiles
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private string GetTilePath()
+        private async Task StartExport()
         {
-            // Return the platform-specific path for storing the tile cache
-            return $"{Path.GetTempFileName()}.tpk";
-        }
-
-        /// <summary>
-        /// Starts the export job and registers callbacks to be notified of changes to job status
-        /// </summary>
-        private async void StartExport()
-        {
-            // Get the parameters for the job
+            // Get the parameters for the job.
             ExportTileCacheParameters parameters = GetExportParameters();
 
-            // Create the task
+            // Create the task.
             ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
 
-            // Get the tile cache path
-            _tilePath = GetTilePath();
+            // Get the tile cache path.
+            _tilePath = $"{Path.GetTempFileName()}.tpk";
 
-            // Create the export job
+            // Create the export job.
             ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
 
-            // Subscribe to notifications for status updates
-            job.JobChanged += Job_JobChanged;
-
-            // Start the export job
+            // Start the export job.
             job.Start();
+
+            // Get the result.
+            TileCache cache = await job.GetResultAsync();
+
+            // Do the rest of the work.
+            await HandleExportComplete(job, cache);
         }
 
-        /// <summary>
-        /// Constructs and returns parameters for the Export Tile Cache Job
-        /// </summary>
-        /// <returns></returns>
+        private async Task HandleExportComplete(ExportTileCacheJob job, TileCache cache)
+        {
+            // Update the view if the job is complete.
+            if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
+            {
+                // Show the exported tiles on the preview map.
+                await UpdatePreviewMap(cache);
+
+                // Show the preview window.
+                MyPreviewMapView.Visibility = Visibility.Visible;
+
+                // Show the 'close preview' button.
+                MyClosePreviewButton.Visibility = Visibility.Visible;
+
+                // Hide the 'export tiles' button.
+                MyExportButton.Visibility = Visibility.Collapsed;
+
+                // Hide the progress bar.
+                MyProgressBar.Visibility = Visibility.Collapsed;
+
+                // Enable the 'export tiles' button.
+                MyExportButton.IsEnabled = true;
+            }
+            else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
+            {
+                // Notify the user.
+                ShowStatusMessage("Job failed");
+
+                // Hide the progress bar.
+                MyProgressBar.Visibility = Visibility.Collapsed;
+            }
+        }
+
         private ExportTileCacheParameters GetExportParameters()
         {
-            // Create a new parameters instance
+            // Create a new parameters instance.
             ExportTileCacheParameters parameters = new ExportTileCacheParameters();
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.First();
 
-            // Get the area selection graphic's extent
+            // Get the area selection graphic's extent.
             Graphic extentGraphic = extentOverlay.Graphics.First();
 
-            // Set the area for the export
+            // Set the area for the export.
             parameters.AreaOfInterest = extentGraphic.Geometry;
 
-            // Get the highest possible export quality
+            // Set the highest possible export quality.
             parameters.CompressionQuality = 100;
 
-            // Add level IDs 1-9
-            //     Note: Failing to add at least one Level ID will result in job failure
+            // Add level IDs 1-9.
+            //     Note: Failing to add at least one Level ID will result in job failure.
             for (int x = 1; x < 10; x++)
             {
                 parameters.LevelIds.Add(x);
             }
 
-            // Return the parameters
+            // Return the parameters.
             return parameters;
         }
 
-        /// <summary>
-        /// Called by the ExportTileCacheJob on any status changes
-        /// </summary>
-        private async void Job_JobChanged(object sender, EventArgs e)
+        private async Task UpdatePreviewMap(TileCache cache)
         {
-            // Get reference to the job
-            ExportTileCacheJob job = sender as ExportTileCacheJob;
-
-            // Update the view if the job is complete
-            if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
-            {
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                {
-                    // Show the exported tiles on the preview map
-                    UpdatePreviewMap();
-
-                    // Show the preview window
-                    MyPreviewMapView.Visibility = Visibility.Visible;
-
-                    // Show the 'close preview' button
-                    MyClosePreviewButton.Visibility = Visibility.Visible;
-
-                    // Hide the 'export tiles' button
-                    MyExportButton.Visibility = Visibility.Collapsed;
-
-                    // Hide the progress bar
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-
-                    // Enable the 'export tiles' button
-                    MyExportButton.IsEnabled = true;
-                });
-            }
-            else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
-            {
-                // Notify the user
-                ShowStatusMessage("Job failed");
-
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-                {
-                    // Hide the progress bar
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                });
-            }
-        }
-
-        /// <summary>
-        /// Loads the tile cache from disk and displays it in the preview map
-        /// </summary>
-        private async void UpdatePreviewMap()
-        {
-            // Load the saved tile cache
-            TileCache cache = new TileCache(_tilePath);
-
-            // Load the cache
+            // Load the cache.
             await cache.LoadAsync();
 
-            // Create a tile layer with the cache
+            // Create a tile layer with the cache.
             ArcGISTiledLayer myLayer = new ArcGISTiledLayer(cache);
 
-            // Create a new map with the layer as basemap
-            Map previewMap = new Map(new Basemap(myLayer));
-
-            // Apply the map to the preview mapview
-            MyPreviewMapView.Map = previewMap;
+            // Apply the map to the preview mapview.
+            MyPreviewMapView.Map = new Map(new Basemap(myLayer));
         }
 
-        /// <summary>
-        /// Begins the export process
-        /// </summary>
-        private void MyExportButton_Click(object sender, RoutedEventArgs e)
+        private async void MyExportButton_Click(object sender, RoutedEventArgs e)
         {
-            // Disable the export button
-            MyExportButton.IsEnabled = false;
+            try
+            {
+                MyExportButton.IsEnabled = false;
 
-            // Show the progress bar
-            MyProgressBar.Visibility = Visibility.Visible;
+                // Show the progress bar.
+                MyProgressBar.Visibility = Visibility.Visible;
 
-            // Hide the preview window if not already hidden
-            MyPreviewMapView.Visibility = Visibility.Collapsed;
+                // Hide the preview window if not already hidden.
+                MyPreviewMapView.Visibility = Visibility.Collapsed;
 
-            // Hide the 'close preview' button if not already hidden
-            MyClosePreviewButton.Visibility = Visibility.Collapsed;
+                // Hide the 'close preview' button if not already hidden.
+                MyClosePreviewButton.Visibility = Visibility.Collapsed;
 
-            // Show the 'export tiles' button
-            MyExportButton.Visibility = Visibility.Visible;
+                // Show the 'export tiles' button.
+                MyExportButton.Visibility = Visibility.Visible;
 
-            // Start the export
-            StartExport();
+                // Start the export.
+                await StartExport();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        /// <summary>
-        /// Abstraction of platform-specific functionality to maximize re-use of common code
-        /// </summary>
         private async void ShowStatusMessage(string message)
         {
-            // Display the message to the user
-            MessageDialog dialog = new MessageDialog(message);
-            await dialog.ShowAsync();
+            // Display the message to the user.
+            await new MessageDialog(message).ShowAsync();
         }
 
         private void ClosePreview_Click(object sender, RoutedEventArgs e)
         {
-            // Hide the preview map
+            // Hide the preview map.
             MyPreviewMapView.Visibility = Visibility.Collapsed;
 
-            // Hide the 'close preview' button
+            // Hide the 'close preview' button.
             MyClosePreviewButton.Visibility = Visibility.Collapsed;
 
-            // Show the 'export tiles' button
+            // Show the 'export tiles' button.
             MyExportButton.Visibility = Visibility.Visible;
         }
     }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -30,7 +30,7 @@ namespace ArcGISRuntime.WPF.Samples.EditAndSyncFeatures
         "Edit and sync features",
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
-        "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
+        "1. Pan and zoom to the area you would like to download point features for, ensuring that all point features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures
     {
@@ -380,10 +380,9 @@ namespace ArcGISRuntime.WPF.Samples.EditAndSyncFeatures
             // Subscribe to progress updates.
             job.ProgressChanged += (o, e) =>
             {
-                    // Update the progress bar.
-                    UpdateProgressBar(job.Progress);
-            }
-            ;
+                // Update the progress bar.
+                UpdateProgressBar(job.Progress);
+            };
 
             // Show the progress bar.
             MyProgressBar.Visibility = Visibility.Visible;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.ArcGISServices;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -15,13 +16,13 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
-using Esri.ArcGISRuntime.ArcGISServices;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
-using System.Drawing;
 
 namespace ArcGISRuntime.WPF.Samples.EditAndSyncFeatures
 {
@@ -30,218 +31,220 @@ namespace ArcGISRuntime.WPF.Samples.EditAndSyncFeatures
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class EditAndSyncFeatures
     {
-        // Enumeration to track which phase of the workflow the sample is in
+        // Enumeration to track which phase of the workflow the sample is in.
         private enum EditState
         {
-            NotReady, // Geodatabase has not yet been generated
-            Editing, // A feature is in the process of being moved
-            Ready // The geodatabase is ready for synchronization or further edits
+            NotReady, // Geodatabase has not yet been generated.
+            Editing, // A feature is in the process of being moved.
+            Ready // The geodatabase is ready for synchronization or further edits.
         }
 
-        // URI for a feature service that supports geodatabase generation
+        // URI for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Flag to indicate which stage of the edit process we're in
+        // Flag to indicate which stage of the edit process we're in.
         private EditState _readyForEdits = EditState.NotReady;
 
-        // Hold a reference to the generated geodatabase
+        // Hold a reference to the generated geodatabase.
         private Geodatabase _resultGdb;
 
         public EditAndSyncFeatures()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache tileCache = new TileCache(GetTpkPath());
+            // Create a tile cache and load it with the SanFrancisco streets tpk.
+            TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-            // Create the corresponding layer based on the tile cache
+            // Create the corresponding layer based on the tile cache.
             ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-            // Create the basemap based on the tile cache
+            // Create the basemap based on the tile cache.
             Basemap sfBasemap = new Basemap(tileLayer);
 
-            // Create the map with the tile-based basemap
+            // Create the map with the tile-based basemap.
             Map myMap = new Map(sfBasemap);
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
+            // Create a new symbol for the extent graphic.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+            // Create a graphics overlay for the extent graphic and apply a renderer.
+            GraphicsOverlay extentOverlay = new GraphicsOverlay
+            {
+                Renderer = new SimpleRenderer(lineSymbol)
+            };
 
-            // Add graphics overlay to the map view
+            // Add graphics overlay to the map view.
             MyMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Set up an event handler for when the viewpoint (extent) changes
+            // Set up an event handler for when the viewpoint (extent) changes.
             MyMapView.ViewpointChanged += MapViewExtentChanged;
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Add all graphics from the service to the map
+            // Add all graphics from the service to the map.
             foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
             {
-                // Get the Uri for this particular layer
+                // Get the URL for this particular layer.
                 Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
 
-                // Create the ServiceFeatureTable
+                // Create the ServiceFeatureTable.
                 ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
 
-                // Wait for the table to load
+                // Wait for the table to load.
                 await onlineTable.LoadAsync();
 
-                // Add the layer to the map's operational layers if load succeeds
+                // Add the layer to the map's operational layers if load succeeds.
                 if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
                 {
                     myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
                 }
             }
 
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
+            // Update the graphic - needed in case the user decides not to interact before pressing the button.
             UpdateMapExtent();
 
-            // Enable the generate button
+            // Enable the generate button.
             MyGenerateButton.IsEnabled = true;
         }
 
         private async void GeoViewTapped(object sender, Esri.ArcGISRuntime.UI.Controls.GeoViewInputEventArgs e)
         {
-            // Disregard if not ready for edits
+            // Disregard if not ready for edits.
             if (_readyForEdits == EditState.NotReady) { return; }
 
-            // If an edit is in process, finish it
+            // If an edit is in process, finish it.
             if (_readyForEdits == EditState.Editing)
             {
-                // Hold a list of any selected features
+                // Hold a list of any selected features.
                 List<Feature> selectedFeatures = new List<Feature>();
 
-                // Get all selected features then clear selection
+                // Get all selected features then clear selection.
                 foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
                 {
-                    // Get the selected features
+                    // Get the selected features.
                     FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
 
-                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features
+                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features.
                     selectedFeatures.AddRange(layerFeatures);
 
-                    // Clear the selection
+                    // Clear the selection.
                     layer.ClearSelection();
                 }
 
-                // Update all selected features' geometry
+                // Update all selected features' geometry.
                 foreach (Feature feature in selectedFeatures)
                 {
-                    // Get a reference to the correct feature table for the feature
+                    // Get a reference to the correct feature table for the feature.
                     GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
 
-                    // Ensure the geometry type of the table is point
+                    // Ensure the geometry type of the table is point.
                     if (table.GeometryType != GeometryType.Point)
                     {
                         continue;
                     }
 
-                    // Set the new geometry
+                    // Set the new geometry.
                     feature.Geometry = e.Location;
 
                     try
                     {
-                        // Update the feature in the table
+                        // Update the feature in the table.
                         await table.UpdateFeatureAsync(feature);
                     }
                     catch (Esri.ArcGISRuntime.ArcGISException)
                     {
-                        ShowStatusMessage("Feature must be within extent of geodatabase.");
+                        MessageBox.Show("Feature must be within extent of geodatabase.");
                     }
                 }
 
-                // Update the edit state
+                // Update the edit state.
                 _readyForEdits = EditState.Ready;
 
-                // Enable the sync button
+                // Enable the sync button.
                 MySyncButton.IsEnabled = true;
 
-                // Update the help label
+                // Update the help label.
                 MyHelpLabel.Content = "4. Click 'Sync Geodatabase' or edit more features";
             }
-            // Otherwise, start an edit
+            // Otherwise, start an edit.
             else
             {
-                // Define a tolerance for use with identifying the feature
+                // Define a tolerance for use with identifying the feature.
                 double tolerance = 15 * MyMapView.UnitsPerPixel;
 
-                // Define the selection envelope
+                // Define the selection envelope.
                 Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
 
-                // Define query parameters for feature selection
+                // Define query parameters for feature selection.
                 QueryParameters query = new QueryParameters()
                 {
                     Geometry = selectionEnvelope
                 };
 
-                // Select the feature in all applicable tables
+                // Select the feature in all applicable tables.
                 foreach (FeatureLayer layer in MyMapView.Map.OperationalLayers)
                 {
                     await layer.SelectFeaturesAsync(query, SelectionMode.New);
                 }
 
-                // Set the edit state
+                // Set the edit state.
                 _readyForEdits = EditState.Editing;
 
-                // Update the help label
+                // Update the help label.
                 MyHelpLabel.Content = "3. Tap on the map to move the point";
             }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -249,246 +252,242 @@ namespace ArcGISRuntime.WPF.Samples.EditAndSyncFeatures
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, simply update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the (only) graphic in the map view
+            // Get the (only) graphic in the map view.
             Graphic redPreviewBox = MyMapView.GraphicsOverlays.First().Graphics.First();
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = redPreviewBox.Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             GenerateGeodatabaseJob generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the progress changed event with an inline (lambda) function to show the progress bar
+            // Handle the progress changed event with an inline (lambda) function to show the progress bar.
             generateGdbJob.ProgressChanged += ((sender, e) =>
             {
-                // Get the job
-                GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-                // Update the progress bar
-                UpdateProgressBar(job.Progress);
+                // Update the progress bar.
+                UpdateProgressBar(generateGdbJob.Progress);
             });
 
-            // Show the progress bar
+            // Show the progress bar.
             MyProgressBar.Visibility = Visibility.Visible;
 
-            // Start the job
+            // Start the job.
             generateGdbJob.Start();
 
-            // Get the result of the job
+            // Get the result of the job.
             _resultGdb = await generateGdbJob.GetResultAsync();
 
-            // Hide the progress bar
+            // Hide the progress bar.
             MyProgressBar.Visibility = Visibility.Collapsed;
 
-            // If the job completed successfully, add the geodatabase to the map, replacing the layer from the service
-            if (generateGdbJob.Status == JobStatus.Succeeded)
+            // Do the rest of the work.
+            HandleGenerationCompleted(generateGdbJob);
+        }
+
+        private void HandleGenerationCompleted(GenerateGeodatabaseJob job)
+        {
+            // If the job completed successfully, add the geodatabase to the map, replacing the layer from the service.
+            if (job.Status == JobStatus.Succeeded)
             {
-                // Remove the existing layer
+                // Remove the existing layers.
                 MyMapView.Map.OperationalLayers.Clear();
 
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     MyMapView.Map.OperationalLayers.Add(layer);
                 }
 
-                // Enable editing features
+                // Enable editing features.
                 _readyForEdits = EditState.Ready;
 
-                // Update help label
+                // Update help label.
                 MyHelpLabel.Content = "2. Tap a point feature to select";
             }
             else
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
-                if (generateGdbJob.Error != null)
-                {
-                    message += ": " + generateGdbJob.Error.Message;
-                }
-                else
-                {
-                    // If no error, show messages from the job
-                    foreach (JobMessage m in generateGdbJob.Messages)
-                    {
-                        // Get the text from the JobMessage and add it to the output string
-                        message += "\n" + m.Message;
-                    }
-                }
-
-                // Show the message
-                ShowStatusMessage(message);
-            }
-        }
-
-        private async void SyncGeodatabase()
-        {
-            // Return if not ready
-            if (_readyForEdits != EditState.Ready) { return; }
-
-            // Create parameters for the sync task
-            SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
-            {
-                GeodatabaseSyncDirection = SyncDirection.Bidirectional,
-                RollbackOnFailure = false
-            };
-
-            // Get the layer Id for each feature table in the geodatabase, then add to the sync job
-            foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
-            {
-                // Get the ID for the layer
-                long id = table.ServiceLayerId;
-
-                // Create the SyncLayerOption
-                SyncLayerOption option = new SyncLayerOption(id);
-
-                // Add the option
-                parameters.LayerOptions.Add(option);
-            }
-
-            // Create job
-            SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
-
-            // Subscribe to progress updates
-            job.ProgressChanged += Job_ProgressChanged;
-
-            // Show the progress bar
-            MyProgressBar.Visibility = Visibility.Visible;
-
-            // Start the sync
-            job.Start();
-
-            // Wait for the result
-            await job.GetResultAsync();
-
-            // Hide the progress bar
-            MyProgressBar.Visibility = Visibility.Hidden;
-
-            // Do the remainder of the work
-            HandleSyncStatusChange(job);
-        }
-
-        private void HandleSyncStatusChange(SyncGeodatabaseJob job)
-        {
-            JobStatus status = job.Status;
-
-            // Tell the user about job completion
-            if (status == JobStatus.Succeeded)
-            {
-                // Update the progress bar's value
-                UpdateProgressBar(0);
-
-                ShowStatusMessage("Sync task completed");
-            }
-
-            // See if the job failed
-            if (status == JobStatus.Failed)
-            {
-                // Create a message to show the user
-                string message = "Sync geodatabase job failed";
-
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
-                ShowStatusMessage(message);
+                // Show the message.
+                MessageBox.Show(message);
             }
         }
 
-        private void Job_ProgressChanged(object sender, EventArgs e)
+        private async Task SyncGeodatabase()
         {
-            // Get the job object
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
+            // Return if not ready.
+            if (_readyForEdits != EditState.Ready) { return; }
 
-            // Update the progress bar
-            UpdateProgressBar(job.Progress);
+            // Disable the sync button.
+            MySyncButton.IsEnabled = false;
+
+            // Create parameters for the sync task.
+            SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
+            {
+                GeodatabaseSyncDirection = SyncDirection.Bidirectional,
+                RollbackOnFailure = false
+            };
+
+            // Get the layer ID for each feature table in the geodatabase, then add to the sync job.
+            foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
+            {
+                // Get the ID for the layer.
+                long id = table.ServiceLayerId;
+
+                // Create the SyncLayerOption.
+                SyncLayerOption option = new SyncLayerOption(id);
+
+                // Add the option.
+                parameters.LayerOptions.Add(option);
+            }
+
+            // Create job.
+            SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
+
+            // Subscribe to progress updates.
+            job.ProgressChanged += (o, e) =>
+            {
+                    // Update the progress bar.
+                    UpdateProgressBar(job.Progress);
+            }
+            ;
+
+            // Show the progress bar.
+            MyProgressBar.Visibility = Visibility.Visible;
+
+            // Start the sync job.
+            job.Start();
+
+            // Wait for the result.
+            await job.GetResultAsync();
+
+            // Hide the progress bar.
+            MyProgressBar.Visibility = Visibility.Hidden;
+
+            // Do the remainder of the work.
+            HandleSyncCompleted(job);
+
+            // Re-enable the sync button.
+            MySyncButton.IsEnabled = true;
         }
 
-        // Get the path to the tile package used for the basemap
-        // (this is plumbing for the sample viewer)
-        private static string GetTpkPath()
+        private void HandleSyncCompleted(SyncGeodatabaseJob job)
         {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
+            // Tell the user about job completion.
+            if (job.Status == JobStatus.Succeeded)
+            {
+                // Update the progress bar's value.
+                UpdateProgressBar(0);
+
+                MessageBox.Show("Sync task completed");
+            }
+
+            // See if the job failed.
+            if (job.Status == JobStatus.Failed)
+            {
+                // Create a message to show the user.
+                string message = "Sync geodatabase job failed";
+
+                // Show an error message (if there is one).
+                if (job.Error != null)
+                {
+                    message += ": " + job.Error.Message;
+                }
+                else
+                {
+                    // If no error, show messages from the job.
+                    foreach (JobMessage m in job.Messages)
+                    {
+                        // Get the text from the JobMessage and add it to the output string.
+                        message += "\n" + m.Message;
+                    }
+                }
+
+                // Show the message.
+                MessageBox.Show(message);
+            }
         }
 
-        private string GetGdbPath()
+        private async void GenerateButton_Clicked(object sender, RoutedEventArgs e)
         {
-            // Return the WPF-specific path for storing the geodatabase
-            return Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".geodatabase");
+            // Update the Geodatabase path for the new run.
+            try
+            {
+                _gdbPath = Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".geodatabase");
+
+                // Prevent duplicate clicks.
+                MyGenerateButton.IsEnabled = false;
+
+                // Call the cross-platform geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
 
-        private void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            MessageBox.Show(message);
-        }
-
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, RoutedEventArgs e)
-        {
-            // Update the gdb path for the new run
-            _gdbPath = GetGdbPath();
-
-            // Prevent duplicate clicks
-            MyGenerateButton.IsEnabled = false;
-
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
-        }
-
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the cross-platform map extent update method.
             UpdateMapExtent();
         }
 
         private void UpdateProgressBar(int progress)
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
+            //     the dispatcher needs to be used to interact with the UI.
+            // The dispatcher takes an Action, provided here as a lambda function.
             Dispatcher.Invoke(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 MyProgressBar.Value = progress;
             });
         }
 
-        private void SyncButton_Click(object sender, RoutedEventArgs e)
+        private async void SyncButton_Click(object sender, RoutedEventArgs e)
         {
-            SyncGeodatabase();
+            try
+            {
+                await SyncGeodatabase();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,12 +7,7 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using System.Linq;
-using System.Windows;
-using System.Drawing;
-using System.IO;
-using System.Threading.Tasks;
+using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -20,7 +15,12 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
-using ArcGISRuntime.Samples.Managers;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
 
 namespace ArcGISRuntime.WPF.Samples.GenerateGeodatabase
 {
@@ -29,116 +29,125 @@ namespace ArcGISRuntime.WPF.Samples.GenerateGeodatabase
         "Data",
         "This sample demonstrates how to take a feature service offline by generating a geodatabase.",
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap on the button. This will start the process of generating the offline geodatabase.\n3. Observe that the sample unregisters the geodatabase. This is best practice when changes won't be edited and synced back to the service.\n\nNote that the basemap will be automatically downloaded from an ArcGIS Online portal.")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     public partial class GenerateGeodatabase
     {
-        // URI for a feature service that supports geodatabase generation
+        // URI for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Job used to generate the geodatabase
+        // Job used to generate the geodatabase.
         private GenerateGeodatabaseJob _generateGdbJob;
 
         public GenerateGeodatabase()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache _tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap _sfBasemap = new Basemap(_tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(_sfBasemap);
-
-            // Assign the map to the MapView
-            MyMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            MyMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            MyMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            try
             {
-                // Create the ServiceFeatureTable for this particular layer
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+                // Create a tile cache from a locally downloaded file.
+                TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(tileCache);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the basemap based on the tile cache.
+                Basemap _sfBasemap = new Basemap(_tileLayer);
+
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(_sfBasemap);
+
+                // Assign the map to the MapView.
+                MyMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                MyMapView.ViewpointChanged += UpdateMapExtent;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all graphics from the service to the map.
+                foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+                {
+                    // Create the ServiceFeatureTable for this layer.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtent(null, null);
+
+                // Enable the generate button.
+                MyGenerateButton.IsEnabled = true;
             }
-
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtent();
-
-            // Enable the generate button
-            MyGenerateButton.IsEnabled = true;
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
 
-        private void UpdateMapExtent()
+        private void UpdateMapExtent(Object sender, EventArgs e)
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -146,130 +155,117 @@ namespace ArcGISRuntime.WPF.Samples.GenerateGeodatabase
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, simply update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = MyMapView.GraphicsOverlays.First().Graphics.First().Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             _generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the progress changed event (to show progress bar)
+            // Handle the progress changed event (to show progress bar).
             _generateGdbJob.ProgressChanged += ((sender, e) =>
             {
                 UpdateProgressBar();
             });
 
-            // Show the progress bar
+            // Show the progress bar.
             MyProgressBar.Visibility = Visibility.Visible;
 
-            // Start the job
+            // Start the job.
             _generateGdbJob.Start();
 
-            // Get the result
+            // Get the result.
             Geodatabase resultGdb = await _generateGdbJob.GetResultAsync();
 
-            // Hide the progress bar
+            // Hide the progress bar.
             MyProgressBar.Visibility = Visibility.Hidden;
 
+            // Do the rest of the work.
+            await HandleGenerationCompleted(resultGdb);
+        }
+
+        private async Task HandleGenerationCompleted(Geodatabase resultGdb)
+        {
             // If the job completed successfully, add the geodatabase data to the map,
-            // removing the version from the service
+            // removing the version from the service.
             if (_generateGdbJob.Status == JobStatus.Succeeded)
             {
                 MyMapView.Map.OperationalLayers.Clear();
 
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer _layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     MyMapView.Map.OperationalLayers.Add(_layer);
                 }
-                // Best practice is to unregister the geodatabase
+                // Best practice is to unregister the geodatabase.
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
-                // Tell the user that the geodatabase was unregistered
-                ShowStatusMessage("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
-            } 
+                // Tell the user that the geodatabase was unregistered.
+                MessageBox.Show("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
+            }
             else
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (_generateGdbJob.Error != null)
                 {
                     message += ": " + _generateGdbJob.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the _generateGdbJob
+                    // If no error, show messages from the _generateGdbJob.
                     var m = from msg in _generateGdbJob.Messages select msg.Message;
                     message += ": " + string.Join<string>("\n", m);
                 }
 
-                ShowStatusMessage(message);
+                MessageBox.Show(message);
             }
         }
 
-        // Get the path to the tile package used for the basemap
-        private static string GetTpkPath()
+        private async void GenerateButton_Clicked(object sender, RoutedEventArgs e)
         {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
+            // Update the geodatabase path for the new run.
+            try
+            {
+                _gdbPath = Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".geodatabase");
 
-        private string GetGdbPath()
-        {
-            // Return the WPF-specific path for storing the geodatabase
-            return Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".geodatabase");
-        }
+                // Prevent the user from clicking twice - errors happen.
+                MyGenerateButton.IsEnabled = false;
 
-        private void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            MessageBox.Show(message);
-        }
-
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, RoutedEventArgs e)
-        {
-            // Update the gdb path for the new run
-            _gdbPath = GetGdbPath();
-
-            // Prevent the user from clicking twice - errors happen
-            MyGenerateButton.IsEnabled = false;
-
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
-        }
-
-        // Handler for the MapView Extent Changed event
-        private void MapViewExtentChanged(object sender, EventArgs e)
-        {
-            // Call the cross-platform map extent update method
-            UpdateMapExtent();
+                // Call the cross-platform geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
 
         private void UpdateProgressBar()
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
+            //     the dispatcher needs to be used to interact with the UI.
             Dispatcher.Invoke(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 MyProgressBar.Value = _generateGdbJob.Progress / 1.0;
             });
         }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -13,10 +13,11 @@ using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
-using System.Drawing;
 
 namespace ArcGISRuntime.WPF.Samples.ExportTiles
 {
@@ -27,57 +28,61 @@ namespace ArcGISRuntime.WPF.Samples.ExportTiles
         "1. Pan and zoom until the area you want tiles for is within the red box.\n2. Click 'Export Tiles'.\n3. Pan and zoom to see the area covered by the downloaded tiles in the preview box.")]
     public partial class ExportTiles
     {
-        // URL to the service tiles will be exported from
+        // URL to the service tiles will be exported from.
         private Uri _serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
-
-        // Hold the location on disk of the exported tiles
-        private string _tilePath;
 
         public ExportTiles()
         {
             InitializeComponent();
 
-            // Call a function to set up the map
+            // Call a function to set up the map.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create the tile layer
-            ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
+            try
+            {
+                // Create the tile layer.
+                ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
 
-            // Load the layer
-            await myLayer.LoadAsync();
+                // Load the layer.
+                await myLayer.LoadAsync();
 
-            // Create the basemap with the layer
-            Map myMap = new Map(new Basemap(myLayer));
+                // Create the basemap with the layer.
+                Map myMap = new Map(new Basemap(myLayer));
 
-            // Set the min and max scale - export task fails if the scale is too big or small
-            myMap.MaxScale = 5000000;
-            myMap.MinScale = 10000000;
+                // Set the min and max scale - export task fails if the scale is too big or small.
+                myMap.MaxScale = 5000000;
+                myMap.MinScale = 10000000;
 
-            // Assign the map to the mapview
-            MyMapView.Map = myMap;
+                // Assign the map to the mapview.
+                MyMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
-            //     This is the red box that visualizes the extent for which tiles will be exported
-            SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+                // Create a new symbol for the extent graphic.
+                //     This is the red box that visualizes the extent for which tiles will be exported.
+                SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
 
-            // Add graphics overlay to the map view
-            MyMapView.GraphicsOverlays.Add(extentOverlay);
+                // Add the overlay to the view.
+                MyMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position
-            MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
+                // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position.
+                MyMapView.ViewpointChanged += MyMapView_ViewpointChanged;
 
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtentGraphic();
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtentGraphic();
 
-            // Enable the export button
-            MyExportButton.IsEnabled = true;
+                // Enable the export button.
+                MyExportButton.IsEnabled = true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
 
         private void MyMapView_ViewpointChanged(object sender, EventArgs e)
@@ -86,41 +91,41 @@ namespace ArcGISRuntime.WPF.Samples.ExportTiles
         }
 
         /// <summary>
-        /// Function used to keep the overlaid preview area marker in position
+        /// Function used to keep the overlaid preview area marker in position.
         /// This is called by MyMapView_ViewpointChanged every time the user pans/zooms
-        ///     and updates the red box graphic to outline 80% of the current view
+        /// and updates the red box graphic to outline 80% of the current view.
         /// </summary>
         private void UpdateMapExtentGraphic()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (MyMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = MyMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.80);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -128,169 +133,144 @@ namespace ArcGISRuntime.WPF.Samples.ExportTiles
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, simply update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private string GetTilePath()
+        private async Task StartExport()
         {
-            // Return the platform-specific path for storing the tile cache
-            return Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".tpk");
-        }
-
-        /// <summary>
-        /// Starts the export job and registers callbacks to be notified of changes to job status
-        /// </summary>
-        private async void StartExport()
-        {
-            // Get the parameters for the job
+            // Get the parameters for the job.
             ExportTileCacheParameters parameters = GetExportParameters();
 
-            // Create the task
+            // Create the task.
             ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
 
-            // Update the tile cache path
-            _tilePath = GetTilePath();
+            // Get the tile cache path.
+            string tilePath = Path.Combine(Environment.ExpandEnvironmentVariables("%TEMP%"), Path.GetTempFileName() + ".tpk");
 
-            // Create the export job
-            ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
+            // Create the export job.
+            ExportTileCacheJob job = exportTask.ExportTileCache(parameters, tilePath);
 
-            // Start the export job
+            // Start the export job.
             job.Start();
 
-            // Wait for the job to complete
+            // Wait for the job to complete.
             TileCache resultTileCache = await job.GetResultAsync();
 
+            // Do the rest of the work.
+            await HandleExportCompleted(job, resultTileCache);
+        }
+
+        private async Task HandleExportCompleted(ExportTileCacheJob job, TileCache cache)
+        {
             if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
             {
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                Dispatcher.Invoke(() =>
-                {
-                    // Show the exported tiles on the preview map
-                    UpdatePreviewMap(resultTileCache);
+                // Show the exported tiles on the preview map.
+                await UpdatePreviewMap(cache);
 
-                    // Show the preview window
-                    MyPreviewMapView.Visibility = Visibility.Visible;
+                // Show the preview window.
+                MyPreviewMapView.Visibility = Visibility.Visible;
 
-                    // Show the 'close preview' button
-                    MyClosePreviewButton.Visibility = Visibility.Visible;
+                // Show the 'close preview' button.
+                MyClosePreviewButton.Visibility = Visibility.Visible;
 
-                    // Hide the 'export tiles' button
-                    MyExportButton.Visibility = Visibility.Collapsed;
+                // Hide the 'export tiles' button.
+                MyExportButton.Visibility = Visibility.Collapsed;
 
-                    // Hide the progress bar
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                });
+                // Hide the progress bar.
+                MyProgressBar.Visibility = Visibility.Collapsed;
             }
             else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
-                // Notify the user
-                ShowStatusMessage("Job failed");
+                // Notify the user.
+                MessageBox.Show("Job failed");
 
-                // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                Dispatcher.Invoke(() =>
-                {
-                    // Hide the progress bar
-                    MyProgressBar.Visibility = Visibility.Collapsed;
-                });
+                // Hide the progress bar.
+                MyProgressBar.Visibility = Visibility.Collapsed;
             }
         }
 
-        /// <summary>
-        /// Constructs and returns parameters for the Export Tile Cache Job
-        /// </summary>
-        /// <returns></returns>
         private ExportTileCacheParameters GetExportParameters()
         {
-            // Create a new parameters instance
+            // Create a new ExportTileCacheParameters instance.
             ExportTileCacheParameters parameters = new ExportTileCacheParameters();
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = MyMapView.GraphicsOverlays.First();
 
-            // Get the area selection graphic's extent
+            // Get the area selection graphic's extent.
             Graphic extentGraphic = extentOverlay.Graphics.First();
 
-            // Set the area for the export
+            // Set the area for the export.
             parameters.AreaOfInterest = extentGraphic.Geometry;
 
-            // Get the highest possible export quality
+            // Set the highest possible export quality.
             parameters.CompressionQuality = 100;
 
-            // Add level IDs 1-9
-            //     Note: Failing to add at least one Level ID will result in job failure
+            // Add level IDs 1-9.
+            //     Note: Failing to add at least one Level ID will result in job failure.
             for (int x = 1; x < 10; x++)
             {
                 parameters.LevelIds.Add(x);
             }
 
-            // Return the parameters
+            // Return the parameters.
             return parameters;
         }
 
-        /// <summary>
-        /// Loads the tile cache from disk and displays it in the preview map
-        /// </summary>
-        private async void UpdatePreviewMap(TileCache cache)
+        private async Task UpdatePreviewMap(TileCache cache)
         {
-            // Load the cache
+            // Load the cache.
             await cache.LoadAsync();
 
-            // Create a tile layer with the cache
+            // Create a tile layer from the tile cache.
             ArcGISTiledLayer myLayer = new ArcGISTiledLayer(cache);
 
-            // Show the layer in a new map
+            // Show the layer in a new map.
             MyPreviewMapView.Map = new Map(new Basemap(myLayer));
         }
 
-        /// <summary>
-        /// Begins the export process
-        /// </summary>
-        private void MyExportButton_Click(object sender, RoutedEventArgs e)
+        private async void MyExportButton_Click(object sender, RoutedEventArgs e)
         {
-            // Show the progress bar
-            MyProgressBar.Visibility = Visibility.Visible;
+            try
+            {
+                // Show the progress bar.
+                MyProgressBar.Visibility = Visibility.Visible;
 
-            // Hide the preview window if not already hidden
-            MyPreviewMapView.Visibility = Visibility.Collapsed;
+                // Hide the preview window.
+                MyPreviewMapView.Visibility = Visibility.Collapsed;
 
-            // Hide the 'close preview' button if not already hidden
-            MyClosePreviewButton.Visibility = Visibility.Collapsed;
+                // Hide the 'close preview' button.
+                MyClosePreviewButton.Visibility = Visibility.Collapsed;
 
-            // Show the 'export tiles' button
-            MyExportButton.Visibility = Visibility.Visible;
+                // Show the 'export tiles' button.
+                MyExportButton.Visibility = Visibility.Visible;
 
-            // Disable the 'export tiles' button
-            MyExportButton.IsEnabled = false;
+                // Disable the 'export tiles' button.
+                MyExportButton.IsEnabled = false;
 
-            // Start the export
-            StartExport();
-        }
-
-        /// <summary>
-        /// Abstraction of platform-specific functionality to maximize re-use of common code
-        /// </summary>
-        private void ShowStatusMessage(string message)
-        {
-            // Display the message to the user
-            MessageBox.Show(message);
+                // Start the export.
+                await StartExport();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+            }
         }
 
         private void ClosePreview_Click(object sender, RoutedEventArgs e)
         {
-            // Hide the preview map
+            // Hide the preview map.
             MyPreviewMapView.Visibility = Visibility.Collapsed;
 
-            // Hide the close preview button
+            // Hide the close preview button.
             MyClosePreviewButton.Visibility = Visibility.Collapsed;
 
-            // Show the 'export tiles' button
+            // Show the 'export tiles' button.
             MyExportButton.Visibility = Visibility.Visible;
 
-            // Re-enabled the export button
+            // Re-enable the export button.
             MyExportButton.IsEnabled = true;
         }
     }

--- a/src/iOS/Xamarin.iOS/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
@@ -34,7 +34,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "Edit and sync features",
         "Data",
         "This sample demonstrates how to synchronize offline edits with a feature service.",
-        "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
+        "1. Pan and zoom to the area you would like to download point features for, ensuring that all point features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     public class EditAndSyncFeatures : UIViewController
     {
         // Enumeration to track which phase of the workflow the sample is in.

--- a/src/iOS/Xamarin.iOS/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,6 +7,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGISRuntime.Samples.Managers;
+using Esri.ArcGISRuntime.ArcGISServices;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
@@ -15,20 +17,19 @@ using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
-using Esri.ArcGISRuntime.ArcGISServices;
 using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using ArcGISRuntime.Samples.Managers;
+using System.Threading.Tasks;
 using UIKit;
 
 namespace ArcGISRuntime.Samples.EditAndSyncFeatures
 {
     [Register("EditAndSyncFeatures")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Edit and sync features",
         "Data",
@@ -36,42 +37,42 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap the 'generate' button. This will start the process of generating the offline geodatabase.\n3. Tap on a point feature within the area of the generated geodatabase. Then tap on the screen (anywhere within the range of the local geodatabase) to move the point to that location.\n4. Tap the 'Sync Geodatabase' button to synchronize the changes back to the feature service.\n\n Note that the basemap for this sample is downloaded from ArcGIS Online automatically.")]
     public class EditAndSyncFeatures : UIViewController
     {
-        // Enumeration to track which phase of the workflow the sample is in
+        // Enumeration to track which phase of the workflow the sample is in.
         private enum EditState
         {
-            NotReady, // Geodatabase has not yet been generated
-            Editing, // A feature is in the process of being moved
-            Ready // The geodatabase is ready for synchronization or further edits
+            NotReady, // Geodatabase has not yet been generated.
+            Editing, // A feature is in the process of being moved.
+            Ready // The geodatabase is ready for synchronization or further edits.
         }
 
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Flag to indicate which stage of the edit process we're in
+        // Flag to indicate which stage of the edit process the sample is in.
         private EditState _readyForEdits = EditState.NotReady;
 
-        // Hold a reference to the generated geodatabase
+        // Hold a reference to the generated geodatabase.
         private Geodatabase _resultGdb;
 
-        // MapView control
+        // MapView control.
         private MapView myMapView = new MapView();
 
-        // Progress Bar
+        // Progress Bar.
         private UIProgressView myProgressBar = new UIProgressView();
 
-        // Generate button
+        // Generate button.
         private UIButton myGenerateButton = new UIButton() { Enabled = false };
 
-        // Synchronize button
+        // Synchronize button.
         private UIButton mySyncButton = new UIButton();
 
-        // Help label
+        // Help label.
         private UILabel myHelpLabel = new UILabel();
 
         public EditAndSyncFeatures()
@@ -83,7 +84,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
         {
             base.ViewDidLoad();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             CreateLayout();
             Initialize();
         }
@@ -94,227 +95,241 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
 
             nfloat pageOffset = NavigationController.TopLayoutGuide.Length;
 
-            // Place the MapView
+            // Place the MapView.
             myMapView.Frame = new CoreGraphics.CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 
-            // Place the Generate Button
+            // Place the Generate Button.
             myGenerateButton.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 40, View.Bounds.Width / 2, 30);
 
-            // Place the Sync Button
+            // Place the Sync Button.
             mySyncButton.Frame = new CoreGraphics.CGRect(View.Bounds.Width / 2, View.Bounds.Height - 40, View.Bounds.Width / 2, 30);
 
-            // Place the progress bar
+            // Place the progress bar.
             myProgressBar.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 10, View.Bounds.Width, 10);
 
-            // Place the help label
+            // Place the help label.
             myHelpLabel.Frame = new CoreGraphics.CGRect(10, pageOffset + 60, View.Bounds.Width - 20, 30);
         }
 
         private void CreateLayout()
         {
-            // Update the Generate Button
+            // Update the Generate Button.
             myGenerateButton.SetTitle("Generate", UIControlState.Normal);
             myGenerateButton.SetTitleColor(UIColor.Blue, UIControlState.Normal);
             myGenerateButton.BackgroundColor = UIColor.LightTextColor;
             myGenerateButton.TouchUpInside += GenerateButton_Clicked;
 
-            // Update the Sync Button
+            // Update the Sync Button.
             mySyncButton.SetTitle("Synchronize", UIControlState.Normal);
             mySyncButton.SetTitleColor(UIColor.Blue, UIControlState.Normal);
             mySyncButton.BackgroundColor = UIColor.LightTextColor;
             mySyncButton.TouchUpInside += SyncButton_Click;
             mySyncButton.Enabled = false;
 
-            // Update the help label
-            myHelpLabel.Text = "1. Click 'Generate Geodatabase'";
+            // Update the help label.
+            myHelpLabel.Text = "1. Click 'Generate'";
             myHelpLabel.TextColor = UIColor.Red;
             myHelpLabel.ShadowColor = UIColor.DarkGray;
             myHelpLabel.ShadowOffset = new CoreGraphics.CGSize(1, 1);
 
-            // Add the views
+            // Add the views.
             View.AddSubviews(myMapView, myProgressBar, mySyncButton, myGenerateButton, myHelpLabel);
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap sfBasemap = new Basemap(tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(sfBasemap);
-
-            // Assign the map to the MapView
-            myMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            myMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for 'tapped' events
-            myMapView.GeoViewTapped += GeoViewTapped;
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            myMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            try
             {
-                // Get the Uri for this particular layer
-                Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
+                // Create a tile cache and load it with the SanFrancisco streets tpk.
+                TileCache tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Create the ServiceFeatureTable
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer tileLayer = new ArcGISTiledLayer(tileCache);
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the basemap based on the tile cache.
+                Basemap sfBasemap = new Basemap(tileLayer);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(sfBasemap);
+
+                // Assign the map to the MapView.
+                myMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay();
+                extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
+
+                // Add graphics overlay to the map view.
+                myMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for 'tapped' events.
+                myMapView.GeoViewTapped += GeoViewTapped;
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                myMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all graphics from the service to the map.
+                foreach (IdInfo layer in _gdbSyncTask.ServiceInfo.LayerInfos)
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    // Get the Uri for this particular layer.
+                    Uri onlineTableUri = new Uri(_featureServiceUri + "/" + layer.Id);
+
+                    // Create the ServiceFeatureTable.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(onlineTableUri);
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtent();
+
+                // Enable the generate button now that the sample is ready.
+                myGenerateButton.Enabled = true;
             }
-
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtent();
-
-            // Enable the generate button now that the sample is ready
-            myGenerateButton.Enabled = true;
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private async void GeoViewTapped(object sender, GeoViewInputEventArgs e)
         {
-            // Disregard if not ready for edits
-            if (_readyForEdits == EditState.NotReady) { return; }
-
-            // If an edit is in process, finish it
-            if (_readyForEdits == EditState.Editing)
+            try
             {
-                // Hold a list of any selected features
-                List<Feature> selectedFeatures = new List<Feature>();
+                // Disregard if not ready for edits.
+                if (_readyForEdits == EditState.NotReady) { return; }
 
-                // Get all selected features then clear selection
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                // If an edit is in process, finish it.
+                if (_readyForEdits == EditState.Editing)
                 {
-                    // Get the selected features
-                    FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
+                    // Hold a list of any selected features.
+                    List<Feature> selectedFeatures = new List<Feature>();
 
-                    // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features
-                    selectedFeatures.AddRange(layerFeatures);
+                    // Get all selected features then clear selection.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                    {
+                        // Get the selected features.
+                        FeatureQueryResult layerFeatures = await layer.GetSelectedFeaturesAsync();
 
-                    // Clear the selection
-                    layer.ClearSelection();
+                        // FeatureQueryResult implements IEnumerable, so it can be treated as a collection of features.
+                        selectedFeatures.AddRange(layerFeatures);
+
+                        // Clear the selection.
+                        layer.ClearSelection();
+                    }
+
+                    // Update all selected features' geometry.
+                    foreach (Feature feature in selectedFeatures)
+                    {
+                        // Get a reference to the correct feature table for the feature.
+                        GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+
+                        // Ensure the geometry type of the table is point.
+                        if (table.GeometryType != GeometryType.Point)
+                        {
+                            continue;
+                        }
+
+                        // Set the new geometry.
+                        feature.Geometry = e.Location;
+                        try
+                        {
+                            // Update the feature in the table.
+                            await table.UpdateFeatureAsync(feature);
+                        }
+                        catch (Esri.ArcGISRuntime.ArcGISException)
+                        {
+                            ShowStatusMessage("Feature must be within extent of geodatabase.");
+                        }
+                    }
+
+                    // Update the edit state.
+                    _readyForEdits = EditState.Ready;
+
+                    // Enable the sync button.
+                    mySyncButton.Enabled = true;
+
+                    // Update the help label.
+                    myHelpLabel.Text = "4. Click 'Synchronize' or edit more features";
                 }
-
-                // Update all selected features' geometry
-                foreach (Feature feature in selectedFeatures)
+                // Otherwise, start an edit.
+                else
                 {
-                    // Get a reference to the correct feature table for the feature
-                    GeodatabaseFeatureTable table = feature.FeatureTable as GeodatabaseFeatureTable;
+                    // Define a tolerance for use with identifying the feature.
+                    double tolerance = 15 * myMapView.UnitsPerPixel;
 
-                    // Ensure the geometry type of the table is point
-                    if (table.GeometryType != GeometryType.Point)
+                    // Define the selection envelope.
+                    Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
+
+                    // Define query parameters for feature selection.
+                    QueryParameters query = new QueryParameters()
                     {
-                        continue;
+                        Geometry = selectionEnvelope
+                    };
+
+                    // Select the feature in all applicable tables.
+                    foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
+                    {
+                        await layer.SelectFeaturesAsync(query, SelectionMode.New);
                     }
 
-                    // Set the new geometry
-                    feature.Geometry = e.Location;
-                    try
-                    {
-                        // Update the feature in the table
-                        await table.UpdateFeatureAsync(feature);
-                    }
-                    catch (Esri.ArcGISRuntime.ArcGISException)
-                    {
-                        ShowStatusMessage("Feature must be within extent of geodatabase.");
-                    }
+                    // Set the edit state.
+                    _readyForEdits = EditState.Editing;
+
+                    // Update the help label.
+                    myHelpLabel.Text = "3. Tap on the map to move the point";
                 }
-
-                // Update the edit state
-                _readyForEdits = EditState.Ready;
-
-                // Enable the sync button
-                mySyncButton.Enabled = true;
-
-                // Update the help label
-                myHelpLabel.Text = "4. Click 'Synchronize' or edit more features";
             }
-            // Otherwise, start an edit
-            else
+            catch (Exception ex)
             {
-                // Define a tolerance for use with identifying the feature
-                double tolerance = 15 * myMapView.UnitsPerPixel;
-
-                // Define the selection envelope
-                Envelope selectionEnvelope = new Envelope(e.Location.X - tolerance, e.Location.Y - tolerance, e.Location.X + tolerance, e.Location.Y + tolerance);
-
-                // Define query parameters for feature selection
-                QueryParameters query = new QueryParameters()
-                {
-                    Geometry = selectionEnvelope
-                };
-
-                // Select the feature in all applicable tables
-                foreach (FeatureLayer layer in myMapView.Map.OperationalLayers)
-                {
-                    await layer.SelectFeaturesAsync(query, SelectionMode.New);
-                }
-
-                // Set the edit state
-                _readyForEdits = EditState.Editing;
-
-                // Update the help label
-                myHelpLabel.Text = "3. Tap on the map to move the point";
+                ShowStatusMessage(ex.ToString());
             }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.70);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -322,281 +337,234 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the (only) graphic in the map view
+            // Get the (only) graphic in the map view.
             Graphic redPreviewBox = myMapView.GraphicsOverlays.First().Graphics.First();
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = redPreviewBox.Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             GenerateGeodatabaseJob generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event with an inline (lambda) function to show the progress bar
+            // Handle the progress changed event with an inline (lambda) function to show the progress bar.
             generateGdbJob.ProgressChanged += ((sender, e) =>
             {
-                // Get the job
+                // Get the job.
                 GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
 
-                // Update the progress bar
+                // Update the progress bar.
                 UpdateProgressBar(job.Progress);
             });
 
-            // Start the job
+            // Start the job.
             generateGdbJob.Start();
+
+            // Get the result.
+            _resultGdb = await generateGdbJob.GetResultAsync();
+
+            // Do the rest of the work.
+            HandleGenerationCompleted(generateGdbJob);
         }
 
-        private string GetGdbPath()
+        private void HandleGenerationCompleted(GenerateGeodatabaseJob job)
         {
-            // Return a path
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
-        {
-            JobStatus status = job.Status;
-
-            // If the job completed successfully, add the geodatabase data to the map
-            if (status == JobStatus.Succeeded)
+            // If the job completed successfully, add the geodatabase data to the map.
+            if (job.Status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                _resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(layer);
                 }
 
-                // Enable editing features
+                // Enable editing features.
                 _readyForEdits = EditState.Ready;
 
-                // Update the help label
+                // Update the help label.
                 myHelpLabel.Text = "2. Tap a point feature to select";
             }
 
-            // See if the job failed
-            if (status == JobStatus.Failed)
+            // See if the job failed.
+            if (job.Status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
+                // Show the message.
                 ShowStatusMessage(message);
             }
         }
 
-        private void HandleSyncStatusChange(SyncGeodatabaseJob job)
+        private void HandleSyncCompleted(SyncGeodatabaseJob job)
         {
             JobStatus status = job.Status;
 
-            // Tell the user about job completion
+            // Tell the user about job completion.
             if (status == JobStatus.Succeeded)
             {
                 ShowStatusMessage("Sync task completed");
             }
 
-            // See if the job failed
+            // See if the job failed.
             if (status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Sync geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     foreach (JobMessage m in job.Messages)
                     {
-                        // Get the text from the JobMessage and add it to the output string
+                        // Get the text from the JobMessage and add it to the output string.
                         message += "\n" + m.Message;
                     }
                 }
 
-                // Show the message
+                // Show the message.
                 ShowStatusMessage(message);
             }
         }
 
-        private void SyncGeodatabase()
+        private async Task SyncGeodatabase()
         {
-            // Return if not ready
+            // Return if not ready.
             if (_readyForEdits != EditState.Ready) { return; }
 
-            // Create parameters for the sync task
+            // Create parameters for the sync task.
             SyncGeodatabaseParameters parameters = new SyncGeodatabaseParameters()
             {
                 GeodatabaseSyncDirection = SyncDirection.Bidirectional,
                 RollbackOnFailure = false
             };
 
-            // Get the layer Id for each feature table in the geodatabase, then add to the sync job
+            // Get the layer Id for each feature table in the geodatabase, then add to the sync job.
             foreach (GeodatabaseFeatureTable table in _resultGdb.GeodatabaseFeatureTables)
             {
-                // Get the ID for the layer
+                // Get the ID for the layer.
                 long id = table.ServiceLayerId;
 
-                // Create the SyncLayerOption
+                // Create the SyncLayerOption.
                 SyncLayerOption option = new SyncLayerOption(id);
 
-                // Add the option
+                // Add the option.
                 parameters.LayerOptions.Add(option);
             }
 
-            // Create job
+            // Create job.
             SyncGeodatabaseJob job = _gdbSyncTask.SyncGeodatabase(parameters, _resultGdb);
 
-            // Subscribe to status updates
-            job.JobChanged += Job_JobChanged;
+            // Subscribe to progress updates.
+            job.ProgressChanged += (o, e) =>
+            {
+                // Update the progress bar.
+                UpdateProgressBar(job.Progress);
+            };
 
-            // Subscribe to progress updates
-            job.ProgressChanged += Job_ProgressChanged;
-
-            // Start the sync
+            // Start the sync.
             job.Start();
-        }
 
-        private void Job_ProgressChanged(object sender, EventArgs e)
-        {
-            // Get the job object
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
+            // Get the result.
+            await job.GetResultAsync();
 
-            // Update the progress bar
-            UpdateProgressBar(job.Progress);
-        }
-
-        // Get the path to the tile package used for the basemap
-        // (this is plumbing for the sample viewer)
-        private string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
+            // Do the rest of the work.
+            HandleSyncCompleted(job);
         }
 
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             UIAlertView alertView = new UIAlertView("alert", message, null, "OK", null);
             alertView.Show();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            // Disable the generate button
-            myGenerateButton.Enabled = false;
+            try
+            {
+                // Disable the generate button.
+                myGenerateButton.Enabled = false;
 
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            InvokeOnMainThread(() =>
-            {
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar(int progress)
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
+            //     the dispatcher needs to be used to interact with the UI.
+            // The dispatcher takes an Action, provided here as a lambda function.
             InvokeOnMainThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = progress / 100.0f;
             });
         }
 
-        private void SyncButton_Click(object sender, EventArgs e)
+        private async void SyncButton_Click(object sender, EventArgs e)
         {
-            SyncGeodatabase();
-        }
-
-        private void Job_JobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            SyncGeodatabaseJob job = sender as SyncGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            // The dispatcher takes an Action, provided here as a lambda function
-            InvokeOnMainThread(() =>
+            try
             {
-                // Update the progress bar as appropriate
-                if (job.Status == JobStatus.Succeeded || job.Status == JobStatus.Failed)
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(0);
-                }
-                else
-                {
-                    // Update the progress bar's value
-                    UpdateProgressBar(job.Progress);
-                }
-
-                // Do the remainder of the job status changed work
-                HandleSyncStatusChange(job);
-            });
+                await SyncGeodatabase();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
     }
 }

--- a/src/iOS/Xamarin.iOS/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,10 +7,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Drawing;
 using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
@@ -21,12 +17,17 @@ using Esri.ArcGISRuntime.Tasks.Offline;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using Foundation;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using UIKit;
 
 namespace ArcGISRuntime.Samples.GenerateGeodatabase
 {
     [Register("GenerateGeodatabase")]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Generate geodatabase",
         "Data",
@@ -34,25 +35,25 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
         "1. Pan and zoom to the area you would like to download features for, ensuring that all features are within the rectangle.\n2. Tap on the button. This will start the process of generating the offline geodatabase.\n3. Observe that the sample unregisters the geodatabase. This is best practice when changes won't be edited and synced back to the service.\n\nNote that the basemap will be automatically downloaded from an ArcGIS Online portal.")]
     public class GenerateGeodatabase : UIViewController
     {
-        // URI for a feature service that supports geodatabase generation
+        // URL for a feature service that supports geodatabase generation.
         private Uri _featureServiceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/WildfireSync/FeatureServer");
 
-        // Path to the geodatabase file on disk
+        // Path to the geodatabase file on disk.
         private string _gdbPath;
 
-        // Task to be used for generating the geodatabase
+        // Task to be used for generating the geodatabase.
         private GeodatabaseSyncTask _gdbSyncTask;
 
-        // Job used to generate the geodatabase
+        // Job used to generate the geodatabase.
         private GenerateGeodatabaseJob _generateGdbJob;
 
-        // MapView control
+        // MapView control.
         private MapView myMapView = new MapView();
 
-        // Progress Bar
+        // Progress Bar.
         private UIProgressView myProgressBar = new UIProgressView();
 
-        // Generate button
+        // Generate button.
         private UIButton myGenerateButton = new UIButton() { Enabled = false };
 
         public GenerateGeodatabase()
@@ -64,7 +65,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
         {
             base.ViewDidLoad();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             CreateLayout();
             Initialize();
         }
@@ -72,122 +73,131 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
         public override void ViewDidLayoutSubviews()
         {
             base.ViewDidLayoutSubviews();
-            // Place the MapView
+            // Place the MapView.
             myMapView.Frame = new CoreGraphics.CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 
-            // Place the Button
+            // Place the Button.
             myGenerateButton.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 40, View.Bounds.Width, 30);
 
-            // Place the progress bar
+            // Place the progress bar.
             myProgressBar.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 10, View.Bounds.Width, 10);
         }
 
         private void CreateLayout()
         {
-            // Place the MapView
+            // Place the MapView.
             myMapView.Frame = new CoreGraphics.CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 
-            // Place the Button
+            // Place the Button.
             myGenerateButton.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 40, View.Bounds.Width, 30);
             myGenerateButton.SetTitle("Generate", UIControlState.Normal);
             myGenerateButton.SetTitleColor(UIColor.Blue, UIControlState.Normal);
             myGenerateButton.BackgroundColor = UIColor.LightTextColor;
             myGenerateButton.TouchUpInside += GenerateButton_Clicked;
 
-            // Place the progress bar
+            // Place the progress bar.
             myProgressBar.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 10, View.Bounds.Width, 10);
 
-            // Add the views
+            // Add the views.
             View.AddSubviews(myMapView, myProgressBar, myGenerateButton);
         }
 
         private async void Initialize()
         {
-            // Create a tile cache and load it with the SanFrancisco streets tpk
-            TileCache _tileCache = new TileCache(GetTpkPath());
-
-            // Create the corresponding layer based on the tile cache
-            ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
-
-            // Create the basemap based on the tile cache
-            Basemap _sfBasemap = new Basemap(_tileLayer);
-
-            // Create the map with the tile-based basemap
-            Map myMap = new Map(_sfBasemap);
-
-            // Assign the map to the MapView
-            myMapView.Map = myMap;
-
-            // Create a new symbol for the extent graphic
-            SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
-
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(lineSymbol);
-
-            // Add graphics overlay to the map view
-            myMapView.GraphicsOverlays.Add(extentOverlay);
-
-            // Set up an event handler for when the viewpoint (extent) changes
-            myMapView.ViewpointChanged += MapViewExtentChanged;
-
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
-            _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
-
-            // Add all graphics from the service to the map
-            foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+            try
             {
-                // Create the ServiceFeatureTable for this particular layer
-                ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+                // Create a tile cache and load it with the SanFrancisco streets tpk.
+                TileCache _tileCache = new TileCache(DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk"));
 
-                // Wait for the table to load
-                await onlineTable.LoadAsync();
+                // Create the corresponding layer based on the tile cache.
+                ArcGISTiledLayer _tileLayer = new ArcGISTiledLayer(_tileCache);
 
-                // Add the layer to the map's operational layers if load succeeds
-                if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                // Create the basemap based on the tile cache.
+                Basemap _sfBasemap = new Basemap(_tileLayer);
+
+                // Create the map with the tile-based basemap.
+                Map myMap = new Map(_sfBasemap);
+
+                // Assign the map to the MapView.
+                myMapView.Map = myMap;
+
+                // Create a new symbol for the extent graphic.
+                SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+
+                // Create graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
                 {
-                    myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    Renderer = new SimpleRenderer(lineSymbol)
+                };
+
+                // Add graphics overlay to the map view.
+                myMapView.GraphicsOverlays.Add(extentOverlay);
+
+                // Set up an event handler for when the viewpoint (extent) changes.
+                myMapView.ViewpointChanged += MapViewExtentChanged;
+
+                // Create a task for generating a geodatabase (GeodatabaseSyncTask).
+                _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
+
+                // Add all graphics from the service to the map.
+                foreach (var layer in _gdbSyncTask.ServiceInfo.LayerInfos)
+                {
+                    // Create the ServiceFeatureTable for this particular layer.
+                    ServiceFeatureTable onlineTable = new ServiceFeatureTable(new Uri(_featureServiceUri + "/" + layer.Id));
+
+                    // Wait for the table to load.
+                    await onlineTable.LoadAsync();
+
+                    // Add the layer to the map's operational layers if load succeeds.
+                    if (onlineTable.LoadStatus == Esri.ArcGISRuntime.LoadStatus.Loaded)
+                    {
+                        myMap.OperationalLayers.Add(new FeatureLayer(onlineTable));
+                    }
                 }
+
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtent();
+
+                // Enable the generate button now that the sample is ready.
+                myGenerateButton.Enabled = true;
             }
-
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtent();
-
-            // Enable the generate button now that the sample is ready
-            myGenerateButton.Enabled = true;
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void UpdateMapExtent()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.70);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             var extentOverlay = myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -195,156 +205,134 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private async void StartGeodatabaseGeneration()
+        private async Task StartGeodatabaseGeneration()
         {
-            // Update geodatabase path
-            _gdbPath = GetGdbPath();
+            // Update geodatabase path.
+            _gdbPath = $"{Path.GetTempFileName()}.geodatabase";
 
-            // Create a task for generating a geodatabase (GeodatabaseSyncTask)
+            // Create a task for generating a geodatabase (GeodatabaseSyncTask).
             _gdbSyncTask = await GeodatabaseSyncTask.CreateAsync(_featureServiceUri);
 
-            // Get the current extent of the red preview box
+            // Get the current extent of the red preview box.
             Envelope extent = myMapView.GraphicsOverlays.First().Graphics.First().Geometry as Envelope;
 
-            // Get the default parameters for the generate geodatabase task
+            // Get the default parameters for the generate geodatabase task.
             GenerateGeodatabaseParameters generateParams = await _gdbSyncTask.CreateDefaultGenerateGeodatabaseParametersAsync(extent);
 
-            // Create a generate geodatabase job
+            // Create a generate geodatabase job.
             _generateGdbJob = _gdbSyncTask.GenerateGeodatabase(generateParams, _gdbPath);
 
-            // Handle the job changed event
-            _generateGdbJob.JobChanged += GenerateGdbJobChanged;
-
-            // Handle the progress changed event (to show progress bar)
+            // Handle the progress changed event (to show progress bar).
             _generateGdbJob.ProgressChanged += ((sender, e) =>
             {
                 UpdateProgressBar();
             });
 
-            // Start the job
+            // Start the job.
             _generateGdbJob.Start();
+
+            // Get the result.
+            Geodatabase resultGdb = await _generateGdbJob.GetResultAsync();
+
+            // Do the rest of the work.
+            await HandleGenerationStatusChange(_generateGdbJob, resultGdb);
         }
 
-        private async void HandleGenerationStatusChange(GenerateGeodatabaseJob job)
+        private async Task HandleGenerationStatusChange(GenerateGeodatabaseJob job, Geodatabase resultGdb)
         {
             JobStatus status = job.Status;
 
-            // If the job completed successfully, add the geodatabase data to the map
+            // If the job completed successfully, add the geodatabase data to the map.
             if (status == JobStatus.Succeeded)
             {
-                // Clear out the existing layers
+                // Clear out the existing layers.
                 myMapView.Map.OperationalLayers.Clear();
 
-                // Get the new geodatabase
-                Geodatabase resultGdb = await job.GetResultAsync();
-
-                // Loop through all feature tables in the geodatabase and add a new layer to the map
+                // Loop through all feature tables in the geodatabase and add a new layer to the map.
                 foreach (GeodatabaseFeatureTable table in resultGdb.GeodatabaseFeatureTables)
                 {
-                    // Create a new feature layer for the table
+                    // Create a new feature layer for the table.
                     FeatureLayer _layer = new FeatureLayer(table);
 
-                    // Add the new layer to the map
+                    // Add the new layer to the map.
                     myMapView.Map.OperationalLayers.Add(_layer);
                 }
-                // Best practice is to unregister the geodatabase
+                // Best practice is to unregister the geodatabase.
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
-                // Tell the user that the geodatabase was unregistered
+                // Tell the user that the geodatabase was unregistered.
                 ShowStatusMessage("Since no edits will be made, the local geodatabase has been unregistered per best practice.");
 
-                // Re-enable the generate button
+                // Re-enable the generate button.
                 myGenerateButton.Enabled = true;
             }
 
-            // See if the job failed
+            // See if the job failed.
             if (status == JobStatus.Failed)
             {
-                // Create a message to show the user
+                // Create a message to show the user.
                 string message = "Generate geodatabase job failed";
 
-                // Show an error message (if there is one)
+                // Show an error message (if there is one).
                 if (job.Error != null)
                 {
                     message += ": " + job.Error.Message;
                 }
                 else
                 {
-                    // If no error, show messages from the job
+                    // If no error, show messages from the job.
                     var m = from msg in job.Messages select msg.Message;
                     message += ": " + string.Join<string>("\n", m);
                 }
 
                 ShowStatusMessage(message);
 
-                // Re-enable the generate button
+                // Re-enable the generate button.
                 myGenerateButton.Enabled = true;
             }
         }
 
-        // Get the path to the tile package used for the basemap
-        private string GetTpkPath()
-        {
-            return DataManager.GetDataFolder("3f1bbf0ec70b409a975f5c91f363fe7d", "SanFrancisco.tpk");
-        }
-
-        private string GetGdbPath()
-        {
-            // Return a path
-            return $"{Path.GetTempFileName()}.geodatabase";
-        }
-
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             UIAlertView alertView = new UIAlertView("alert", message, null, "OK", null);
             alertView.Show();
         }
 
-        // Handler for the generate button clicked event
-        private void GenerateButton_Clicked(object sender, EventArgs e)
+        private async void GenerateButton_Clicked(object sender, EventArgs e)
         {
-            // Disable the generate button
-            myGenerateButton.Enabled = false;
+            try
+            {
+                // Disable the generate button.
+                myGenerateButton.Enabled = false;
 
-            // Call the cross-platform geodatabase generation method
-            StartGeodatabaseGeneration();
+                // Call the geodatabase generation method.
+                await StartGeodatabaseGeneration();
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
-        // Handler for the MapView Extent Changed event
         private void MapViewExtentChanged(object sender, EventArgs e)
         {
-            // Call the cross-platform map extent update method
+            // Call the map extent update method.
             UpdateMapExtent();
-        }
-
-        // Handler for the job changed event
-        private void GenerateGdbJobChanged(object sender, EventArgs e)
-        {
-            // Get the job object; will be passed to HandleGenerationStatusChange
-            GenerateGeodatabaseJob job = sender as GenerateGeodatabaseJob;
-
-            // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
-            InvokeOnMainThread(() =>
-            {
-                // Do the remainder of the job status changed work
-                HandleGenerationStatusChange(job);
-            });
         }
 
         private void UpdateProgressBar()
         {
             // Due to the nature of the threading implementation,
-            //     the dispatcher needs to be used to interact with the UI
+            //     the dispatcher needs to be used to interact with the UI.
             InvokeOnMainThread(() =>
             {
-                // Update the progress bar value
+                // Update the progress bar value.
                 myProgressBar.Progress = (float)(_generateGdbJob.Progress / 100.0);
             });
         }

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ExportTiles/ExportTiles.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ExportTiles/ExportTiles.cs
@@ -1,4 +1,4 @@
-// Copyright 2017 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -18,6 +18,7 @@ using System;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using UIKit;
 
 namespace ArcGISRuntime.Samples.ExportTiles
@@ -30,25 +31,25 @@ namespace ArcGISRuntime.Samples.ExportTiles
         "1. Pan and zoom until the area you want tiles for is within the red box.\n2. Click 'Export Tiles'.\n3. Pan and zoom to see the area covered by the downloaded tiles in the preview box.")]
     public class ExportTiles : UIViewController
     {
-        // Reference to the MapView used in the sample
+        // Reference to the MapView used in the sample.
         private MapView _myMapView;
 
-        // Reference to the preview MapView
+        // Reference to the preview MapView.
         private MapView _myPreviewMapView;
 
-        // Reference to the progress bar
+        // Reference to the progress bar.
         private UIActivityIndicatorView _myProgressBar;
 
-        // Reference to the 'export' button
+        // Reference to the 'export' button.
         private UIButton _myExportButton;
 
-        // URL to the service tiles will be exported from
+        // URL to the service tiles will be exported from.
         private Uri _serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer");
 
-        // Path to exported tiles on disk
+        // Path to exported tiles on disk.
         private string _tilePath;
 
-        // Flag to indicate if an exported cache is being previewed
+        // Flag to indicate if an exported cache is being previewed.
         private bool _previewOpen = false;
 
         public ExportTiles()
@@ -60,28 +61,28 @@ namespace ArcGISRuntime.Samples.ExportTiles
         {
             base.ViewDidLoad();
 
-            // Create the layout
+            // Create the layout.
             CreateLayout();
 
-            // Initialize the app
+            // Initialize the app.
             Initialize();
         }
 
         public override void ViewDidLayoutSubviews()
         {
-            // Hold a margin value
+            // Hold a margin value.
             int margin = 30;
 
-            // Set up the visual frame for the MapView
+            // Set up the visual frame for the MapView.
             _myMapView.Frame = new CoreGraphics.CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 
-            // Set up the visual frame for the preview MapView
+            // Set up the visual frame for the preview MapView.
             _myPreviewMapView.Frame = new CoreGraphics.CGRect(margin, margin * 2, View.Bounds.Width - 2 * margin, View.Bounds.Height - 4 * margin);
 
-            // Set up the visual frame for the progress bar
+            // Set up the visual frame for the progress bar.
             _myProgressBar.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 40, View.Bounds.Width, 20);
 
-            // Set up the visual frame for the button
+            // Set up the visual frame for the button.
             _myExportButton.Frame = new CoreGraphics.CGRect(0, View.Bounds.Height - 20, View.Bounds.Width, 20);
 
             base.ViewDidLayoutSubviews();
@@ -89,76 +90,86 @@ namespace ArcGISRuntime.Samples.ExportTiles
 
         private async void Initialize()
         {
-            // Create the tile layer
-            ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
+            try
+            {
+                // Create the tile layer.
+                ArcGISTiledLayer myLayer = new ArcGISTiledLayer(_serviceUri);
 
-            // Load the layer
-            await myLayer.LoadAsync();
+                // Load the layer.
+                await myLayer.LoadAsync();
 
-            // Create the basemap with the layer
-            Map myMap = new Map(new Basemap(myLayer));
+                // Create the basemap with the layer.
+                Map myMap = new Map(new Basemap(myLayer));
 
-            // Set the min and max scale - export task fails if the scale is too big or small
-            myMap.MaxScale = 5000000;
-            myMap.MinScale = 10000000;
+                // Set the min and max scale - export task fails if the scale is too big or small.
+                myMap.MaxScale = 5000000;
+                myMap.MinScale = 10000000;
 
-            // Assign the map to the mapview
-            _myMapView.Map = myMap;
+                // Assign the map to the mapview.
+                _myMapView.Map = myMap;
 
-            // Create a new symbol for the extent graphic
-            //     This is the red box that visualizes the extent for which tiles will be exported
-            SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
+                // Create a new symbol for the extent graphic.
+                //     This is the red box that visualizes the extent for which tiles will be exported.
+                SimpleLineSymbol myExtentSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Red, 2);
 
-            // Create graphics overlay for the extent graphic and apply a renderer
-            GraphicsOverlay extentOverlay = new GraphicsOverlay();
-            extentOverlay.Renderer = new SimpleRenderer(myExtentSymbol);
+                // Create a graphics overlay for the extent graphic and apply a renderer.
+                GraphicsOverlay extentOverlay = new GraphicsOverlay
+                {
+                    Renderer = new SimpleRenderer(myExtentSymbol)
+                };
 
-            // Add graphics overlay to the map view
-            _myMapView.GraphicsOverlays.Add(extentOverlay);
+                // Add the graphics overlay to the map view.
+                _myMapView.GraphicsOverlays.Add(extentOverlay);
 
-            // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position
-            _myMapView.ViewpointChanged += MyMapView_ViewpointChanged;
+                // Subscribe to changes in the mapview's viewpoint so the preview box can be kept in position.
+                _myMapView.ViewpointChanged += MyMapView_ViewpointChanged;
 
-            // Update the graphic - needed in case the user decides not to interact before pressing the button
-            UpdateMapExtentGraphic();
+                // Update the graphic - needed in case the user decides not to interact before pressing the button.
+                UpdateMapExtentGraphic();
 
-            // Enable the export button now that sample is ready
-            _myExportButton.Enabled = true;
+                // Enable the export button now that sample is ready.
+                _myExportButton.Enabled = true;
+            }
+            catch (Exception ex)
+            {
+                ShowStatusMessage(ex.ToString());
+            }
         }
 
         private void CreateLayout()
         {
-            // Create the first mapview
+            // Create the first mapview.
             _myMapView = new MapView();
 
-            // Create the preview mapview
+            // Create the preview mapview.
             _myPreviewMapView = new MapView()
             {
-                Hidden = true // hide it by default
+                Hidden = true // hide it by default.
             };
 
-            // Set a border on the preview window
+            // Set a border on the preview window.
             _myPreviewMapView.Layer.BorderColor = new CoreGraphics.CGColor(.8f, .2f, .6f);
             _myPreviewMapView.Layer.BorderWidth = 2.0f;
 
-            // Create the progress bar
-            _myProgressBar = new UIActivityIndicatorView();
+            // Create the progress bar.
+            _myProgressBar = new UIActivityIndicatorView
+            {
+                // Set the progress bar to hide when not animating.
+                HidesWhenStopped = true
+            };
 
-            // Set the progress bar to hide when not animating
-            _myProgressBar.HidesWhenStopped = true;
-
-            // Create the export button - disabled until sample is ready
+            // Create the export button - disabled until sample is ready.
             _myExportButton = new UIButton() { Enabled = false };
             _myExportButton.SetTitle("Export", UIControlState.Normal);
 
-            // Set background color on the button and progressbar
+            // Set background color on the button and progressbar.
             _myExportButton.BackgroundColor = UIColor.LightGray;
             _myProgressBar.BackgroundColor = UIColor.LightGray;
 
-            // Get notified of button taps
+            // Get notified of button taps.
             _myExportButton.TouchUpInside += MyExportButton_Click;
 
-            // Add the views
+            // Add the views.
             View.AddSubviews(_myMapView, _myProgressBar, _myExportButton, _myPreviewMapView);
         }
 
@@ -170,39 +181,39 @@ namespace ArcGISRuntime.Samples.ExportTiles
         /// <summary>
         /// Function used to keep the overlaid preview area marker in position.
         /// This is called by MyMapView_ViewpointChanged every time the user pans/zooms
-        ///     and updates the red box graphic to outline 70% of the current view
+        ///     and updates the red box graphic to outline 70% of the current view.
         /// </summary>
         private void UpdateMapExtentGraphic()
         {
-            // Return if mapview is null
+            // Return if mapview is null.
             if (_myMapView == null) { return; }
 
-            // Get the new viewpoint
+            // Get the new viewpoint.
             Viewpoint myViewPoint = _myMapView.GetCurrentViewpoint(ViewpointType.BoundingGeometry);
 
-            // Return if viewpoint is null
+            // Return if viewpoint is null.
             if (myViewPoint == null) { return; }
 
-            // Get the updated extent for the new viewpoint
+            // Get the updated extent for the new viewpoint.
             Envelope extent = myViewPoint.TargetGeometry as Envelope;
 
-            // Return if extent is null
+            // Return if extent is null.
             if (extent == null) { return; }
 
-            // Create an envelope that is a bit smaller than the extent
+            // Create an envelope that is a bit smaller than the extent.
             EnvelopeBuilder envelopeBldr = new EnvelopeBuilder(extent);
             envelopeBldr.Expand(0.70);
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = _myMapView.GraphicsOverlays.FirstOrDefault();
 
-            // Return if the extent overlay is null
+            // Return if the extent overlay is null.
             if (extentOverlay == null) { return; }
 
-            // Get the extent graphic
+            // Get the extent graphic.
             Graphic extentGraphic = extentOverlay.Graphics.FirstOrDefault();
 
-            // Create the extent graphic and add it to the overlay if it doesn't exist
+            // Create the extent graphic and add it to the overlay if it doesn't exist.
             if (extentGraphic == null)
             {
                 extentGraphic = new Graphic(envelopeBldr.ToGeometry());
@@ -210,191 +221,170 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             else
             {
-                // Otherwise, simply update the graphic's geometry
+                // Otherwise, update the graphic's geometry.
                 extentGraphic.Geometry = envelopeBldr.ToGeometry();
             }
         }
 
-        private string GetTilePath()
+        private async Task StartExport()
         {
-            // Return a path
-            return $"{Path.GetTempFileName()}.tpk";
-        }
-
-        /// <summary>
-        /// Starts the export job and registers callbacks to be notified of changes to job status
-        /// </summary>
-        private async void StartExport()
-        {
-            // Get the parameters for the job
+            // Get the parameters for the job.
             ExportTileCacheParameters parameters = GetExportParameters();
 
-            // Create the task
+            // Create the task.
             ExportTileCacheTask exportTask = await ExportTileCacheTask.CreateAsync(_serviceUri);
 
-            // Update tile cache path
-            _tilePath = GetTilePath();
+            // Update tile cache path.
+            _tilePath = $"{Path.GetTempFileName()}.tpk";
 
-            // Create the export job
+            // Create the export job.
             ExportTileCacheJob job = exportTask.ExportTileCache(parameters, _tilePath);
 
-            // Subscribe to notifications for status updates
-            job.JobChanged += Job_JobChanged;
-
-            // Start the export job
+            // Start the export job.
             job.Start();
+
+            // Get the result.
+            TileCache resultTileCache = await job.GetResultAsync();
+
+            // Do the rest of the work.
+            HandleExportCompletion(job, resultTileCache);
         }
 
-        /// <summary>
-        /// Constructs and returns parameters for the Export Tile Cache Job
-        /// </summary>
-        /// <returns></returns>
         private ExportTileCacheParameters GetExportParameters()
         {
-            // Create a new parameters instance
+            // Create a new parameters instance.
             ExportTileCacheParameters parameters = new ExportTileCacheParameters();
 
-            // Get the (only) graphics overlay in the map view
+            // Get the (only) graphics overlay in the map view.
             GraphicsOverlay extentOverlay = _myMapView.GraphicsOverlays.First();
 
-            // Get the area selection graphic's extent
+            // Get the area selection graphic's extent.
             Graphic extentGraphic = extentOverlay.Graphics.First();
 
-            // Set the area for the export
+            // Set the area for the export.
             parameters.AreaOfInterest = extentGraphic.Geometry;
 
-            // Get the highest possible export quality
+            // Get the highest possible export quality.
             parameters.CompressionQuality = 100;
 
-            // Add level IDs 1-9
-            //     Note: Failing to add at least one Level ID will result in job failure
+            // Add level IDs 1-9.
+            //     Note: Failing to add at least one Level ID will result in job failure.
             for (int x = 1; x < 10; x++)
             {
                 parameters.LevelIds.Add(x);
             }
 
-            // Return the parameters
+            // Return the parameters.
             return parameters;
         }
 
-        /// <summary>
-        /// Called by the ExportTileCacheJob on any status changes
-        /// </summary>
-        private void Job_JobChanged(object sender, EventArgs e)
+        private void HandleExportCompletion(ExportTileCacheJob job, TileCache cache)
         {
-            // Get reference to the job
-            ExportTileCacheJob job = sender as ExportTileCacheJob;
-
-            // Update the view if the job is complete
+            // Hide the progress bar.
+            _myProgressBar.StopAnimating();
+            // Update the view if the job is complete.
             if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Succeeded)
             {
                 // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
-                InvokeOnMainThread(() =>
+                //     this method is called from a thread other than the UI thread.
+                InvokeOnMainThread(async () =>
                 {
-                    // Show the exported tiles on the preview map
-                    UpdatePreviewMap();
+                    // Show the exported tiles on the preview map.
+                    try
+                    {
+                        await UpdatePreviewMap(cache);
 
-                    // Show the preview window
-                    _myPreviewMapView.Hidden = false;
+                        // Show the preview window.
+                        _myPreviewMapView.Hidden = false;
 
-                    // Hide the progress bar
-                    _myProgressBar.StopAnimating();
+                        // Change the export button text.
+                        _myExportButton.SetTitle("Close Preview", UIControlState.Normal);
 
-                    // Change the export button text
-                    _myExportButton.SetTitle("Close Preview", UIControlState.Normal);
+                        // Re-enable the button.
+                        _myExportButton.Enabled = true;
 
-                    // Re-enable the button
-                    _myExportButton.Enabled = true;
-
-                    // Set the preview open flag
-                    _previewOpen = true;
+                        // Set the preview open flag.
+                        _previewOpen = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        ShowStatusMessage(ex.ToString());
+                    }
                 });
             }
             else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
-                // Notify the user
+                // Notify the user.
                 ShowStatusMessage("Job failed");
 
                 // Dispatcher is necessary due to the threading implementation;
-                //     this method is called from a thread other than the UI thread
+                //     this method is called from a thread other than the UI thread.
                 InvokeOnMainThread(() =>
                 {
-                    // Hide the progress bar
-                    _myProgressBar.StopAnimating();
-
-                    // Change the export button text
+                    // Change the export button text.
                     _myExportButton.SetTitle("Export Tiles", UIControlState.Normal);
 
-                    // Re-enable the export button
+                    // Re-enable the export button.
                     _myExportButton.Enabled = true;
 
-                    // Set the preview open flag
+                    // Set the preview open flag.
                     _previewOpen = false;
                 });
             }
         }
 
-        /// <summary>
-        /// Loads the tile cache from disk and displays it in the preview map
-        /// </summary>
-        private async void UpdatePreviewMap()
+        private async Task UpdatePreviewMap(TileCache cache)
         {
-            // Load the saved tile cache
-            TileCache cache = new TileCache(_tilePath);
-
-            // Load the cache
+            // Load the cache.
             await cache.LoadAsync();
 
-            // Create a tile layer with the cache
+            // Create a tile layer with the cache.
             ArcGISTiledLayer myLayer = new ArcGISTiledLayer(cache);
 
-            // Create a new map with the layer as basemap
-            Map previewMap = new Map(new Basemap(myLayer));
-
-            // Apply the map to the preview mapview
-            _myPreviewMapView.Map = previewMap;
+            // Show the exported tiles in new map.
+            _myPreviewMapView.Map = new Map(new Basemap(myLayer));
         }
 
-        /// <summary>
-        /// Begins the export process
-        /// </summary>
-        private void MyExportButton_Click(object sender, EventArgs e)
+        private async void MyExportButton_Click(object sender, EventArgs e)
         {
-            // If preview isn't open, start an export
-            if (!_previewOpen)
+            // If preview isn't open, start an export.
+            try
             {
-                // Disable the export button
-                _myExportButton.Enabled = false;
+                if (!_previewOpen)
+                {
+                    // Disable the export button.
+                    _myExportButton.Enabled = false;
 
-                // Show the progress bar
-                _myProgressBar.StartAnimating();
+                    // Show the progress bar.
+                    _myProgressBar.StartAnimating();
 
-                // Hide the preview window if not already hidden
-                _myPreviewMapView.Hidden = true;
+                    // Hide the preview window if not already hidden.
+                    _myPreviewMapView.Hidden = true;
 
-                // Start the export
-                StartExport();
+                    // Start the export.
+                    await StartExport();
+                }
+                else // Otherwise, close the preview.
+                {
+                    // Hide the preview.
+                    _myPreviewMapView.Hidden = true;
+
+                    // Change the button text.
+                    _myExportButton.SetTitle("Export Tiles", UIControlState.Normal);
+
+                    // Clear the preview open flag.
+                    _previewOpen = false;
+                }
             }
-            else // Otherwise, close the preview
+            catch (Exception ex)
             {
-                // Hide the preview
-                _myPreviewMapView.Hidden = true;
-
-                // Change the button text
-                _myExportButton.SetTitle("Export Tiles", UIControlState.Normal);
-
-                // Clear the preview open flag
-                _previewOpen = false;
+                ShowStatusMessage(ex.ToString());
             }
         }
 
-        /// <summary>
-        /// Abstraction of platform-specific functionality to maximize re-use of common code
-        /// </summary>
         private void ShowStatusMessage(string message)
         {
-            // Display the message to the user
+            // Display the message to the user.
             UIAlertView alertView = new UIAlertView("alert", message, null, "OK", null);
             alertView.Show();
         }


### PR DESCRIPTION
Job status change events can be fire multiple times on completion, so apps shouldn't be written in a way that relies on the job status events to detect completion. Instead, `job.GetResultAsync` should be used.

While updating these samples I found several other quality issues that needed to be addressed (in particular, excessive usage of async void).

@ThadT Can you please review this when you get a chance? Thanks!