### PR TITLE
Change to feature layer extrusion sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -74,8 +74,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
                 // Get the scene properties from the simple renderer
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties to be base height
-                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.BaseHeight;
+                // Set the extrusion mode for the scene properties
+                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
                 // Set the initial extrusion expression
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
@@ -125,7 +125,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (_button_ToggleExtrusionData.Text == "Population Density")
             {
-                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000";
+                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 _button_ToggleExtrusionData.Text = "Total Population";
             }
             else if (_button_ToggleExtrusionData.Text == "Total Population")

--- a/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -125,6 +125,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (_button_ToggleExtrusionData.Text == "Population Density")
             {
+                // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
+                // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 _button_ToggleExtrusionData.Text = "Total Population";
             }

--- a/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -62,8 +62,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
                 // Get the scene properties from the simple renderer
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties to be base height
-                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.BaseHeight;
+                // Set the extrusion mode for the scene properties
+                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
                 // Set the initial extrusion expression
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
@@ -111,7 +111,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (Button_ToggleExtrusionData.Text == "Population Density")
             {
-                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000";
+                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 Button_ToggleExtrusionData.Text = "Total Population";
             }
             else if (Button_ToggleExtrusionData.Text == "Total Population")

--- a/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -111,6 +111,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (Button_ToggleExtrusionData.Text == "Population Density")
             {
+                // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
+                // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 Button_ToggleExtrusionData.Text = "Total Population";
             }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -61,8 +61,8 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerExtrusion
                 // Get the scene properties from the simple renderer
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties to be base height
-                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.BaseHeight;
+                // Set the extrusion mode for the scene properties
+                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
                 // Set the initial extrusion expression
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
@@ -111,7 +111,7 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (Button_ToggleExtrusionData.Content.ToString() == "Population Density")
             {
-                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000";
+                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 Button_ToggleExtrusionData.Content = "Total Population";
             }
             else if (Button_ToggleExtrusionData.Content.ToString() == "Total Population")

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -111,6 +111,8 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (Button_ToggleExtrusionData.Content.ToString() == "Population Density")
             {
+                // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
+                // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 Button_ToggleExtrusionData.Content = "Total Population";
             }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -59,8 +59,8 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
                 // Get the scene properties from the simple renderer
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties to be base height
-                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.BaseHeight;
+                // Set the extrusion mode for the scene properties
+                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
                 // Set the initial extrusion expression
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
@@ -107,7 +107,7 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (ToggleDataButton.Content.ToString() == "Population Density")
             {
-                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000";
+                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 ToggleDataButton.Content = "Total Population";
             }
             else if(ToggleDataButton.Content.ToString() == "Total Population")

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -107,6 +107,8 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (ToggleDataButton.Content.ToString() == "Population Density")
             {
+                // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
+                // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 ToggleDataButton.Content = "Total Population";
             }

--- a/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -80,8 +80,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
                 // Get the scene properties from the simple renderer
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties to be base height
-                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.BaseHeight;
+                // Set the extrusion mode for the scene properties
+                myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
                 // Set the initial extrusion expression
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
@@ -130,7 +130,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (_button_ToggleExtrusionData.Title(UIControlState.Normal) == "Population Density")
             {
-                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000";
+                myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 _button_ToggleExtrusionData.SetTitle("Total Population", UIControlState.Normal);
             }
             else if (_button_ToggleExtrusionData.Title(UIControlState.Normal) == "Total Population")

--- a/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -130,6 +130,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
             if (_button_ToggleExtrusionData.Title(UIControlState.Normal) == "Population Density")
             {
+                // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
+                // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 _button_ToggleExtrusionData.SetTitle("Total Population", UIControlState.Normal);
             }


### PR DESCRIPTION
Two changes:

* The sample was using `ExtrusionMode.BaseHeight`; because there is no elevation to consider, `ExtrusionMode.AbsoluteHeight` is the better approach.
* Because of how polygons are extruded, for some polygons covering a wide area, portions of the polygon can be rendered underneath the globe surface. This PR adds a constant offset to the extrusion expression to prevent this from happening.

@ThadT Can you please take a look?