### PR TITLE
Update map used in Open Map URL sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
@@ -40,7 +40,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Population pressure",
+            "Population Pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to hold urls to publicly available web maps
         private string[] itemURLs = new string[]
         {
-            "http://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "http://www.arcgis.com/home/item.html?id=392451c381ad4109bf04f7bd442bc038",
             "http://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
             "http://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
@@ -40,7 +40,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Housing with Mortgages",
+            "Population pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/Forms/Shared/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Population pressure",
+            "Population Pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/Forms/Shared/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -24,7 +24,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to hold urls to publicly available web maps
         private string[] itemURLs = new string[]
         {
-            "https://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "https://www.arcgis.com/home/item.html?id=392451c381ad4109bf04f7bd442bc038",
             "https://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
             "https://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Housing with Mortgages",
+            "Population pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.UWP.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] _titles = new string[]
         {
-            "Population pressure",
+            "Population Pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -24,7 +24,7 @@ namespace ArcGISRuntime.UWP.Samples.OpenMapURL
         // String array to hold urls to publicly available web maps
         private string[] _itemURLs = new string[]
         {
-            "http://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "http://www.arcgis.com/home/item.html?id=392451c381ad4109bf04f7bd442bc038",
             "http://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
             "http://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.UWP.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] _titles = new string[]
         {
-            "Housing with Mortgages",
+            "Population pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WPF.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] _titles = new string[]
         {
-            "Population pressure",
+            "Population Pressure",
             "USA Tapestry Segmentation",
             "Geology of the United States"
         };

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/OpenMapURL/OpenMapURL.xaml.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntime.WPF.Samples.OpenMapURL
         // String array to hold urls to publicly available web maps
         private string[] _itemURLs = new string[]
         {
-            "http://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "http://www.arcgis.com/home/item.html?id=392451c381ad4109bf04f7bd442bc038",
             "http://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
             "http://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WPF.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] _titles = new string[]
         {
-            "Housing with Mortgages",
+            "Population pressure",
             "USA Tapestry Segmentation",
             "Geology of the United States"
         };

--- a/src/iOS/Xamarin.iOS/Samples/Map/OpenMapURL/OpenMapURL.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/OpenMapURL/OpenMapURL.cs
@@ -41,7 +41,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Population pressure",
+            "Population Pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };

--- a/src/iOS/Xamarin.iOS/Samples/Map/OpenMapURL/OpenMapURL.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/OpenMapURL/OpenMapURL.cs
@@ -33,7 +33,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to hold urls to publicly available web maps
         private string[] itemURLs = new string[] 
         {
-            "https://www.arcgis.com/home/item.html?id=2d6fa24b357d427f9c737774e7b0f977",
+            "https://www.arcgis.com/home/item.html?id=392451c381ad4109bf04f7bd442bc038",
             "https://www.arcgis.com/home/item.html?id=01f052c8995e4b9e889d73c3e210ebe3",
             "https://www.arcgis.com/home/item.html?id=92ad152b9da94dee89b9e387dfe21acd"
         };
@@ -41,7 +41,7 @@ namespace ArcGISRuntime.Samples.OpenMapURL
         // String array to store titles for the webmaps specified above. These titles are in the same order as the urls above
         private string[] titles = new string[]
         {
-            "Housing with Mortgages",
+            "Population pressure",
             "USA Tapestry Segmentation",
             "Geology of United States"
         };


### PR DESCRIPTION
The previous map had a configuration problem that affected the sample on some platforms. This change replaces 'Housing with Mortgages' with 'Population pressure'.