### PR TITLE
Revert Esri.ArcGISRuntime.LocalServices NuGet package to v100.2.1.

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer_100.3.AGSDeployment
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISLocalServer_100.3.AGSDeployment
@@ -1,0 +1,197 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--ArcGIS Local Server Deployment Configuration-->
+<Packages>
+  <!--This local server has support for ArcGIS Pro mpkx and gpkx packages. It is 64 bit only-->
+  <Package id="Pro" name="ArcGIS Pro Compatible Server" enabled="false">
+    <ChildPackages>
+      <!--Including Microsoft C and C++ libraries in the runtime deployment allows for XCopy style deployments.
+Only include these if your setup is not installing the Microsoft redistribution package.-->
+      <Package id="ProCRuntime" name="Microsoft C and C++ Runtime Libraries" enabled="false" />
+      <!--Provides the ability to perform geoprocessing tasks via geoprocessing packages.-->
+      <!--Geoprocessing packages must be created with ArcGIS Runtime support enabled.-->
+      <Package id="ProGeoProcessing" name="Geoprocessing" enabled="false">
+        <ChildPackages>
+          <!--Adds 3D Analyst geoprocessing tools.-->
+          <Package id="Pro3DAnalyst" name="3D Analyst" enabled="false" />
+          <!--Provides the ability to use ArcGIS Locators-->
+          <Package id="ProGeoCoding" name="Geocoding" enabled="false" />
+          <!--Adds data consolidation, map packaging and create runtime content tools.-->
+          <Package id="ProMapPackaging" name="Map Packaging" enabled="false" />
+          <!--Adds the ability to produce results as Map Services.-->
+          <Package id="ProMapServerResults" name="Map Server Results" enabled="false" />
+          <!--Adds Network Analyst geoprocessing tools.-->
+          <Package id="ProNetworkAnalyst" name="Network Analyst" enabled="false" />
+          <!--Adds Spatial Analyst geoprocessing tools.-->
+          <Package id="ProSpatialAnalyst" name="Spatial Analyst" enabled="false" />
+        </ChildPackages>
+      </Package>
+      <!--Provides the ability to use Python scripts.-->
+      <Package id="ProPythonScripting" name="Python Scripting" enabled="false" />
+      <!--Provides additional vector and raster data format support.-->
+      <Package id="ProAdditionalDataFormats" name="Additional Data Formats" enabled="false">
+        <ChildPackages>
+          <!--Provides additional raster file data format support.-->
+          <Package id="ProRaster" name="Raster" enabled="false">
+            <ChildPackages>
+              <!--Provides support for ECW format Raster.-->
+              <Package id="ProECWRasters" name="ECW Rasters" enabled="false" />
+              <!--Provides support for Raster Mosaic Layers.-->
+              <Package id="ProMosaicRasters" name="Mosaic Rasters" enabled="false" />
+            </ChildPackages>
+          </Package>
+          <!--Provides additional vector file data format support.-->
+          <Package id="ProVector" name="Vector" enabled="false" />
+          <!--Adds support for direct connect to DBMS system that Esri supports. This option must be selected in conjunction with at least one of the following DBMS(s): DB2, Informix, Oracle, PostgreSQL, SQL Server, Netezza, HANA, Teradata or Alitbase.-->
+          <!--SDE direct connect deployed. Specific database drivers also required.-->
+          <Package id="ProSDE" name="SDE" enabled="false">
+            <ChildPackages>
+              <!--Adds support for direct connect to geodatabases stored in Alitbase.-->
+              <!--Alitbase Drivers must be present on end users machine.-->
+              <Package id="ProAlitbase" name="Alitbase" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in Dameng.-->
+              <!--Dameng Drivers must be present on end users machine.-->
+              <Package id="ProDameng" name="Dameng" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in DB2.-->
+              <!--DB2 Drivers must be present on end users machine.-->
+              <Package id="ProDB2" name="DB2" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in Netezza.-->
+              <!--Netezza Drivers must be present on end users machine.-->
+              <Package id="ProNetezza" name="Netezza" enabled="false" />
+              <!-- Adds support for direct connect to geodatabases stored in Oracle.-->
+              <!--Oracle Drivers must be present on end users machine.-->
+              <Package id="ProOracle" name="Oracle" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in PostgreSQL.-->
+              <!--PostgreSQL Drivers must be present on end users machine.-->
+              <Package id="ProPostgreSQL" name="PostgreSQL" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SAP HANA.-->
+              <!--SAP HANA SQL Server Drivers must be present on end users machine.-->
+              <Package id="ProSAPHANA" name="SAP HANA" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SQL Server.-->
+              <!--MS SQL Server Drivers must be present on end users machine.-->
+              <Package id="ProSQLServer" name="SQL Server" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SQL Server.-->
+              <!--MS SQL Server Drivers must be present on end users machine.-->
+              <Package id="ProSQLite" name="SQLite" enabled="false">
+                <ChildPackages>
+                  <!--Adds support for SpatiaLite geometry type-->
+                  <Package id="ProSpatialLite" name="SpatiaLite" enabled="false" />
+                </ChildPackages>
+              </Package>
+              <!--Adds support for direct connect to geodatabases stored in Teradata.-->
+              <!--Teradata Drivers must be present on end users machine.-->
+              <Package id="ProTeradata" name="Teradata" enabled="false" />
+            </ChildPackages>
+          </Package>
+        </ChildPackages>
+      </Package>
+      <!--Adds more projections and geotransformations.-->
+      <Package id="ProAdditionalProjectionEngineTransformations" name="Additional Projection Engine Transformations" enabled="false" />
+      <!--Enables debugging options within the runtime.-->
+      <!--Debugging options should only be used for testing purposes, and not deployed in final solutions.-->
+      <Package id="ProDebug" name="Debug" enabled="false">
+        <ChildPackages>
+          <!--Adds support for runtime logging.-->
+          <Package id="ProLogging" name="Logging" enabled="false" />
+        </ChildPackages>
+      </Package>
+    </ChildPackages>
+  </Package>
+  <!--This local server has support for ArcMap mpk and gpk packages.-->
+  <Package id="ArcMap" name="ArcMap Compatible Server" enabled="false">
+    <ChildPackages>
+      <!--Including Microsoft C and C++ libraries in the runtime deployment allows for XCopy style deployments.
+Only include these if your setup is not installing the Microsoft redistribution package.-->
+      <Package id="ArcMapCRuntime" name="Microsoft C and C++ Runtime Libraries" enabled="false" />
+      <!--Provides the ability to perform geoprocessing tasks via geoprocessing packages.-->
+      <!--Geoprocessing packages must be created with ArcGIS Runtime support enabled.-->
+      <Package id="ArcMapGeoprocessing" name="Geoprocessing" enabled="false">
+        <ChildPackages>
+          <!--Adds 3D Analyst geoprocessing tools.-->
+          <Package id="ArcMap3DAnalyst" name="3D Analyst" enabled="false" />
+          <!--Provides the ability to use ArcGIS Locators-->
+          <Package id="ArcMapGeocoding" name="Geocoding" enabled="false" />
+          <!--Adds data consolidation, map packaging and create runtime content tools.-->
+          <Package id="ArcMapMapPackaging" name="Map Packaging" enabled="false" />
+          <!--Adds the ability to produce results as Map Services.-->
+          <Package id="ArcMapMapServerResults" name="Map Server Results" enabled="false" />
+          <!--Adds Network Analyst geoprocessing tools.-->
+          <Package id="ArcMapNetworkAnalyst" name="Network Analyst" enabled="false" />
+          <!--Adds Spatial Analyst geoprocessing tools.-->
+          <Package id="ArcMapSpatialAnalyst" name="Spatial Analyst" enabled="false" />
+        </ChildPackages>
+      </Package>
+      <!--Provides the ability to use Python scripts.-->
+      <Package id="ArcMapPythonScripting" name="Python Scripting" enabled="false" />
+      <!--Provides additional vector and raster data format support.-->
+      <Package id="ArcMapAdditionalDataFormats" name="Additional Data Formats" enabled="false">
+        <ChildPackages>
+          <!--Provides additional raster file data format support.-->
+          <Package id="ArcMapRaster" name="Raster" enabled="false">
+            <ChildPackages>
+              <!--Provides support for ECW format Raster.-->
+              <Package id="ArcMapECWRasters" name="ECW Rasters" enabled="false" />
+              <!--Provides support for Raster Mosaic Layers.-->
+              <Package id="ArcMapMosaicRasters" name="Mosaic Rasters" enabled="false" />
+            </ChildPackages>
+          </Package>
+          <!--Provides additional vector file data format support.-->
+          <Package id="ArcMapVector" name="Vector" enabled="false" />
+          <!--Adds support for direct connect to DBMS system that Esri supports. This option must be selected in conjunction with at least one of the following DBMS(s): DB2, Informix, Oracle, PostgreSQL, SQL Server, Netezza, HANA, Teradata or Alitbase.-->
+          <!--SDE direct connect deployed. Specific database drivers also required.-->
+          <Package id="ArcMapSDE" name="SDE" enabled="false">
+            <ChildPackages>
+              <!--Adds support for direct connect to geodatabases stored in Alitbase.-->
+              <!--Alitbase Drivers must be present on end users machine.-->
+              <Package id="ArcMapAlitbase" name="Alitbase" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in Dameng.-->
+              <!--Dameng Drivers must be present on end users machine.-->
+              <Package id="ArcMapDameng" name="Dameng" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in DB2.-->
+              <!--DB2 Drivers must be present on end users machine.-->
+              <Package id="ArcMapDB2" name="DB2" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in Informix.-->
+              <!--Informix Drivers must be present on end users machine.-->
+              <Package id="ArcMapInformix" name="Informix" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in Netezza.-->
+              <!--Netezza Drivers must be present on end users machine.-->
+              <Package id="ArcMapNetezza" name="Netezza" enabled="false" />
+              <!-- Adds support for direct connect to geodatabases stored in Oracle.-->
+              <!--Oracle Drivers must be present on end users machine.-->
+              <Package id="ArcMapOracle" name="Oracle" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in PostgreSQL.-->
+              <!--PostgreSQL Drivers must be present on end users machine.-->
+              <Package id="ArcMapPostgreSQL" name="PostgreSQL" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SAP HANA.-->
+              <!--SAP HANA SQL Server Drivers must be present on end users machine.-->
+              <Package id="ArcMapSAPHANA" name="SAP HANA" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SQL Server.-->
+              <!--MS SQL Server Drivers must be present on end users machine.-->
+              <Package id="ArcMapSQLServer" name="SQL Server" enabled="false" />
+              <!--Adds support for direct connect to geodatabases stored in SQL Server.-->
+              <!--MS SQL Server Drivers must be present on end users machine.-->
+              <Package id="ArcMapSQLite" name="SQLite" enabled="false">
+                <ChildPackages>
+                  <!--Adds support for SpatiaLite geometry type-->
+                  <Package id="ArcMapSpatiaLite" name="SpatiaLite" enabled="false" />
+                </ChildPackages>
+              </Package>
+              <!--Adds support for direct connect to geodatabases stored in Teradata.-->
+              <!--Teradata Drivers must be present on end users machine.-->
+              <Package id="ArcMapTeradata" name="Teradata" enabled="false" />
+            </ChildPackages>
+          </Package>
+        </ChildPackages>
+      </Package>
+      <!--Adds more projections and geotransformations.-->
+      <Package id="ArcMapAdditionalProjectionEngineTransformations" name="Additional Projection Engine Transformations" enabled="false" />
+      <!--Enables debugging options within the runtime.-->
+      <!--Debugging options should only be used for testing purposes, and not deployed in final solutions.-->
+      <Package id="ArcMapDebug" name="Debug" enabled="false">
+        <ChildPackages>
+          <!--Adds support for runtime logging.-->
+          <Package id="ArcMapLogging" name="Logging" enabled="false" />
+        </ChildPackages>
+      </Package>
+    </ChildPackages>
+  </Package>
+</Packages>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -52,8 +52,8 @@
     <Reference Include="Esri.ArcGISRuntime.Hydrography, Version=100.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Hydrography.100.3.0\lib\net461\Esri.ArcGISRuntime.Hydrography.dll</HintPath>
     </Reference>
-    <Reference Include="Esri.ArcGISRuntime.LocalServices, Version=100.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.3.0lib\net461\Esri.ArcGISRuntime.LocalServices.dll</HintPath>
+    <Reference Include="Esri.ArcGISRuntime.LocalServices, Version=100.2.1.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.2.1\lib\net452\Esri.ArcGISRuntime.LocalServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -76,6 +76,8 @@
   </ItemGroup>
   <!-- Resources -->
   <ItemGroup>
+    <None Include="ArcGISLocalServer.AGSDeployment" />
+    <None Include="ArcGISLocalServer_100.3.AGSDeployment" />
     <None Include="packages.config" />
     <None Include="Readme.md" />
     <Resource Include="Assets\ApplicationIcons\windows-desktop-128.png" />
@@ -314,7 +316,7 @@
     </Compile>
     <Compile Include="Samples\Layers\MapImageSublayerQuery\MapImageSublayerQuery.xaml.cs">
       <DependentUpon>MapImageSublayerQuery.xaml</DependentUpon>
-    </Compile>    
+    </Compile>
     <Compile Include="Samples\Layers\RasterHillshade\RasterHillshade.xaml.cs">
       <DependentUpon>RasterHillshade.xaml</DependentUpon>
     </Compile>
@@ -772,7 +774,7 @@
     <Page Include="Samples\Layers\MapImageSublayerQuery\MapImageSublayerQuery.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
-    </Page>    
+    </Page>
     <Page Include="Samples\Layers\RasterHillshade\RasterHillshade.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -1220,7 +1222,7 @@
     </Content>
     <Content Include="Samples\Layers\MapImageSublayerQuery\MapImageSublayerQuery.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>    
+    </Content>
     <Content Include="Samples\Layers\RasterHillshade\RasterHillshade.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -1464,8 +1466,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.WPF.100.3.0\build\net461\Esri.ArcGISRuntime.WPF.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Esri.ArcGISRuntime.WPF.100.3.0\build\net461\Esri.ArcGISRuntime.WPF.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.Hydrography.100.3.0\build\net461\Esri.ArcGISRuntime.Hydrography.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Esri.ArcGISRuntime.Hydrography.100.3.0\build\net461\Esri.ArcGISRuntime.Hydrography.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.3.0\build\net461\Esri.ArcGISRuntime.LocalServices.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.3.0\build\net461\Esri.ArcGISRuntime.LocalServices.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.2.1\build\net452\Esri.ArcGISRuntime.LocalServices.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.2.1\build\net452\Esri.ArcGISRuntime.LocalServices.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\Esri.ArcGISRuntime.Hydrography.100.3.0\build\net461\Esri.ArcGISRuntime.Hydrography.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.Hydrography.100.3.0\build\net461\Esri.ArcGISRuntime.Hydrography.targets')" />
-  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.3.0\build\net461\Esri.ArcGISRuntime.LocalServices.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.3.0\build\net461\Esri.ArcGISRuntime.LocalServices.targets')" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.2.1\build\net452\Esri.ArcGISRuntime.LocalServices.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.LocalServices.100.2.1\build\net452\Esri.ArcGISRuntime.LocalServices.targets')" />
 </Project>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/packages.config
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Esri.ArcGISRuntime.Hydrography" version="100.3.0" targetFramework="net461" />
-  <package id="Esri.ArcGISRuntime.LocalServices" version="100.3.0" targetFramework="net461" />
+  <package id="Esri.ArcGISRuntime.LocalServices" version="100.2.1" targetFramework="net461" />
   <package id="Esri.ArcGISRuntime.WPF" version="100.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- Reverts the Esri.ArcGISRuntime.LocalServices NuGet package reference to v100.2.1 until ArcGIS Runtime Local Server SDK v100.3 is available.
- Adds deployment manifest file for Esri.ArcGISRuntime.LocalServices v100.3 and includes both manifest files in project.