### PR TITLE
Fix a potential deadlock in iOS LineOfSightGeoElement sample

### DIFF
--- a/src/iOS/Xamarin.iOS/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
@@ -188,7 +188,7 @@ namespace ArcGISRuntime.Samples.LineOfSightGeoElement
         private void Geoline_TargetVisibilityChanged(object sender, EventArgs e)
         {
             // This is needed because Runtime delivers notifications from a different thread that doesn't have access to UI controls
-            InvokeOnMainThread(UpdateUiAndSelection);
+            BeginInvokeOnMainThread(UpdateUiAndSelection);
         }
 
         private void UpdateUiAndSelection()


### PR DESCRIPTION
Our iOS LineOfSightGeoElement sample tries to wait for UI thread while inside a TargetVisibilityChanged event handler. There is a known issue in Runtime core that may cause a deadlock in this very specific scenario. It causes the sample to freeze, and can be easily toggled by moving the camera so that observer/target are near edge of the view.

This PR backports a fix made in https://github.com/Esri/arcgis-runtime-samples-dotnet/pull/476 (more specifically https://github.com/Esri/arcgis-runtime-samples-dotnet/pull/476/commits/d03d1ab076732629c868e56441ee07c35831374b#diff-9a3c411a1f36697934bfddb325700138).

