### PR TITLE
Added `ArcGISLocalServerIgnoreMissingComponent=true`  WPF project file

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -6,6 +6,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5278F66E-D41F-45D2-8327-25EA13A11618}</ProjectGuid>
+	<ArcGISLocalServerIgnoreMissingComponent>true</ArcGISLocalServerIgnoreMissingComponent>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ArcGISRuntime</RootNamespace>


### PR DESCRIPTION
This will avoid build errors when the Local Server SDK is missing.

Hi @nCastle1, this is a really simple (one line) change to the WPF project. I'm going to make the same change with v.next so the automated builds of the samples viewer won't throw an exception when the local server SDK isn't available on the build machine.