### PR TITLE
Added `ArcGISLocalServerIgnoreMissingComponent=true` to WPF Project

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -6,6 +6,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5278F66E-D41F-45D2-8327-25EA13A11618}</ProjectGuid>
+	<ArcGISLocalServerIgnoreMissingComponent>true</ArcGISLocalServerIgnoreMissingComponent>
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ArcGISRuntime</RootNamespace>


### PR DESCRIPTION
This will avoid build errors when the local server SDK is not present on the build machine.

@nCastle1 - please review when you can. Thanks!