### PR TITLE
Fixes for Android configuration in release & non-https URL in sample

### DIFF
--- a/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
+++ b/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
@@ -35,7 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <MandroidI18n />
@@ -51,8 +51,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <LangVersion>6</LangVersion>
+    <AndroidSupportedAbis />
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <!-- References -->
   <ItemGroup>

--- a/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
@@ -29,7 +29,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
         private readonly MapView _myMapView = new MapView();
 
         // Templated URL to the tile service
-        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
+        private readonly string _templateUri = "https://stamen-tiles-{subdomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
@@ -29,7 +29,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
         private readonly MapView _myMapView = new MapView();
 
         // Templated URL to the tile service
-        private readonly string _templateUri = "http://{subDomain}.tile.stamen.com/watercolor/{level}/{col}/{row}.jpg";
+        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
+++ b/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
@@ -37,7 +37,7 @@
     <DefineConstants>TRACE;DEBUG;XAMARIN_ANDROID</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi;armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
@@ -51,8 +51,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <LangVersion>6</LangVersion>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <!-- /Build Configurations -->
   <ItemGroup>

--- a/src/Forms/Shared/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -21,7 +21,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer : ContentPage
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
+        private readonly string _templateUri = "https://stamen-tiles-{subdomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/Forms/Shared/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -21,7 +21,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer : ContentPage
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "http://{subDomain}.tile.stamen.com/watercolor/{level}/{col}/{row}.png";
+        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.UWP.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
+        private readonly string _templateUri = "https://stamen-tiles-{subdomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.UWP.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "http://{subDomain}.tile.stamen.com/watercolor/{level}/{col}/{row}.png";
+        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.WPF.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "http://{subDomain}.tile.stamen.com/watercolor/{level}/{col}/{row}.png";
+        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.xaml.cs
@@ -20,7 +20,7 @@ namespace ArcGISRuntime.WPF.Samples.LoadWebTiledLayer
     public partial class LoadWebTiledLayer
     {
         // Templated URL to the tile service
-        private readonly string _templateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
+        private readonly string _templateUri = "https://stamen-tiles-{subdomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer
         private readonly List<string> _tiledLayerSubdomains = new List<string> { "a", "b", "c", "d" };

--- a/src/iOS/Xamarin.iOS/Info.plist
+++ b/src/iOS/Xamarin.iOS/Info.plist
@@ -122,13 +122,6 @@
 				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>tile.stamen.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>usgs.gov</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>

--- a/src/iOS/Xamarin.iOS/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
         private MapView _myMapView;
 
         // Templated URL to the tile service.
-        private const string TemplateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
+        private const string TemplateUri = "https://stamen-tiles-{subdomain}.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer.
         private readonly List<string> _tiledLayerSubdomains = new List<string> {"a", "b", "c", "d"};

--- a/src/iOS/Xamarin.iOS/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntime.Samples.LoadWebTiledLayer
         private MapView _myMapView;
 
         // Templated URL to the tile service.
-        private const string TemplateUri = "http://{subDomain}.tile.stamen.com/watercolor/{level}/{col}/{row}.jpg";
+        private const string TemplateUri = "https://stamen-tiles.a.ssl.fastly.net/watercolor/{level}/{col}/{row}.jpg";
 
         // List of subdomains for use when constructing the web tiled layer.
         private readonly List<string> _tiledLayerSubdomains = new List<string> {"a", "b", "c", "d"};


### PR DESCRIPTION
Some issues causing http problems on Android discovered during certification:

* Mono HttpClient implementation causes problems in release, so I switched to the native implementaiton
* Load web tiled layer was referring to stamen tiles over http; I updated to use https so that the sample will work on modern Android, which is adopting an iOS-like security policy