### PR TITLE
Fix Android AXML namespaces

### DIFF
--- a/src/Android/Xamarin.Android/Resources/layout/Animate3DGraphic.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/Animate3DGraphic.axml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/Animate3DGraphicLayout">
-    <Esri.ArcGISRuntime.UI.SceneView
+    <Esri.ArcGISRuntime.UI.Controls.SceneView
         android:id="@+id/PrimarySceneView"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -51,7 +51,7 @@
                 style="@android:style/Widget.Material.Button.Borderless.Colored" />
         </TableRow>
     </TableLayout>
-    <Esri.ArcGISRuntime.UI.MapView
+    <Esri.ArcGISRuntime.UI.Controls.MapView
         android:id="@+id/insetMap"
         android:layout_width="120dp"
         android:layout_height="120dp"

--- a/src/Android/Xamarin.Android/Resources/layout/Buffer.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/Buffer.axml
@@ -74,7 +74,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1">
-            <Esri.ArcGISRuntime.UI.MapView
+            <Esri.ArcGISRuntime.UI.Controls.MapView
                 android:id="@+id/buffer_mapView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/src/Android/Xamarin.Android/Resources/layout/DistanceMeasurement.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/DistanceMeasurement.axml
@@ -88,7 +88,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_weight="1">
-            <Esri.ArcGISRuntime.UI.SceneView
+            <Esri.ArcGISRuntime.UI.Controls.SceneView
                 android:id="@+id/distanceMeasurement_sceneView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/src/Android/Xamarin.Android/Resources/layout/FeatureLayerRenderingModeMapLayout.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/FeatureLayerRenderingModeMapLayout.axml
@@ -7,7 +7,7 @@
         android:text="Static:"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />
-    <Esri.ArcGISRuntime.UI.MapView
+    <Esri.ArcGISRuntime.UI.Controls.MapView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"
@@ -16,7 +16,7 @@
         android:text="Dynamic:"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />
-    <Esri.ArcGISRuntime.UI.MapView
+    <Esri.ArcGISRuntime.UI.Controls.MapView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"

--- a/src/Android/Xamarin.Android/Resources/layout/GeoViewSync.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/GeoViewSync.axml
@@ -3,12 +3,12 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <Esri.ArcGISRuntime.UI.MapView
+    <Esri.ArcGISRuntime.UI.Controls.MapView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:id="@+id/GeoViewSync_MyMapView" />
-    <Esri.ArcGISRuntime.UI.SceneView
+    <Esri.ArcGISRuntime.UI.Controls.SceneView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_weight="1"

--- a/src/Android/Xamarin.Android/Resources/layout/ListKmlContents.axml
+++ b/src/Android/Xamarin.Android/Resources/layout/ListKmlContents.axml
@@ -18,7 +18,7 @@
 		android:layout_weight="1" 
 		android:layout_width="fill_parent" 
 		android:layout_height="0dp">
-	<Esri.ArcGISRuntime.UI.SceneView
+	<Esri.ArcGISRuntime.UI.Controls.SceneView
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_alignParentBottom="true"


### PR DESCRIPTION
There is a change to the API that moves the UI controls from `Esri.ArcGISRuntime.UI.` to `Esri.ArcGISRuntime.UI.Controls`. At run time, this causes an exception when loading Android layouts with GeoViews. This PR fixes the samples so that they work with 100.4. 