### PR TITLE
Fix issue with change sublayer visibility sample

### DIFF
--- a/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -102,7 +102,7 @@ namespace ArcGISRuntime.Samples.ChangeSublayerVisibility
             };
                         
             // Navigate to the sublayers page
-            await Navigation.PushModalAsync(sublayersPage);
+            await Navigation.PushAsync(sublayersPage);
         }
 
         private void OnCellOnOffChanged(object sender, ToggledEventArgs e)


### PR DESCRIPTION
Change sublayer visibility didn't allow the user to go back to the map after adjusting the selection. 