### PR TITLE
Added validation to check if the user canceled the change basemap operation to prevent application error.

### DIFF
--- a/src/Forms/Shared/Samples/Map/ChangeBasemap/ChangeBasemap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/ChangeBasemap/ChangeBasemap.xaml.cs
@@ -54,8 +54,12 @@ namespace ArcGISRuntime.Samples.ChangeBasemap
             string selectedBasemap =
                 await ((Page)Parent).DisplayActionSheet("Select basemap", "Cancel", null, _basemapOptions.Keys.ToArray());
 
-            // Retrieve the basemap from the dictionary
-            MyMapView.Map.Basemap = _basemapOptions[selectedBasemap];
+            // Verify the user did not cancel the operation
+            if (!selectedBasemap.ToLower().Equals("cancel"))
+            {
+                // Retrieve the basemap from the dictionary
+                MyMapView.Map.Basemap = _basemapOptions[selectedBasemap];
+            }
         }
 
         private void Initialize()


### PR DESCRIPTION
Simple solution to prevent the application from crashing if the user cancels out of the change basemap prompt.