### PR TITLE
Certification fixes for 100.4 - PR6

### DIFF
--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
         "Animate 3D graphic",
         "GraphicsOverlay",
         "This sample demonstrates how to animate a graphic's position and follow it using a camera controller.",
-        "Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.\nThe plane's route is shown on the inset map in the bottom left corner of the screen. The progress through the plane's mission is shown in a slider within the stats panel. Click 'Stats' to toggle stats display. Drag the slider to seek through the mission (like you might seek through a song). Tap 'Mission' to choose from a list of alternative routes. \n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).",
+        "Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.\nThe plane's route is shown on the inset map in the bottom left corner of the screen. The progress through the plane's mission is shown in a slider within the stats panel. Click 'Stats' to toggle stats display. Drag the slider to seek through the mission (like you might seek through a song). Tap 'Mission' to choose from a list of alternative routes. Changing the settings for choosing a different mission or modifying mission progress will automatically re-start the animation if it is currently paused.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).",
         "Featured")]
     public class Animate3DGraphic : Activity
     {
@@ -228,6 +228,9 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
             _frameCount = _missionData.Length;
             _keyframe = 0;
 
+            // Set the _playButton button back to the currently 'playing' state
+            _playButton.Text = "Pause";
+
             // Restart the animation
             _animationTimer.Start();
         }
@@ -371,6 +374,9 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
 
             // Update the keyframe based on the progress
             _keyframe = (int)(missionProgress * _frameCount);
+
+            // Set the _playButton button back to the currently 'playing' state
+            _playButton.Text = "Pause";
 
             // Restart the animation
             _animationTimer.Start();

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
@@ -8,5 +8,6 @@ This sample demonstrates how to animate a graphic's position and follow it using
 
 Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.
 The plane's route is shown on the inset map in the bottom left corner of the screen. The progress through the plane's mission is shown in a slider within the stats panel. Click 'Stats' to toggle stats display. Drag the slider to seek through the mission (like you might seek through a song). Tap 'Mission' to choose from a list of alternative routes. 
+Changing the settings for choosing a different mission or modifying mission progress will automatically re-start the animation if it is currently paused.
 
 Note that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).

--- a/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
@@ -18,7 +18,7 @@
         <esriUI:SceneView x:Name="MySceneView" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Grid.RowSpan="3" AtmosphereEffect="Realistic" />
         <StackLayout Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="5">
             <Picker x:Name="MissionSelectionBox" />
-            <Button Clicked="MissionPlayPlauseClick" Margin="5,0,0,0" Text="Pause" />
+            <Button x:Name="MissionPlayPause" Clicked="MissionPlayPlauseClick" Margin="5,0,0,0" Text="Pause" />
             <Button  HorizontalOptions="End" VerticalOptions="End" Clicked="ToggleFollowPlane" Text="Don't Follow" />
         </StackLayout>
         <Frame Grid.Row ="1" Grid.Column="2" Margin="5"  x:Name="LayoutFrame">

--- a/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
         "Animate 3D graphic",
         "GraphicsOverlay",
         "This sample demonstrates how to animate a graphic's position and follow it using a camera controller.",
-        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't Follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop or in a simulator).",
+        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't Follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane. Changing the settings for choosing a different mission or modifying mission progress will automatically re-start the animation if it is currently paused.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop or in a simulator).",
         "Featured")]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("290f0c571c394461a8b58b6775d0bd63","e87c154fb9c2487f999143df5b08e9b1","5a9b60cee9ba41e79640a06bcdf8084d","12509ffdc684437f8f2656b0129d2c13","681d6f7694644709a7c830ec57a2d72b")]
     public partial class Animate3DGraphic : ContentPage
@@ -202,6 +202,9 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
             _frameCount = _missionData.Length;
             _keyframe = 0;
 
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Text = "Pause";
+
             // Restart the animation
             _animationTimer = true;
         }
@@ -326,6 +329,9 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
 
             // Update the keyframe based on the progress
             _keyframe = (int)(missionProgress * _frameCount);
+
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Text = "Pause";
 
             // Restart the animation
             _animationTimer = true;

--- a/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
@@ -9,5 +9,6 @@ This sample demonstrates how to animate a graphic's position and follow it using
 Click-and-drag to pan the SceneView, orbiting the moving plane. Click "Don't Follow" to switch to the default camera controller, which does not orbit the plane.
 The plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in the panel on the right.
 There is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.
+Changing the settings for choosing a different mission or modifying mission progress will automatically re-start the animation if it is currently paused.
 
 Note that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop or in a simulator).

--- a/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -89,7 +89,7 @@ namespace ArcGISRuntime.Samples.AuthorMap
             {
                 case Device.Android:
                     LayersList.BackgroundColor = Color.Black;
-                    OAuthSettingsGrid.BackgroundColor = Color.Black;
+                    OAuthSettingsGrid.BackgroundColor = Color.Gray;
                     break;
                 case Device.UWP:
                     LayersList.BackgroundColor = Color.FromRgba(255, 255, 255, 0.3);

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
@@ -28,7 +28,7 @@
             <ComboBox x:Name="MissionSelectionBox"
                       VerticalAlignment="Top"
                       MinWidth="150" />
-            <Button Content="Pause"
+            <Button x:Name="MissionPlayPause" Content="Pause"
                     VerticalAlignment="Top"
                     Margin="5,0,0,0"
                     MinWidth="75"

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -28,7 +28,7 @@ namespace ArcGISRuntime.UWP.Samples.Animate3DGraphic
         "Animate 3D graphic",
         "GraphicsOverlay",
         "This sample demonstrates how to animate a graphic's position and follow it using a camera controller.",
-        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't Follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).")]
+        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't Follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane. Changing the settings for: choosing a different mission, adjusting the play speed, or modifying mission progress will automatically re-start the animation if it is currently paused.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).")]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("290f0c571c394461a8b58b6775d0bd63","e87c154fb9c2487f999143df5b08e9b1","5a9b60cee9ba41e79640a06bcdf8084d","12509ffdc684437f8f2656b0129d2c13","681d6f7694644709a7c830ec57a2d72b")]
     public partial class Animate3DGraphic
     {
@@ -204,6 +204,9 @@ namespace ArcGISRuntime.UWP.Samples.Animate3DGraphic
             _frameCount = _missionData.Length;
             _keyframe = 0;
 
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
+
             // Restart the animation
             _animationTimer.Start();
         }
@@ -328,6 +331,9 @@ namespace ArcGISRuntime.UWP.Samples.Animate3DGraphic
             // Update the keyframe based on the progress
             _keyframe = (int)(missionProgress * _frameCount);
 
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
+
             // Restart the animation
             _animationTimer.Start();
         }
@@ -374,6 +380,9 @@ namespace ArcGISRuntime.UWP.Samples.Animate3DGraphic
 
             // Update the animation speed
             _animationTimer.Interval = new TimeSpan(0, 0, 0, 0, (int)(60 / speedMultiplier));
+
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
 
             // Restart the animation
             _animationTimer.Start();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
@@ -8,6 +8,6 @@ This sample demonstrates how to animate a graphic's position and follow it using
 
 Click-and-drag to pan the SceneView, orbiting the moving plane. Click "Don't Follow" to switch to the default camera controller, which does not orbit the plane.
 The plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.
-There is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.
+There is a drop-down box on the top left part of the window for selecting a mission (route) for the plane. Changing the settings for: choosing a different mission, adjusting the play speed, or modifying mission progress will automatically re-start the animation if it is currently paused.
 
 Note that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml
@@ -40,7 +40,7 @@
                     Orientation="Horizontal" Margin="5">
             <ComboBox x:Name="MissionSelectionBox"
                       VerticalAlignment="Top" Height="25" Width="100" />
-            <Button Content="Pause"
+            <Button x:Name="MissionPlayPause" Content="Pause"
                     VerticalAlignment="Top" Height="25" Width="50"
                     Click="MissionPlayPlauseClick" />
             <TextBlock Text="Progress" Margin="5" />

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WPF.Samples.Animate3DGraphic
         "Animate 3D graphic",
         "GraphicsOverlay",
         "This sample demonstrates how to animate a graphic's position and follow it using a camera controller.",
-        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).",
+        "Click-and-drag to pan the SceneView, orbiting the moving plane. Click \"Don't follow\" to switch to the default camera controller, which does not orbit the plane.\nThe plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.\nThere is a drop-down box on the top left part of the window for selecting a mission (route) for the plane. Changing the settings for: choosing a different mission, adjusting the play speed, or modifying mission progress will automatically re-start the animation if it is currently paused.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).",
         "Featured")]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("290f0c571c394461a8b58b6775d0bd63", "681d6f7694644709a7c830ec57a2d72b", "e87c154fb9c2487f999143df5b08e9b1", "5a9b60cee9ba41e79640a06bcdf8084d", "12509ffdc684437f8f2656b0129d2c13")]
     public partial class Animate3DGraphic
@@ -210,6 +210,9 @@ namespace ArcGISRuntime.WPF.Samples.Animate3DGraphic
             _frameCount = _missionData.Length;
             _keyframe = 0;
 
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
+
             // Restart the animation
             _animationTimer.Start();
         }
@@ -334,6 +337,9 @@ namespace ArcGISRuntime.WPF.Samples.Animate3DGraphic
             // Update the keyframe based on the progress
             _keyframe = (int)(missionProgress * _frameCount);
 
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
+
             // Restart the animation
             _animationTimer.Start();
         }
@@ -378,6 +384,9 @@ namespace ArcGISRuntime.WPF.Samples.Animate3DGraphic
 
             // Update the animation speed
             _animationTimer.Interval = 60 / speedMultiplier;
+
+            // Set the MissionPlayPause button back to the currently 'playing' state
+            MissionPlayPause.Content = "Pause";
 
             // Restart the animation
             _animationTimer.Start();

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
@@ -8,6 +8,7 @@ This sample demonstrates how to animate a graphic's position and follow it using
 
 Click-and-drag to pan the SceneView, orbiting the moving plane. Click "Don't follow" to switch to the default camera controller, which does not orbit the plane.
 The plane's route is shown on the inset map in the bottom left corner of the window. The progress through the plane's mission is shown in a slider at the top of the window. Drag the slider to seek through the mission (like you might seek through a song). The play speed can be adjusted to either be slower or faster using the slider in the panel on the right.
-There is a drop-down box on the top left part of the window for selecting a mission (route) for the plane.
+There is a drop-down box on the top left part of the window for selecting a mission (route) for the plane. Changing the settings for: choosing a different mission, adjusting the play speed, or modifying mission progress will automatically re-start the animation if it is currently paused.
 
 Note that this is a graphics-intensive sample; performance may be degraded in certain situations (such as viewing over Remote Desktop).
+

--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
@@ -33,7 +33,7 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
         "Animate 3D graphic",
         "GraphicsOverlay",
         "This sample demonstrates how to animate a graphic's position and follow it using a camera controller.",
-        "Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.\nThe plane's route is shown on the inset map in the bottom left corner of the screen. Click 'Stats' to toggle stats display. Tap 'Mission' to choose from a list of alternative routes. \n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).",
+        "Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.\nThe plane's route is shown on the inset map in the bottom left corner of the screen. Click 'Stats' to toggle stats display. Tap 'Mission' to choose from a list of alternative routes. Changing the settings for choosing a different mission will automatically re-start the animation if it is currently paused.\n\nNote that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).",
         "Featured")]
     public class Animate3DGraphic : UIViewController
     {
@@ -288,6 +288,9 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
             // Update animation parameters.
             _frameCount = _missionData.Length;
             _keyframe = 0;
+
+            // Set the _playButton button back to the currently 'playing' state
+            _playButton.SetTitle("Pause", UIControlState.Normal);
 
             // Restart the animation.
             _animationTimer.Start();

--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/Animate3DGraphic/readme.md
@@ -8,5 +8,6 @@ This sample demonstrates how to animate a graphic's position and follow it using
 
 Click-and-drag to pan the sceneview, orbiting the moving plane. Click 'Camera' to toggle between the default and the orbiting camera controller.
 The plane's route is shown on the inset map in the bottom left corner of the screen. Click 'Stats' to toggle stats display. Tap 'Mission' to choose from a list of alternative routes. 
+Changing the settings for choosing a different mission will automatically re-start the animation if it is currently paused.
 
 Note that this is a graphics-intensive sample; performance may be degraded in certain situations (such as using a simulator).


### PR DESCRIPTION
@ThadT Can you please code review these fixes for issues found during the 100.4 certification? The issues being fixed are:

-  *Xamarin.Forms Android* **Author and save a map** - OAuth settings form has black text on a black background - unusable. [The fix was to make the background gray so that black text could be read]
-  *All platforms* **Animate 3D graphic** - when the user changes mission progress while the animation is paused, animation resumes. [The fix was to automatically turn play/pause button back to 'play mode' whenever the user made an GUI change by: choosing a different mission, adjusting the play speed, or modifying mission progress. This was the easiest fix given the complex nature of the control interactions. Modifications were made to the readme.md, as well as the .cs and .xaml files depending on the platform.]