### PR TITLE
Remove unnecessary configuration from sketch on map

### DIFF
--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
@@ -76,12 +76,6 @@ namespace ArcGISRuntime.Samples.SketchOnMap
             // Assign the map to the MapView
             _myMapView.Map = myMap;
 
-            // Set the sketch editor configuration to allow vertex editing, resizing, and moving
-            SketchEditConfiguration config = _myMapView.SketchEditor.EditConfiguration;
-            config.AllowVertexEditing = true;
-            config.ResizeMode = SketchResizeMode.Uniform;
-            config.AllowMove = true;
-
             // Listen to the sketch editor tools CanExecuteChange so controls can be enabled/disabled
             _myMapView.SketchEditor.UndoCommand.CanExecuteChanged += CanExecuteChanged;
             _myMapView.SketchEditor.RedoCommand.CanExecuteChanged += CanExecuteChanged;

--- a/src/Forms/Shared/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -60,12 +60,6 @@ namespace ArcGISRuntime.Samples.SketchOnMap
 
             SketchModePicker.SelectedIndex = 0;
 
-            // Set the sketch editor configuration to allow vertex editing, resizing, and moving
-            SketchEditConfiguration config = MyMapView.SketchEditor.EditConfiguration;
-            config.AllowVertexEditing = true;
-            config.ResizeMode = SketchResizeMode.Uniform;
-            config.AllowMove = true;
-
             // Set a gray background color for Android
             if (Device.RuntimePlatform == Device.Android)
             {

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -56,12 +56,6 @@ namespace ArcGISRuntime.UWP.Samples.SketchOnMap
             SketchModeComboBox.ItemsSource = System.Enum.GetValues(typeof(SketchCreationMode));
             SketchModeComboBox.SelectedIndex = 0;
 
-            // Set the sketch editor configuration to allow vertex editing, resizing, and moving
-            SketchEditConfiguration config = MyMapView.SketchEditor.EditConfiguration;
-            config.AllowVertexEditing = true;
-            config.ResizeMode = SketchResizeMode.Uniform;
-            config.AllowMove = true;
-
             // Set the sketch editor as the page's data context
             DataContext = MyMapView.SketchEditor;
         }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -56,12 +56,6 @@ namespace ArcGISRuntime.WPF.Samples.SketchOnMap
             SketchModeComboBox.ItemsSource = System.Enum.GetValues(typeof(SketchCreationMode));
             SketchModeComboBox.SelectedIndex = 0;
 
-            // Set the sketch editor configuration to allow vertex editing, resizing, and moving
-            SketchEditConfiguration config = MyMapView.SketchEditor.EditConfiguration;
-            config.AllowVertexEditing = true;
-            config.ResizeMode = SketchResizeMode.Uniform;
-            config.AllowMove = true;
-
             // Set the sketch editor as the page's data context
             DataContext = MyMapView.SketchEditor;
         }

--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
@@ -95,12 +95,6 @@ namespace ArcGISRuntime.Samples.SketchOnMap
             _sketchOverlay = new GraphicsOverlay();
             _myMapView.GraphicsOverlays.Add(_sketchOverlay);
 
-            // Set the sketch editor configuration to allow vertex editing, resizing, and moving.
-            SketchEditConfiguration config = _myMapView.SketchEditor.EditConfiguration;
-            config.AllowVertexEditing = true;
-            config.ResizeMode = SketchResizeMode.Uniform;
-            config.AllowMove = true;
-
             // Listen to the sketch editor tools CanExecuteChange so controls can be enabled/disabled.
             _myMapView.SketchEditor.UndoCommand.CanExecuteChanged += CanExecuteChanged;
             _myMapView.SketchEditor.RedoCommand.CanExecuteChanged += CanExecuteChanged;


### PR DESCRIPTION
The Sketch on Map sample was making some extra API calls that turned out to be unnecessary. This PR removes those four lines.

Note: this doesn't appear to have a significant effect on behavior - the configuration only affected the first editing session. However, it was causing confusion on GeoNet. 

Another note: this only worked before because of a bug. The old code would have crashed upon upgrading to the next version.