### PR TITLE
Set the AppDataPath for local server in all LS samples

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/App.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/App.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using System;
+using System.IO;
 using System.Windows;
 
 namespace ArcGISRuntime.WPF.Viewer
@@ -18,6 +19,14 @@ namespace ArcGISRuntime.WPF.Viewer
         {
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\Temp.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "Temp");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.TempPath = tempDataPath;
+
+                // Initialize ArcGISRuntime.
                 Esri.ArcGISRuntime.ArcGISRuntimeEnvironment.Initialize();
             }
             catch (Exception ex)

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
@@ -46,10 +46,16 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
 
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/DynamicWorkspaceRaster.xaml.cs
@@ -46,6 +46,13 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceRaster
 
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
@@ -48,6 +48,13 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceShapefile
 
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/DynamicWorkspaceShapefile.xaml.cs
@@ -48,10 +48,16 @@ namespace ArcGISRuntime.WPF.Samples.DynamicWorkspaceShapefile
 
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.LocalServices;
 using Esri.ArcGISRuntime.Mapping;
 using System;
+using System.IO;
 using System.Windows;
 
 namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
@@ -43,6 +44,13 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
 
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
             }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/LocalServerFeatureLayer.xaml.cs
@@ -44,10 +44,16 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerFeatureLayer
 
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
@@ -13,6 +13,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Tasks;
 using Esri.ArcGISRuntime.Tasks.Geoprocessing;
 using System;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -79,6 +80,13 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             // Try to start Local Server
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
             }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/LocalServerGeoprocessing.xaml.cs
@@ -80,10 +80,16 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerGeoprocessing
             // Try to start Local Server
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
@@ -11,6 +11,7 @@ using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.LocalServices;
 using Esri.ArcGISRuntime.Mapping;
 using System;
+using System.IO;
 using System.Windows;
 
 namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
@@ -41,6 +42,13 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
 
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+
                 // Start the local server instance
                 await LocalServer.Instance.StartAsync();
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/LocalServerMapImageLayer.xaml.cs
@@ -42,10 +42,16 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerMapImageLayer
 
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/LocalServerServices.xaml.cs
@@ -10,6 +10,7 @@
 using ArcGISRuntime.Samples.Managers;
 using Esri.ArcGISRuntime.LocalServices;
 using System;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -200,6 +201,13 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
         {
             try
             {
+                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // This path should be kept short to avoid Windows path length limitations.
+                string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
+                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
+                LocalServer.Instance.AppDataPath = tempDataPath;
+                
                 // Start the server
                 await LocalServer.Instance.StartAsync();
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/LocalServerServices.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/LocalServerServices.xaml.cs
@@ -201,10 +201,16 @@ namespace ArcGISRuntime.WPF.Samples.LocalServerServices
         {
             try
             {
-                // Set the local data path - must be done before starting. On most systems, this will be C:\Esri_LS_Data.
+                // LocalServer must not be running when setting the data path.
+                if (LocalServer.Instance.Status == LocalServerStatus.Started)
+                {
+                    await LocalServer.Instance.StopAsync();
+                }
+
+                // Set the local data path - must be done before starting. On most systems, this will be C:\EsriSamples\AppData.
                 // This path should be kept short to avoid Windows path length limitations.
                 string tempDataPathRoot = Directory.GetParent(Environment.GetFolderPath(Environment.SpecialFolder.Windows)).FullName;
-                string tempDataPath = Path.Combine(tempDataPathRoot, "Esri_LS_Data");
+                string tempDataPath = Path.Combine(tempDataPathRoot, "EsriSamples", "AppData");
                 Directory.CreateDirectory(tempDataPath); // CreateDirectory won't overwrite if it already exists.
                 LocalServer.Instance.AppDataPath = tempDataPath;
                 


### PR DESCRIPTION
This is a necessary step to avoid complications when `%LOCALAPPDATA%` is very long.