### PR TITLE
Fix UWP & Android UI issues

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
@@ -20,7 +20,7 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ArcGISRuntime.Samples.DistanceMeasurement
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Distance measurement analysis",
         "Analysis",

--- a/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
@@ -22,7 +22,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.LineOfSightGeoElement
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3af5cfec0fd24dac8d88aea679027cb9")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Line of sight (GeoElement)",

--- a/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightLocation/LineOfSightLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightLocation/LineOfSightLocation.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.LineOfSightLocation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Line of sight from location",
         "Analysis",

--- a/src/Android/Xamarin.Android/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.cs
@@ -20,7 +20,7 @@ using Android.Views.InputMethods;
 
 namespace ArcGISRuntime.Samples.QueryFeatureCountAndExtent
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Query feature count and extent",
         "Analysis",

--- a/src/Android/Xamarin.Android/Samples/Analysis/ViewshedCamera/ViewshedCamera.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/ViewshedCamera/ViewshedCamera.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ViewshedCamera
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Viewshed for camera",
         "Analysis",

--- a/src/Android/Xamarin.Android/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cs
@@ -25,7 +25,7 @@ using System.Timers;
 
 namespace ArcGISRuntime.Samples.ViewshedGeoElement
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("07d62a792ab6496d9b772a24efea45d0")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Viewshed (GeoElement)",

--- a/src/Android/Xamarin.Android/Samples/Analysis/ViewshedLocation/ViewshedLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/ViewshedLocation/ViewshedLocation.cs
@@ -22,7 +22,7 @@ using Surface = Esri.ArcGISRuntime.Mapping.Surface;
 
 namespace ArcGISRuntime.Samples.ViewshedLocation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Viewshed (Location)",
         "Analysis",

--- a/src/Android/Xamarin.Android/Samples/Data/AddFeatures/AddFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/AddFeatures/AddFeatures.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace ArcGISRuntimeXamarin.Samples.AddFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Add features (feature service)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/DeleteFeatures/DeleteFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/DeleteFeatures/DeleteFeatures.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ArcGISRuntimeXamarin.Samples.DeleteFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Delete features (feature service)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.cs
@@ -30,7 +30,7 @@ using Esri.ArcGISRuntime;
 
 namespace ArcGISRuntime.Samples.EditAndSyncFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Edit and sync features",

--- a/src/Android/Xamarin.Android/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.cs
@@ -25,7 +25,7 @@ using Android.Views;
 
 namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Edit feature attachments",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
@@ -19,7 +19,7 @@ using Esri.ArcGISRuntime.Data;
 
 namespace ArcGISRuntime.Samples.FeatureLayerGeoPackage
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer (GeoPackage)",

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
@@ -18,7 +18,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.FeatureLayerGeodatabase
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("2b0f9e17105847809dfeb04e3cad69e0")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer (geodatabase)",

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.cs
@@ -24,7 +24,7 @@ using Android.Text;
 
 namespace ArcGISRuntime.Samples.FeatureLayerQuery
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer query",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerShapefile/FeatureLayerShapefile.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerShapefile/FeatureLayerShapefile.cs
@@ -18,7 +18,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.FeatureLayerShapefile
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("d98b3e5293834c5f852f13c569930caa")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer (shapefile)",

--- a/src/Android/Xamarin.Android/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
@@ -28,7 +28,7 @@ using Esri.ArcGISRuntime.ArcGISServices;
 
 namespace ArcGISRuntime.Samples.GenerateGeodatabase
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("3f1bbf0ec70b409a975f5c91f363fe7d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Generate geodatabase",

--- a/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
@@ -24,7 +24,7 @@ using Android.Views;
 
 namespace ArcGISRuntime.Samples.GeodatabaseTransactions
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Geodatabase transactions",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.cs
@@ -21,7 +21,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ListRelatedFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "List related features",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.cs
@@ -20,7 +20,7 @@ using Esri.ArcGISRuntime.Rasters;
 
 namespace ArcGISRuntime.Samples.RasterLayerGeoPackage
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Raster layer (GeoPackage)",

--- a/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
@@ -23,7 +23,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ReadGeoPackage
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Read a GeoPackage",

--- a/src/Android/Xamarin.Android/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.cs
@@ -21,7 +21,7 @@ using Esri.ArcGISRuntime.UI;
 
 namespace ArcGISRuntime.Samples.ReadShapefileMetadata
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("d98b3e5293834c5f852f13c569930caa")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Read shapefile metadata",

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableCache/ServiceFeatureTableCache.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ServiceFeatureTableCache
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Service feature table (cache)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ServiceFeatureTableManualCache
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Service feature table (manual cache)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/ServiceFeatureTableNoCache.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ServiceFeatureTableNoCache
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Service feature table (no cache)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/StatisticalQuery/StatisticalQuery.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/StatisticalQuery/StatisticalQuery.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.StatisticalQuery
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Statistical query",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.cs
@@ -21,7 +21,7 @@ using OrderFieldOption = ArcGISRuntime.Samples.StatsQueryGroupAndSort.OrderField
 
 namespace ArcGISRuntime.Samples.StatsQueryGroupAndSort
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.AndroidLayout("GroupedResultsList_DataItem.axml", "GroupedResultsList_GroupItem.axml")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Statistical query group and sort results",

--- a/src/Android/Xamarin.Android/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.cs
@@ -20,7 +20,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.SymbolizeShapefile
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("d98b3e5293834c5f852f13c569930caa")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Symbolize a shapefile",

--- a/src/Android/Xamarin.Android/Samples/Data/UpdateAttributes/UpdateAttributes.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/UpdateAttributes/UpdateAttributes.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ArcGISRuntimeXamarin.Samples.UpdateAttributes
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Update attributes (feature service)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/UpdateGeometries/UpdateGeometries.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/UpdateGeometries/UpdateGeometries.cs
@@ -20,7 +20,7 @@ using Android.Views;
 
 namespace ArcGISRuntimeXamarin.Samples.UpdateGeometries
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Update geometries (feature service)",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Data/ViewPointCloudDataOffline/ViewPointCloudDataOffline.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ViewPointCloudDataOffline/ViewPointCloudDataOffline.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntimeXamarin.Samples.ViewPointCloudDataOffline
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "View point cloud data offline",
         "Data",

--- a/src/Android/Xamarin.Android/Samples/Geometry/Buffer/Buffer.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/Buffer/Buffer.cs
@@ -19,7 +19,7 @@ using Colors = System.Drawing.Color;
 
 namespace ArcGISRuntime.Samples.Buffer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Buffer",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/BufferList/BufferList.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/BufferList/BufferList.cs
@@ -21,7 +21,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.BufferList
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Buffer list",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/ClipGeometry/ClipGeometry.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ClipGeometry/ClipGeometry.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ClipGeometry
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Clip geometry",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/ConvexHull/ConvexHull.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ConvexHull/ConvexHull.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.ConvexHull
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Convex hull",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/ConvexHullList/ConvexHullList.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ConvexHullList/ConvexHullList.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.ConvexHullList
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Convex hull list",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/CreateGeometries/CreateGeometries.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/CreateGeometries/CreateGeometries.cs
@@ -18,7 +18,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.CreateGeometries
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Create geometries",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/CutGeometry/CutGeometry.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/CutGeometry/CutGeometry.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.CutGeometry
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Cut geometry",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/DensifyAndGeneralize/DensifyAndGeneralize.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.DensifyAndGeneralize
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Densify and generalize",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/FormatCoordinates/FormatCoordinates.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/FormatCoordinates/FormatCoordinates.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.FormatCoordinates
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Format coordinates",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/GeodesicOperations/GeodesicOperations.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/GeodesicOperations/GeodesicOperations.cs
@@ -18,7 +18,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.GeodesicOperations
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Geodesic operations",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/ListTransformations/ListTransformations.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ListTransformations/ListTransformations.cs
@@ -23,7 +23,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.ListTransformations
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData()]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "List transformations by suitability",

--- a/src/Android/Xamarin.Android/Samples/Geometry/NearestVertex/NearestVertex.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/NearestVertex/NearestVertex.cs
@@ -19,7 +19,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.NearestVertex
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Nearest vertex",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/Project/Project.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/Project/Project.cs
@@ -19,7 +19,7 @@ using System.Drawing;
 
 namespace ArcGISRuntimeXamarin.Samples.Project
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Project",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/ProjectWithSpecificTransformation/ProjectWithSpecificTransformation.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ProjectWithSpecificTransformation/ProjectWithSpecificTransformation.cs
@@ -14,7 +14,7 @@ using Esri.ArcGISRuntime.Geometry;
 
 namespace ArcGISRuntime.Samples.ProjectWithSpecificTransformation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Project with specific transformation",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
@@ -21,7 +21,7 @@ using System.Drawing;
 
 namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample("Spatial operations",
         "Geometry",
         "Demonstrates how to use the GeometryEngine to perform geometry operations between overlapping polygons in a GraphicsOverlay.",

--- a/src/Android/Xamarin.Android/Samples/Geometry/SpatialRelationships/SpatialRelationships.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/SpatialRelationships/SpatialRelationships.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.SpatialRelationships
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Spatial relationships",
         "Geometry",

--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.AnalyzeHotspots
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Analyze hotspots",
         "Geoprocessing",

--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.AnalyzeViewshed
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Viewshed (Geoprocessing)",
         "Geoprocessing",

--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.ListGeodatabaseVersions
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "List geodatabase versions",
         "Geoprocessing",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.AddGraphicsRenderer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Add graphics (SimpleRenderer)",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
@@ -19,7 +19,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Add graphics with symbols",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.cs
@@ -28,7 +28,7 @@ using Surface = Esri.ArcGISRuntime.Mapping.Surface;
 
 namespace ArcGISRuntime.Samples.Animate3DGraphic
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.AndroidLayout("Animate3DGraphic.axml")]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("290f0c571c394461a8b58b6775d0bd63","e87c154fb9c2487f999143df5b08e9b1","5a9b60cee9ba41e79640a06bcdf8084d","12509ffdc684437f8f2656b0129d2c13","681d6f7694644709a7c830ec57a2d72b")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.cs
@@ -23,7 +23,7 @@ using System.Xml.Linq;
 
 namespace ArcGISRuntimeXamarin.Samples.DictionaryRendererGraphicsOverlay
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Dictionary renderer with graphics overlay",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.cs
@@ -20,7 +20,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.IdentifyGraphics
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Identify graphics",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/ScenePropertiesExpressions/ScenePropertiesExpressions.cs
@@ -19,7 +19,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntimeXamarin.Samples.ScenePropertiesExpressions
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Scene properties expressions",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.cs
@@ -26,7 +26,7 @@ using System.Windows.Input;
 
 namespace ArcGISRuntime.Samples.SketchOnMap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Sketch graphics on the map",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/SurfacePlacements/SurfacePlacements.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.SurfacePlacements
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Surface placement",
         "GraphicsOverlay",

--- a/src/Android/Xamarin.Android/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.cs
+++ b/src/Android/Xamarin.Android/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntimeXamarin.Samples.AddEncExchangeSet
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Add ENC Exchange Set",
         "Hydrography",

--- a/src/Android/Xamarin.Android/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.cs
+++ b/src/Android/Xamarin.Android/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntimeXamarin.Samples.ChangeEncDisplaySettings
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change ENC display settings",
         "Hydrography",

--- a/src/Android/Xamarin.Android/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.cs
@@ -23,7 +23,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.SelectEncFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("9d2987a825c646468b3ce7512fb76e2d")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Select ENC features",

--- a/src/Android/Xamarin.Android/Samples/Layers/AddAnIntegratedMeshLayer/AddAnIntegratedMeshLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/AddAnIntegratedMeshLayer/AddAnIntegratedMeshLayer.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntimeXamarin.Samples.AddAnIntegratedMeshLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Add an integrated mesh layer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ArcGISMapImageLayerUrl/ArcGISMapImageLayerUrl.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ArcGISMapImageLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS map image layer (URL)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ArcGISTiledLayerUrl/ArcGISTiledLayerUrl.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ArcGISTiledLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS tiled layer (URL)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ArcGISVectorTiledLayerUrl/ArcGISVectorTiledLayerUrl.cs
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ArcGISVectorTiledLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS vector tiled layer (URL)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ChangeFeatureLayerRenderer/ChangeFeatureLayerRenderer.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.ChangeFeatureLayerRenderer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change feature layer renderer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ChangeSublayerRenderer/ChangeSublayerRenderer.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.ChangeSublayerRenderer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change sublayer renderer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ChangeSublayerVisibility
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change sublayer visibility",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayKml/DisplayKml.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayKml/DisplayKml.cs
@@ -20,7 +20,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntimeXamarin.Samples.DisplayKml
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display KML",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntimeXamarin.Samples.DisplayKmlNetworkLinks
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display KML network links",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayScene/DisplayScene.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayScene/DisplayScene.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.DisplayScene
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display scene",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerDefinitionExpression/FeatureLayerDefinitionExpression.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.FeatureLayerDefinitionExpression
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer definition expression",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.cs
@@ -20,7 +20,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.FeatureLayerDictionaryRenderer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("e34835bf5ec5430da7cf16bb8c0b075c","e0d41b4b409a49a5a7ba11939d8535dc")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer dictionary renderer",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.cs
@@ -20,7 +20,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.FeatureLayerRenderingModeMap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.AndroidLayout("FeatureLayerRenderingModeMapLayout.axml")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer rendering mode (Map)",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerRenderingModeScene/FeatureLayerRenderingModeScene.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.FeatureLayerRenderingModeScene
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.AndroidLayout("FeatureLayerRenderingModeScene.axml")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer rendering mode (Scene)",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.cs
@@ -20,7 +20,7 @@ using Esri.ArcGISRuntime;
 
 namespace ArcGISRuntime.Samples.FeatureLayerSelection
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer selection",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/FeatureLayerUrl/FeatureLayerUrl.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.FeatureLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer (feature service)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cs
@@ -23,7 +23,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntimeXamarin.Samples.IdentifyKmlFeatures
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Identify KML features",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ListKmlContents/ListKmlContents.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ListKmlContents/ListKmlContents.cs
@@ -24,7 +24,7 @@ using ArcGISRuntime;
 
 namespace ArcGISRuntimeXamarin.Samples.ListKmlContents
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "List KML contents",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/LoadWebTiledLayer/LoadWebTiledLayer.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.LoadWebTiledLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Web tiled layer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/MapImageLayerTables/MapImageLayerTables.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/MapImageLayerTables/MapImageLayerTables.cs
@@ -24,7 +24,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.MapImageLayerTables
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Query map image layer tables",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.cs
@@ -22,7 +22,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.MapImageSublayerQuery
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Query a map image sublayer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/OpenStreetMapLayer/OpenStreetMapLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/OpenStreetMapLayer/OpenStreetMapLayer.cs
@@ -15,7 +15,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntimeXamarin.Samples.OpenStreetMapLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "OpenStreetMap layer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/RasterLayerImageServiceRaster/RasterLayerImageServiceRaster.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/RasterLayerImageServiceRaster/RasterLayerImageServiceRaster.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.RasterLayerImageServiceRaster
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS raster layer (service)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.RasterLayerRasterFunction
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS raster function (service)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/RasterRenderingRule/RasterRenderingRule.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/RasterRenderingRule/RasterRenderingRule.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.RasterRenderingRule
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Raster rendering rule",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/SceneLayerSelection/SceneLayerSelection.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/SceneLayerSelection/SceneLayerSelection.cs
@@ -20,7 +20,7 @@ using Esri.ArcGISRuntime.Geometry;
 
 namespace ArcGISRuntime.Samples.SceneLayerSelection
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Scene layer selection",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/SceneLayerUrl/SceneLayerUrl.cs
@@ -17,7 +17,7 @@ using Esri.ArcGISRuntime.Geometry;
 
 namespace ArcGISRuntime.Samples.SceneLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "ArcGIS scene layer (URL)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
@@ -18,7 +18,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Show labels on layer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/StyleWmsLayer/StyleWmsLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/StyleWmsLayer/StyleWmsLayer.cs
@@ -19,7 +19,7 @@ using Esri.ArcGISRuntime.Geometry;
 
 namespace ArcGISRuntime.Samples.StyleWmsLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Style WMS layers",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/TimeBasedQuery/TimeBasedQuery.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/TimeBasedQuery/TimeBasedQuery.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.TimeBasedQuery
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Time-based query",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/WMSLayerUrl/WMSLayerUrl.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/WMSLayerUrl/WMSLayerUrl.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.WMSLayerUrl
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "WMS layer (URL)",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/WMTSLayer/WMTSLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/WMTSLayer/WMTSLayer.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntime.Samples.WMTSLayer
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "WMTS layer",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/WmsIdentify/WmsIdentify.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/WmsIdentify/WmsIdentify.cs
@@ -22,7 +22,7 @@ using Android.Views;
 
 namespace ArcGISRuntime.Samples.WmsIdentify
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Identify WMS features",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.WmsServiceCatalog
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "WMS service catalog",
         "Layers",

--- a/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.DisplayDeviceLocation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display Device Location",
         "Location",

--- a/src/Android/Xamarin.Android/Samples/Map/AccessLoadStatus/AccessLoadStatus.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/AccessLoadStatus/AccessLoadStatus.cs
@@ -16,7 +16,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.AccessLoadStatus
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Access load status",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/ChangeAtmosphereEffect/ChangeAtmosphereEffect.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/ChangeAtmosphereEffect/ChangeAtmosphereEffect.cs
@@ -19,7 +19,7 @@ using Surface = Esri.ArcGISRuntime.Mapping.Surface;
 
 namespace ArcGISRuntimeXamarin.Samples.ChangeAtmosphereEffect
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change atmosphere effect",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/ChangeBasemap/ChangeBasemap.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/ChangeBasemap/ChangeBasemap.cs
@@ -19,7 +19,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ChangeBasemap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change basemap",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/DisplayMap/DisplayMap.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/DisplayMap/DisplayMap.cs
@@ -15,7 +15,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.DisplayMap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display a map",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.cs
@@ -28,7 +28,7 @@ using Xamarin.Auth;
 
 namespace ArcGISRuntime.Samples.GenerateOfflineMap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Generate an offline map",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/ManageOperationalLayers/ManageOperationalLayers.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace ArcGISRuntimeXamarin.Samples.ManageOperationalLayers
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Manage operational layers",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntimeXamarin.Samples.MobileMapSearchAndRoute
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Mobile map (search and route)",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OpenMapURL/OpenMapURL.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.OpenMapURL
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Open map (URL)",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/OpenMobileMap/OpenMobileMap.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OpenMobileMap/OpenMobileMap.cs
@@ -18,7 +18,7 @@ using ArcGISRuntime.Samples.Managers;
 
 namespace ArcGISRuntime.Samples.OpenMobileMap
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
 	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("e1f3a7254cb845b09450f54937c16061")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Open mobile map (map package)",

--- a/src/Android/Xamarin.Android/Samples/Map/OpenScene/OpenScene.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OpenScene/OpenScene.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.OpenScene
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Open scene (Portal item)",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/SearchPortalMaps/SearchPortalMaps.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SearchPortalMaps/SearchPortalMaps.cs
@@ -24,7 +24,7 @@ using Xamarin.Auth;
 
 namespace ArcGISRuntime.Samples.SearchPortalMaps
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Search a portal for maps",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapArea/SetInitialMapArea.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapArea/SetInitialMapArea.cs
@@ -16,7 +16,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.SetInitialMapArea
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Set initial map area",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
@@ -15,7 +15,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.SetInitialMapLocation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Set initial map location",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetMapSpatialReference/SetMapSpatialReference.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.SetMapSpatialReference
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Set map spatial reference",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/SetMinMaxScale/SetMinMaxScale.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetMinMaxScale/SetMinMaxScale.cs
@@ -16,7 +16,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.SetMinMaxScale
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Set min & max scale",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
@@ -17,7 +17,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Terrain exaggeration",
         "Map",

--- a/src/Android/Xamarin.Android/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ChangeTimeExtent/ChangeTimeExtent.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.ChangeTimeExtent
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change time extent",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/ChangeViewpoint/ChangeViewpoint.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ChangeViewpoint/ChangeViewpoint.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.ChangeViewpoint
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Change viewpoint",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -19,7 +19,7 @@ using Android.Views;
 
 namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display drawing status",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/DisplayGrid/DisplayGrid.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/DisplayGrid/DisplayGrid.cs
@@ -20,7 +20,7 @@ using Colors = System.Drawing.Color;
 
 namespace ArcGISRuntime.Samples.DisplayGrid
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display a grid",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/DisplayLayerViewState/DisplayLayerViewState.cs
@@ -17,7 +17,7 @@ using Android.Widget;
 
 namespace ArcGISRuntime.Samples.DisplayLayerViewState
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Display layer view state",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.cs
@@ -19,7 +19,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.FeatureLayerTimeOffset
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer time offset",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/GeoViewSync/GeoViewSync.cs
@@ -16,7 +16,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.GeoViewSync
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.AndroidLayout("GeoViewSync.axml")]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "GeoView viewpoint synchronization",

--- a/src/Android/Xamarin.Android/Samples/MapView/IdentifyLayers/IdentifyLayers.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/IdentifyLayers/IdentifyLayers.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace ArcGISRuntimeXamarin.Samples.IdentifyLayers
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Identify layers",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/MapRotation/MapRotation.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/MapRotation/MapRotation.cs
@@ -16,7 +16,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.MapRotation
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Map rotation",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/ShowCallout/ShowCallout.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ShowCallout/ShowCallout.cs
@@ -17,7 +17,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.ShowCallout
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Show callout",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -15,7 +15,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.ShowMagnifier
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Show magnifier",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/MapView/TakeScreenshot/TakeScreenshot.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/TakeScreenshot/TakeScreenshot.cs
@@ -17,7 +17,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.TakeScreenshot
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Take screenshot",
         "MapView",

--- a/src/Android/Xamarin.Android/Samples/Search/FindAddress/FindAddress.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/FindAddress/FindAddress.cs
@@ -28,7 +28,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.FindAddress
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Find address",
         "Search",

--- a/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
@@ -27,7 +27,7 @@ using Android.Views;
 
 namespace ArcGISRuntime.Samples.FindPlace
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Find place",
         "Search",

--- a/src/Android/Xamarin.Android/Samples/Search/OfflineGeocode/OfflineGeocode.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/OfflineGeocode/OfflineGeocode.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Offline geocode",
         "Search",

--- a/src/Android/Xamarin.Android/Samples/Search/ReverseGeocode/ReverseGeocode.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/ReverseGeocode/ReverseGeocode.cs
@@ -26,7 +26,7 @@ using Android.Views;
 
 namespace ArcGISRuntimeXamarin.Samples.ReverseGeocode
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Reverse geocode",
         "Search",

--- a/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -21,7 +21,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Feature layer extrusion",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.RenderPictureMarkers
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Render picture markers",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/RenderSimpleMarkers/RenderSimpleMarkers.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/RenderSimpleMarkers/RenderSimpleMarkers.cs
@@ -19,7 +19,7 @@ using System.Drawing;
 
 namespace ArcGISRuntime.Samples.RenderSimpleMarkers
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Render simple markers",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/RenderUniqueValues/RenderUniqueValues.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/RenderUniqueValues/RenderUniqueValues.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace ArcGISRuntime.Samples.RenderUniqueValues
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Unique value renderer",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/SceneSymbols/SceneSymbols.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/SceneSymbols/SceneSymbols.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 
 namespace ArcGISRuntimeXamarin.Samples.SceneSymbols
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Scene symbols",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/SimpleRenderers/SimpleRenderers.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/SimpleRenderers/SimpleRenderers.cs
@@ -18,7 +18,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace ArcGISRuntime.Samples.SimpleRenderers
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Simple renderer",
         "Symbology",

--- a/src/Android/Xamarin.Android/Samples/Symbology/UseDistanceCompositeSym/UseDistanceCompositeSym.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/UseDistanceCompositeSym/UseDistanceCompositeSym.cs
@@ -21,7 +21,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Samples.UseDistanceCompositeSym
 {
-    [Activity]
+    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         "Distance composite symbol",
         "Symbology",

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
@@ -9,7 +9,8 @@
             <StackPanel>
                 <TextBlock Text="Terrain exaggeration:" />
                 <Slider x:Name="TerrainSlider"
-                        Minimum="0" Value="1" Maximum="3"/>
+                        Minimum="0" Value="1" Maximum="3"
+                        StepFrequency=".01"/>
             </StackPanel>
         </Border>
     </Grid>


### PR DESCRIPTION
This fixes an issue with the terrain elevation slider in UWP. Previously it was snapping to integer values, where other platforms allowed more fine-grained adjustments. 

Also updates the Android samples to not automatically reload when the device is rotated. 