### PR TITLE
Update KML tour sample to use PCE

### DIFF
--- a/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
+++ b/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
@@ -495,6 +495,9 @@
     <PackageReference Include="Xamarin.Android.Support.Fragment">
       <Version>28.0.0.1</Version>
     </PackageReference>
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Auth">
       <Version>1.6.0.4</Version>
     </PackageReference>    

--- a/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
@@ -170,6 +170,14 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
         // Reset the tour when the button is pressed.
         private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
 
+        protected override void OnStop()
+        {
+            base.OnStop();
+
+            // Reset the tour controller when the sample closes - avoids a crash.
+            _tourController?.Reset();
+        }
+
         private void CreateLayout()
         {
             // Create a new vertical layout for the app.

--- a/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
@@ -17,6 +17,7 @@ using Esri.ArcGISRuntime.Ogc;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Debug = System.Diagnostics.Debug;
 
@@ -81,6 +82,9 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                     throw new InvalidOperationException("No tour found. Can't enable touring for a KML file with no tours.");
                 }
 
+                // Listen for changes to the tour status.
+                _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
+
                 // Enable the play button.
                 _playButton.Enabled = true;
             }
@@ -109,16 +113,15 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                 KmlNode currentNode = nodesToExplore.Dequeue();
 
                 // If the node is a tour, use it.
-                if (currentNode is KmlTour)
+                if (currentNode is KmlTour tourNode)
                 {
-                    _tourController.Tour = (KmlTour) currentNode;
+                    _tourController.Tour = tourNode;
                     return;
                 }
 
                 // If the node is a container, add all of its children to the list of nodes to explore.
-                if (currentNode is KmlContainer)
+                if (currentNode is KmlContainer container)
                 {
-                    KmlContainer container = (KmlContainer) currentNode;
                     foreach (KmlNode node in container.ChildNodes)
                     {
                         nodesToExplore.Enqueue(node);
@@ -129,46 +132,43 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
             }
         }
 
-        private void Play_Clicked(object sender, EventArgs routedEventArgs)
+        private void Tour_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (_tourController != null)
+            // Skip for everything except tour status property changes.
+            if (e.PropertyName != nameof(KmlTour.TourStatus))
             {
-                // Play the tour.
-                _tourController.Play();
+                return;
+            }
 
-                // Configure the UI.
-                _pauseButton.Enabled = true;
-                _playButton.Enabled = false;
-                _resetButton.Enabled = true;
+            // Set the UI based on the current state of the tour.
+            switch (_tourController.Tour.TourStatus)
+            {
+                case KmlTourStatus.Completed:
+                case KmlTourStatus.Initialized:
+                    _playButton.Enabled = true;
+                    _pauseButton.Enabled = false;
+                    break;
+                case KmlTourStatus.Paused:
+                    _playButton.Enabled = true;
+                    _pauseButton.Enabled = false;
+                    _resetButton.Enabled = true;
+                    break;
+                case KmlTourStatus.Playing:
+                    _resetButton.Enabled = true;
+                    _playButton.Enabled = false;
+                    _pauseButton.Enabled = true;
+                    break;
             }
         }
 
-        private void Pause_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Pause the tour.
-                _tourController.Pause();
+        // Play the tour when the button is pressed.
+        private void Play_Clicked(object sender, EventArgs e) => _tourController?.Play();
 
-                // Configure the UI.
-                _playButton.Enabled = true;
-                _pauseButton.Enabled = false;
-            }
-        }
+        // Pause the tour when the button is pressed.
+        private void Pause_Clicked(object sender, EventArgs e) => _tourController?.Pause();
 
-        private void Reset_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Reset the tour.
-                _tourController.Reset();
-
-                // Configure the UI.
-                _playButton.Enabled = true;
-                _pauseButton.Enabled = false;
-                _resetButton.Enabled = false;
-            }
-        }
+        // Reset the tour when the button is pressed.
+        private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
 
         private void CreateLayout()
         {

--- a/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Layers/PlayKmlTours/readme.md
@@ -29,6 +29,8 @@ This sample is graphics intensive and includes audio. Performance may be poor on
 * KmlTourController.Pause()
 * KmlTourController.Reset()
 * KmlTour
+* KmlTour.TourStatus
+* KmlTour.PropertyChanged
 
 ## Offline data
 

--- a/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Ogc;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Xamarin.Forms;
@@ -66,6 +67,9 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                     throw new InvalidOperationException("No tour found. Can't enable touring for a KML file with no tours.");
                 }
 
+                // Listen for changes to the tour status.
+                _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
+
                 // Enable the play button.
                 PlayButton.IsEnabled = true;
 
@@ -97,16 +101,15 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                 KmlNode currentNode = nodesToExplore.Dequeue();
 
                 // If the node is a tour, use it.
-                if (currentNode is KmlTour)
+                if (currentNode is KmlTour tour)
                 {
-                    _tourController.Tour = (KmlTour) currentNode;
+                    _tourController.Tour = tour;
                     return;
                 }
 
                 // If the node is a container, add all of its children to the list of nodes to explore.
-                if (currentNode is KmlContainer)
+                if (currentNode is KmlContainer container)
                 {
-                    KmlContainer container = (KmlContainer) currentNode;
                     foreach (KmlNode node in container.ChildNodes)
                     {
                         nodesToExplore.Enqueue(node);
@@ -117,45 +120,42 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
             }
         }
 
-        private void Play_Clicked(object sender, EventArgs routedEventArgs)
+        private void Tour_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (_tourController != null)
+            // Skip for everything except tour status property changes.
+            if (e.PropertyName != nameof(KmlTour.TourStatus))
             {
-                // Play the tour.
-                _tourController.Play();
+                return;
+            }
 
-                // Configure the UI.
-                PauseButton.IsEnabled = true;
-                PlayButton.IsEnabled = false;
-                ResetButton.IsEnabled = true;
+            // Set the UI based on the current state of the tour.
+            switch (_tourController.Tour.TourStatus)
+            {
+                case KmlTourStatus.Completed:
+                case KmlTourStatus.Initialized:
+                    PlayButton.IsEnabled = true;
+                    PauseButton.IsEnabled = false;
+                    break;
+                case KmlTourStatus.Paused:
+                    PlayButton.IsEnabled = true;
+                    PauseButton.IsEnabled = false;
+                    ResetButton.IsEnabled = true;
+                    break;
+                case KmlTourStatus.Playing:
+                    ResetButton.IsEnabled = true;
+                    PlayButton.IsEnabled = false;
+                    PauseButton.IsEnabled = true;
+                    break;
             }
         }
 
-        private void Pause_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Pause the tour.
-                _tourController.Pause();
+        // Play the tour when the button is pressed.
+        private void Play_Clicked(object sender, EventArgs e) => _tourController?.Play();
 
-                // Configure the UI.
-                PlayButton.IsEnabled = true;
-                PauseButton.IsEnabled = false;
-            }
-        }
+        // Pause the tour when the button is pressed.
+        private void Pause_Clicked(object sender, EventArgs e) => _tourController?.Pause();
 
-        private void Reset_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Reset the tour.
-                _tourController.Reset();
-
-                // Configure the UI.
-                PlayButton.IsEnabled = true;
-                PauseButton.IsEnabled = false;
-                ResetButton.IsEnabled = false;
-            }
-        }
+        // Reset the tour when the button is pressed.
+        private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
     }
 }

--- a/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -70,6 +70,11 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                 // Listen for changes to the tour status.
                 _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
 
+                // Subscribe to notifications about leaving so that the tour can be reset.
+                // This looks different because of sample viewer plumbing.
+                // Replace `((ArcGISRuntime.SamplePage)this.Parent)` with `this` in your app.
+                ((Page)this.Parent).Disappearing += Sample_Unloaded;
+
                 // Enable the play button.
                 PlayButton.IsEnabled = true;
 
@@ -157,5 +162,8 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
 
         // Reset the tour when the button is pressed.
         private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
+
+        // Reset the tour when the user leaves the sample - avoids a crash.
+        private void Sample_Unloaded(object sender, EventArgs e) => _tourController?.Reset();
     }
 }

--- a/src/Forms/Shared/Samples/Layers/PlayKmlTours/readme.md
+++ b/src/Forms/Shared/Samples/Layers/PlayKmlTours/readme.md
@@ -29,6 +29,8 @@ This sample is graphics intensive and includes audio. Performance may be poor on
 * KmlTourController.Pause()
 * KmlTourController.Reset()
 * KmlTour
+* KmlTour.TourStatus
+* KmlTour.PropertyChanged
 
 ## Offline data
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -71,6 +71,9 @@ namespace ArcGISRuntime.UWP.Samples.PlayKmlTours
                 // Listen for changes to the tour status.
                 _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
 
+                // Be notified when the sample is left so that the tour can be reset.
+                this.Unloaded += Sample_Unloaded;
+
                 // Enable the play button.
                 PlayButton.IsEnabled = true;
 
@@ -158,5 +161,8 @@ namespace ArcGISRuntime.UWP.Samples.PlayKmlTours
 
         // Reset the tour when the button is pressed.
         private void Reset_Clicked(object sender, RoutedEventArgs e) => _tourController?.Reset();
+
+        // Reset the tour when the user leaves the sample - avoids a crash.
+        private void Sample_Unloaded(object sender, RoutedEventArgs e) => _tourController?.Reset();
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/PlayKmlTours/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/PlayKmlTours/readme.md
@@ -29,6 +29,8 @@ This sample is graphics intensive and includes audio. Performance may be poor on
 * KmlTourController.Pause()
 * KmlTourController.Reset()
 * KmlTour
+* KmlTour.TourStatus
+* KmlTour.PropertyChanged
 
 ## Offline data
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -11,6 +11,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Ogc;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows;
@@ -66,6 +67,9 @@ namespace ArcGISRuntime.WPF.Samples.PlayKmlTours
                     throw new InvalidOperationException("No tour found. Can't enable touring for a KML file with no tours.");
                 }
 
+                // Listen for changes to the tour status.
+                _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
+
                 // Enable the play button.
                 PlayButton.IsEnabled = true;
 
@@ -97,16 +101,15 @@ namespace ArcGISRuntime.WPF.Samples.PlayKmlTours
                 KmlNode currentNode = nodesToExplore.Dequeue();
 
                 // If the node is a tour, use it.
-                if (currentNode is KmlTour)
+                if (currentNode is KmlTour tourNode)
                 {
-                    _tourController.Tour = (KmlTour) currentNode;
+                    _tourController.Tour = tourNode;
                     return;
                 }
 
                 // If the node is a container, add all of its children to the list of nodes to explore.
-                if (currentNode is KmlContainer)
+                if (currentNode is KmlContainer container)
                 {
-                    KmlContainer container = (KmlContainer) currentNode;
                     foreach (KmlNode node in container.ChildNodes)
                     {
                         nodesToExplore.Enqueue(node);
@@ -117,45 +120,42 @@ namespace ArcGISRuntime.WPF.Samples.PlayKmlTours
             }
         }
 
-        private void Play_Clicked(object sender, EventArgs e)
+        private void Tour_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (_tourController != null)
+            // Skip for everything except tour status property changes.
+            if (e.PropertyName != nameof(KmlTour.TourStatus))
             {
-                // Play the tour.
-                _tourController.Play();
+                return;
+            }
 
-                // Configure the UI.
-                PauseButton.IsEnabled = true;
-                PlayButton.IsEnabled = false;
-                ResetButton.IsEnabled = true;
+            // Set the UI based on the current state of the tour.
+            switch (_tourController.Tour.TourStatus)
+            {
+                case KmlTourStatus.Completed:
+                case KmlTourStatus.Initialized:
+                    PlayButton.IsEnabled = true;
+                    PauseButton.IsEnabled = false;
+                    break;
+                case KmlTourStatus.Paused:
+                    PlayButton.IsEnabled = true;
+                    PauseButton.IsEnabled = false;
+                    ResetButton.IsEnabled = true;
+                    break;
+                case KmlTourStatus.Playing:
+                    ResetButton.IsEnabled = true;
+                    PlayButton.IsEnabled = false;
+                    PauseButton.IsEnabled = true;
+                    break;
             }
         }
 
-        private void Pause_Clicked(object sender, EventArgs e)
-        {
-            if (_tourController != null)
-            {
-                // Pause the tour.
-                _tourController.Pause();
+        // Play the tour when the button is pressed.
+        private void Play_Clicked(object sender, EventArgs e) => _tourController?.Play();
 
-                // Configure the UI.
-                PlayButton.IsEnabled = true;
-                PauseButton.IsEnabled = false;
-            }
-        }
+        // Pause the tour when the button is pressed.
+        private void Pause_Clicked(object sender, EventArgs e) => _tourController?.Pause();
 
-        private void Reset_Clicked(object sender, EventArgs e)
-        {
-            if (_tourController != null)
-            {
-                // Reset the tour.
-                _tourController.Reset();
-
-                // Configure the UI.
-                PlayButton.IsEnabled = true;
-                PauseButton.IsEnabled = false;
-                ResetButton.IsEnabled = false;
-            }
-        }
+        // Reset the tour when the button is pressed.
+        private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -70,6 +70,10 @@ namespace ArcGISRuntime.WPF.Samples.PlayKmlTours
                 // Listen for changes to the tour status.
                 _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
 
+                // Be notified when the sample is left so that the tour can be reset.
+                this.Unloaded += Sample_Unloaded;
+                Application.Current.Exit += Application_Exit;
+
                 // Enable the play button.
                 PlayButton.IsEnabled = true;
 
@@ -157,5 +161,9 @@ namespace ArcGISRuntime.WPF.Samples.PlayKmlTours
 
         // Reset the tour when the button is pressed.
         private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
+
+        // Reset the tour when the user leaves the sample - avoids a crash.
+        private void Sample_Unloaded(object sender, RoutedEventArgs e) => _tourController?.Reset();
+        private void Application_Exit(object sender, ExitEventArgs e) => _tourController?.Reset();
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/PlayKmlTours/readme.md
@@ -29,6 +29,8 @@ This sample is graphics intensive and includes audio. Performance may be poor on
 * KmlTourController.Pause()
 * KmlTourController.Reset()
 * KmlTour
+* KmlTour.TourStatus
+* KmlTour.PropertyChanged
 
 ## Offline data
 

--- a/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
@@ -165,6 +165,14 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
         // Reset the tour when the button is pressed.
         private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
 
+        public override void ViewWillDisappear(bool animated)
+        {
+            base.ViewWillDisappear(animated);
+
+            // Reset the tour controller when the sample closes - avoids a crash.
+            _tourController?.Reset();
+        }
+
         public override void LoadView()
         {
             // Create the views.

--- a/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/PlayKmlTours.cs
@@ -14,6 +14,7 @@ using Esri.ArcGISRuntime.UI.Controls;
 using Foundation;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using UIKit;
 
@@ -74,6 +75,9 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                     throw new InvalidOperationException("No tour found. Can't enable touring for a KML file with no tours.");
                 }
 
+                // Listen for changes to the tour status.
+                _tourController.Tour.PropertyChanged += Tour_PropertyChanged;
+
                 // Enable the play button.
                 _playButton.Enabled = true;
 
@@ -104,16 +108,15 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
                 KmlNode currentNode = nodesToExplore.Dequeue();
 
                 // If the node is a tour, use it.
-                if (currentNode is KmlTour)
+                if (currentNode is KmlTour tourNode)
                 {
-                    _tourController.Tour = (KmlTour) currentNode;
+                    _tourController.Tour = tourNode;
                     return;
                 }
 
                 // If the node is a container, add all of its children to the list of nodes to explore.
-                if (currentNode is KmlContainer)
+                if (currentNode is KmlContainer container)
                 {
-                    KmlContainer container = (KmlContainer) currentNode;
                     foreach (KmlNode node in container.ChildNodes)
                     {
                         nodesToExplore.Enqueue(node);
@@ -124,46 +127,43 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
             }
         }
 
-        private void Play_Clicked(object sender, EventArgs routedEventArgs)
+        private void Tour_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (_tourController != null)
+            // Skip for everything except tour status property changes.
+            if (e.PropertyName != nameof(KmlTour.TourStatus))
             {
-                // Play the tour.
-                _tourController.Play();
+                return;
+            }
 
-                // Configure the UI.
-                _pauseButton.Enabled = true;
-                _playButton.Enabled = false;
-                _resetButton.Enabled = true;
+            // Set the UI based on the current state of the tour.
+            switch (_tourController.Tour.TourStatus)
+            {
+                case KmlTourStatus.Completed:
+                case KmlTourStatus.Initialized:
+                    _playButton.Enabled = true;
+                    _pauseButton.Enabled = false;
+                    break;
+                case KmlTourStatus.Paused:
+                    _playButton.Enabled = true;
+                    _pauseButton.Enabled = false;
+                    _resetButton.Enabled = true;
+                    break;
+                case KmlTourStatus.Playing:
+                    _resetButton.Enabled = true;
+                    _playButton.Enabled = false;
+                    _pauseButton.Enabled = true;
+                    break;
             }
         }
 
-        private void Pause_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Pause the tour.
-                _tourController.Pause();
+        // Play the tour when the button is pressed.
+        private void Play_Clicked(object sender, EventArgs e) => _tourController?.Play();
 
-                // Configure the UI.
-                _playButton.Enabled = true;
-                _pauseButton.Enabled = false;
-            }
-        }
+        // Pause the tour when the button is pressed.
+        private void Pause_Clicked(object sender, EventArgs e) => _tourController?.Pause();
 
-        private void Reset_Clicked(object sender, EventArgs routedEventArgs)
-        {
-            if (_tourController != null)
-            {
-                // Reset the tour.
-                _tourController.Reset();
-
-                // Configure the UI.
-                _playButton.Enabled = true;
-                _pauseButton.Enabled = false;
-                _resetButton.Enabled = false;
-            }
-        }
+        // Reset the tour when the button is pressed.
+        private void Reset_Clicked(object sender, EventArgs e) => _tourController?.Reset();
 
         public override void LoadView()
         {

--- a/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/PlayKmlTours/readme.md
@@ -29,6 +29,8 @@ This sample is graphics intensive and includes audio. Performance may be poor on
 * KmlTourController.Pause()
 * KmlTourController.Reset()
 * KmlTour
+* KmlTour.TourStatus
+* KmlTour.PropertyChanged
 
 ## Offline data
 


### PR DESCRIPTION
I had missed the KmlTour.TourStatus property. Using PropertyChanged event, it is possible to detect changes to the tour status, which enables updating the UI when the tour completes.

Two other changes:
* Changed some code to use a new pattern `if (node is KmlContainer container)` which saves a line and hopefully makes the intent clearer.
* Added an Android package reference. I believe this should have done in a previous PR, but possibly due to some caching/partial build issue I didn't see the error previously. 