### PR TITLE
Update terrain exaggeration minimums

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
@@ -63,7 +63,8 @@ namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
             // Update terrain exaggeration based on the slider value.
             _terrainSlider.ProgressChanged += (sender, e) =>
             {
-                elevationSurface.ElevationExaggeration = _terrainSlider.Progress;
+                // Values are scaled to enable smoother animation - Android Seekbar has a course step size.
+                elevationSurface.ElevationExaggeration = 1 + _terrainSlider.Progress / 20.0;
             };
         }
 
@@ -75,7 +76,7 @@ namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
             // Create the views.
             _mySceneView = new SceneView();
             _terrainSlider = new SeekBar(this);
-            _terrainSlider.Max = 3;
+            _terrainSlider.Max = 20;
 
             TextView terrainLabel = new TextView(this);
             terrainLabel.Text = "Terrain exaggeration:";

--- a/src/Forms/Shared/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
+++ b/src/Forms/Shared/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
@@ -10,7 +10,7 @@
             <StackLayout>
                 <Label Text="Terrain exaggeration:" Style="{StaticResource LabelStyle}" />
                 <Slider x:Name="TerrainSlider" 
-                        Minimum="0" Value="1" Maximum="3"
+                        Maximum="3" Minimum="1" Value="1"
                         BackgroundColor="Black" />
             </StackLayout>
         </resources:ResponsiveFormContainer>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
@@ -9,7 +9,7 @@
             <StackPanel>
                 <TextBlock Text="Terrain exaggeration:" />
                 <Slider x:Name="TerrainSlider"
-                        Minimum="0" Value="1" Maximum="3"
+                        Minimum="1" Value="1" Maximum="3"
                         StepFrequency=".01"/>
             </StackPanel>
         </Border>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/TerrainExaggeration/TerrainExaggeration.xaml
@@ -8,7 +8,7 @@
             <StackPanel>
                 <Label Content="Terrain exaggeration:" />
                 <Slider x:Name="TerrainSlider"
-                        Minimum="0" Value="1" Maximum="3" 
+                        Minimum="1" Value="1" Maximum="3" 
                         AutoToolTipPlacement="TopLeft" AutoToolTipPrecision="2" />
             </StackPanel>
         </Border>

--- a/src/iOS/Xamarin.iOS/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/TerrainExaggeration/TerrainExaggeration.cs
@@ -70,6 +70,7 @@ namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
 
             _terrainSlider = new UISlider();
             _terrainSlider.TranslatesAutoresizingMaskIntoConstraints = false;
+            _terrainSlider.MinValue = 1;
             _terrainSlider.MaxValue = 3;
 
             UIToolbar toolbar = new UIToolbar();


### PR DESCRIPTION
There was a change to the design of the sample. The new minimum value for the terrain exaggeration slider is `1` at v100.5. 