### PR TITLE
An example of how to do some telemetry in the WPF Sample app using AppInsights.

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/App.config
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/App.config
@@ -3,6 +3,9 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+  <appSettings>    
+    <add key="InstrumentationKey" value="__AppInsightsKey__" />
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/App.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/App.xaml.cs
@@ -15,6 +15,13 @@ namespace ArcGISRuntime.WPF.Viewer
 {
     public partial class App
     {
+        public App()
+        {
+#if TELEMETRY
+            Telemetry.DiagnosticsClient.Initialize();
+#endif
+        }
+
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             try

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ApplicationInsights.config
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ApplicationInsights.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
+  <TelemetryInitializers>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.DeviceTelemetryInitializer, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.SessionTelemetryInitializer, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.VersionTelemetryInitializer, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.GraphicsTelemetryInitializer, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.WTSSessionTelemetryInitializer, AppInsights.WindowsDesktop"/>
+  </TelemetryInitializers>
+  <TelemetryModules>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.DeveloperModeWithDebuggerAttachedTelemetryModule, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.UnhandledExceptionTelemetryModule, AppInsights.WindowsDesktop"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.UnobservedExceptionTelemetryModule, AppInsights.WindowsDesktop" />    
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.WTSSessionTelemetryModule, AppInsights.WindowsDesktop" />
+    <Add Type="Microsoft.ApplicationInsights.WindowsDesktop.GraphicsTelemetryModule, AppInsights.WindowsDesktop" />
+  </TelemetryModules>
+  <TelemetryProcessors>
+    <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
+  </TelemetryProcessors>
+  <TelemetryChannel Type="Microsoft.ApplicationInsights.Channel.PersistenceChannel, AppInsights.WindowsDesktop"/>
+</ApplicationInsights>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -20,6 +20,9 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AppInsightsKey)'!=''">
+     <EnableAppTelemetry>true</EnableAppTelemetry>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
@@ -42,12 +45,16 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
+  <PropertyGroup  Condition="'$(EnableAppTelemetry)'=='true'">
+    <DefineConstants>$(DefineConstants);TELEMETRY</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Assets\ApplicationIcons\windows-desktop-256.ico</ApplicationIcon>
   </PropertyGroup>
   <!-- References -->
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
@@ -1913,6 +1920,15 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+  </ItemGroup>
+  <ItemGroup Condition="'$(EnableAppTelemetry)'=='true'">
+    <Compile Include="Telemetry\*.cs" />
+    <Content Include="ApplicationInsights.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <PackageReference Include="AppInsights.WindowsDesktop">
+      <Version>2.10.37-preview</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Hydrography">

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/MainWindow.xaml.cs
@@ -85,6 +85,9 @@ namespace ArcGISRuntime.Samples.Desktop
         private async Task SelectSample(SampleInfo selectedSample)
         {
             if (selectedSample == null) return;
+#if TELEMETRY
+            WPF.Viewer.Telemetry.DiagnosticsClient.TrackPageView(selectedSample.SampleType.FullName);
+#endif
 
             SampleManager.Current.SelectedSample = selectedSample;
             DescriptionContainer.SetSample(selectedSample);
@@ -105,12 +108,18 @@ namespace ArcGISRuntime.Samples.Desktop
 
                 // Show the sample
                 SampleContainer.Content = SampleManager.Current.SampleToControl(selectedSample);
+#if TELEMETRY
+                WPF.Viewer.Telemetry.DiagnosticsClient.TrackEvent($"{selectedSample.SampleType.FullName} loaded");
+#endif
                 SourceCodeContainer.LoadSourceCode();
             }
             catch (Exception exception)
             {
                 // failed to create new instance of the sample
                 SampleContainer.Content = new WPF.Viewer.ErrorPage(exception);
+#if TELEMETRY
+                WPF.Viewer.Telemetry.DiagnosticsClient.Notify(exception, new Dictionary<string, string>() { { "Sample", selectedSample.SampleType.FullName } });
+#endif
             }
             CategoriesRegion.Visibility = Visibility.Collapsed;
             SampleContainer.Visibility = Visibility.Visible;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Telemetry/DiagnosticsClient.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Telemetry/DiagnosticsClient.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace ArcGISRuntime.WPF.Viewer.Telemetry
+{
+    public static class DiagnosticsClient
+    {
+        private static bool _initialized;
+        private static TelemetryClient _client;
+
+        public static void Initialize()
+        {
+            var apiKey = System.Configuration.ConfigurationManager.AppSettings["InstrumentationKey"];
+
+            if (!string.IsNullOrEmpty(apiKey) && apiKey != "__AppInsightsKey__")
+            {
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                {
+                    TelemetryConfiguration.Active.InstrumentationKey = apiKey;
+                    TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = Debugger.IsAttached;
+                    _initialized = true;
+                    _client = new TelemetryClient();
+                    System.Windows.Application.Current.Startup += Application_Startup;
+                    System.Windows.Application.Current.Exit += Application_Exit;
+                }
+            }
+        }
+
+        private static void Application_Exit(object sender, System.Windows.ExitEventArgs e)
+        {
+            TrackEvent("AppExit");
+            _client.Flush();
+            // Allow time for flushing:
+            System.Threading.Thread.Sleep(1000);
+        }
+
+        private static void Application_Startup(object sender, System.Windows.StartupEventArgs e)
+        {
+            TrackEvent("AppStart", new Dictionary<string, string> { { "launchType", e.Args.Length > 0 ? "fileAssociation" : "shortcut" } });
+        }
+
+        public static void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+        {
+            if (!_initialized) return;
+            _client.TrackEvent(eventName, properties, metrics);
+        }
+
+        public static void TrackTrace(string evt)
+        {
+            if (!_initialized) return;
+            _client.TrackTrace(evt);
+        }
+
+        public static void Notify(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+        {
+            if (!_initialized) return;
+            _client.TrackException(exception, properties, metrics);
+        }
+
+        public static void TrackPageView(string pageName)
+        {
+            if (!_initialized) return;
+            _client.TrackPageView(pageName);
+        }
+    }
+}


### PR DESCRIPTION
This tracks all samples that gets loaded in what order, and a few key system metrics (like graphics card/driver, OS/Framework versions, remote desktop etc) that have been known to cause various rendering problems.

To enable this, declare an msbuild variable `AppInsightsKey` that matches the app insights app center key, and either manually update the key in App.config, or use a build-script in the CI build to do it.
Without any of this, the user won't see any difference to the app (we don't want telemetry from locally modified apps, as this could provide false positives)

For instance in Azure Pipelines, it can be done like this: https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/blob/3e083f4e541dc71ee9a4fe68c492ef3af07dc52b/azure-pipelines.yml#L73-L76
The variable is then secretly declared in the Azure Pipeline and stays internal.

![image](https://user-images.githubusercontent.com/1378165/56071940-e30ec280-5d46-11e9-92a2-62971c4205a3.png)

Thanks to @onovotny for the steps to do this.

Note: There's some definite to-do's here, most importantly we need a way for users to opt in/out of this in the settings page, the first run of the app should ask users for permission, and a privacy policy should be included. Therefore this is more a draft/proof-of-concept.