### PR TITLE
Updated the ReadMes for the IWA security samples

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Security/IntegratedWindowsAuth/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Security/IntegratedWindowsAuth/readme.md
@@ -4,6 +4,8 @@ This sample illustrates the use of Windows credentials to access services hosted
 When accessing an item secured with IWA from a WPF app, default credentials (the current user's login) are sent to the portal. 
 Platforms such as Android, iOS, and Universal Windows Platform (UWP) require credentials to be entered explicitly.
 
+See [Use the Authentication Manager](https://developers.arcgis.com/net/latest/android/guide/use-the-authentication-manager.htm) in the developers guide for more information.
+
 <image src="IntegratedWindowsAuth.jpg"/>     
 
      

--- a/src/Forms/Shared/Samples/Security/IntegratedWindowsAuth/readme.md
+++ b/src/Forms/Shared/Samples/Security/IntegratedWindowsAuth/readme.md
@@ -4,6 +4,8 @@ This sample illustrates the use of Windows credentials to access services hosted
 When accessing an item secured with IWA from a WPF app, default credentials (the current user's login) are sent to the portal. 
 Platforms such as Android, iOS, and Universal Windows Platform (UWP) require credentials to be entered explicitly.
 
+See [Use the Authentication Manager](https://developers.arcgis.com/net/latest/forms/guide/use-the-authentication-manager.htm) in the developers guide for more information.
+
 <img src="IntegratedWindowsAuth.jpg"/>    
 
      

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Security/IntegratedWindowsAuth/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Security/IntegratedWindowsAuth/readme.md
@@ -4,6 +4,8 @@ This sample illustrates the use of Windows credentials to access services hosted
 When accessing an item secured with IWA from a WPF app, default credentials (the current user's login) are sent to the portal. 
 Platforms such as Android, iOS, and Universal Windows Platform (UWP) require credentials to be entered explicitly.
 
+See [Use the Authentication Manager](https://developers.arcgis.com/net/latest/uwp/guide/use-the-authentication-manager.htm) in the developers guide for more information.
+
 <img src="IntegratedWindowsAuth.jpg"/>    
 
      

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Security/IntegratedWindowsAuth/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Security/IntegratedWindowsAuth/readme.md
@@ -1,8 +1,13 @@
 ## Integrated Windows Authentication
 
 This sample illustrates the use of Windows credentials to access services hosted on a portal secured with Integrated Windows Authentication (IWA).
-When accessing an item secured with IWA from a WPF app, default credentials (the current user's login) are sent to the portal. 
+When accessing resources secured with IWA from a WPF app, default credentials (the current user's username and password) are sent to the portal. 
+Assuming the user has access, such an app requires no additional authentication code and secure portal resources can be accessed without
+the user being prompted to sign in. For the sake of illustration, this sample shows how to prompt for a username, password, and domain in order to 
+explicitly create an `ArcGISNetworkCredential`.
 Platforms such as Android, iOS, and Universal Windows Platform (UWP) require credentials to be entered explicitly.
+
+See [Use the Authentication Manager](https://developers.arcgis.com/net/latest/wpf/guide/use-the-authentication-manager.htm) in the developers guide for more information.
 
 <img src="IntegratedWindowsAuth.jpg"/>    
 

--- a/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/readme.md
@@ -4,6 +4,8 @@ This sample illustrates the use of Windows credentials to access services hosted
 When accessing an item secured with IWA from a WPF app, default credentials (the current user's login) are sent to the portal. 
 Platforms such as Android, iOS, and Universal Windows Platform (UWP) require credentials to be entered explicitly.
 
+See [Use the Authentication Manager](https://developers.arcgis.com/net/latest/ios/guide/use-the-authentication-manager.htm) in the developers guide for more information.
+
 <img src="IntegratedWindowsAuth.jpg"/>     
 
      


### PR DESCRIPTION
 - Added info for the WPF sample to be clear that IWA auth generally works without additional auth code (for authenticated Windows users). 
 - Added a link to the [Authentication Manager topic](https://developers.arcgis.com/net/latest/wpf/guide/use-the-authentication-manager.htm) in the guide for all platforms.

@nCastle1 - can you please review when you have a chance?