### PR TITLE
Fix DisplayAlert in Forms

### DIFF
--- a/src/Forms/Shared/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
+++ b/src/Forms/Shared/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
@@ -139,7 +139,7 @@ namespace ArcGISRuntime.Samples.LineOfSightGeoElement
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
+++ b/src/Forms/Shared/Samples/Analysis/QueryFeatureCountAndExtent/QueryFeatureCountAndExtent.xaml.cs
@@ -62,7 +62,7 @@ namespace ArcGISRuntime.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -93,7 +93,7 @@ namespace ArcGISRuntime.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -120,7 +120,7 @@ namespace ArcGISRuntime.Samples.QueryFeatureCountAndExtent
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
+++ b/src/Forms/Shared/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
@@ -139,7 +139,7 @@ namespace ArcGISRuntime.Samples.ViewshedGeoElement
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/AddFeatures/AddFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/AddFeatures/AddFeatures.xaml.cs
@@ -81,11 +81,11 @@ namespace ArcGISRuntimeXamarin.Samples.AddFeatures
                 feature.Refresh();
 
                 // Confirm feature addition.
-                await ((Page) Parent).DisplayAlert("Success!", $"Created feature {feature.Attributes["objectid"]}", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", $"Created feature {feature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error adding feature", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error adding feature", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/DeleteFeatures/DeleteFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/DeleteFeatures/DeleteFeatures.xaml.cs
@@ -96,7 +96,7 @@ namespace ArcGISRuntimeXamarin.Samples.DeleteFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -130,11 +130,11 @@ namespace ArcGISRuntimeXamarin.Samples.DeleteFeatures
                 await serviceTable.ApplyEditsAsync();
 
                 // Show a message confirming the deletion.
-                await ((Page)Parent).DisplayAlert("Success!", $"Deleted feature with ID {_tappedFeature.Attributes["objectid"]}", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", $"Deleted feature with ID {_tappedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditAndSyncFeatures/EditAndSyncFeatures.xaml.cs
@@ -136,7 +136,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -232,7 +232,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -378,7 +378,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
                 }
 
                 // Show the message.
-                ((Page)Parent).DisplayAlert("Error", message, "OK");
+                Application.Current.MainPage.DisplayAlert("Error", message, "OK");
             }
         }
 
@@ -443,7 +443,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             // Tell the user about job completion.
             if (job.Status == JobStatus.Succeeded)
             {
-                ((Page)Parent).DisplayAlert("Alert", "Geodatabase synchronization succeeded.", "OK");
+                Application.Current.MainPage.DisplayAlert("Alert", "Geodatabase synchronization succeeded.", "OK");
             }
             // See if the job failed.
             else if (job.Status == JobStatus.Failed)
@@ -467,7 +467,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
                 }
 
                 // Show the message.
-               ((Page)Parent).DisplayAlert("Error", message, "OK");
+               Application.Current.MainPage.DisplayAlert("Error", message, "OK");
             }
         }
 
@@ -486,7 +486,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -516,7 +516,7 @@ namespace ArcGISRuntime.Samples.EditAndSyncFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Alert", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -113,7 +113,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error selecting feature", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error selecting feature", ex.ToString(), "OK");
             }
         }
 
@@ -158,7 +158,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
 
                 if (!fileData.FileName.EndsWith(".jpg") && !fileData.FileName.EndsWith(".jpeg"))
                 {
-                    await ((Page) Parent).DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Try again!", "This sample only allows uploading jpg files.", "OK");
                     return;
                 }
 
@@ -179,11 +179,11 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 _selectedFeature.Refresh();
                 AttachmentsListBox.ItemsSource = await _selectedFeature.GetAttachmentsAsync();
 
-                await ((Page) Parent).DisplayAlert("Success!", "Successfully added attachment", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", "Successfully added attachment", "OK");
             }
             catch (Exception exception)
             {
-                await ((Page) Parent).DisplayAlert("Error adding attachment", exception.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error adding attachment", exception.ToString(), "OK");
             }
             finally
             {
@@ -217,11 +217,11 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 AttachmentsListBox.ItemsSource = await _selectedFeature.GetAttachmentsAsync();
 
                 // Show success message.
-                await ((Page) Parent).DisplayAlert("Success!", "Successfully deleted attachment", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", "Successfully deleted attachment", "OK");
             }
             catch (Exception exception)
             {
-                await ((Page) Parent).DisplayAlert("Error deleting attachment", exception.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error deleting attachment", exception.ToString(), "OK");
             }
             finally
             {
@@ -252,12 +252,12 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 }
                 else
                 {
-                    await ((Page) Parent).DisplayAlert("Can't show attachment", "This sample can only show image attachments.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Can't show attachment", "This sample can only show image attachments.", "OK");
                 }
             }
             catch (Exception exception)
             {
-                await ((Page) Parent).DisplayAlert("Error reading attachment", exception.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error reading attachment", exception.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeoPackage
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.xaml.cs
@@ -62,7 +62,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeodatabase
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerQuery/FeatureLayerQuery.xaml.cs
@@ -131,12 +131,12 @@ namespace ArcGISRuntime.Samples.FeatureLayerQuery
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("State Not Found!", "Add a valid state name.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("State Not Found!", "Add a valid state name.", "OK");
                 }
             }
             catch (Exception)
             {
-                await ((Page)Parent).DisplayAlert("Sample error", "An error occurred", "OK");
+                await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred", "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/FeatureLayerShapefile/FeatureLayerShapefile.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerShapefile/FeatureLayerShapefile.xaml.cs
@@ -56,7 +56,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerShapefile
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
@@ -114,7 +114,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -244,7 +244,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
                     message += ": " + String.Join("\n", job.Messages.Select(m => m.Message));
                 }
 
-                await ((Page)Parent).DisplayAlert("Alert", message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", message, "OK");
             }
         }
 
@@ -263,7 +263,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.xaml.cs
@@ -221,7 +221,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
                 await _gdbSyncTask.UnregisterGeodatabaseAsync(resultGdb);
 
                 // Tell the user that the geodatabase was unregistered.
-                await ((Page)Parent).DisplayAlert("Alert", "Since no edits will be made, the local geodatabase has been unregistered per best practice.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", "Since no edits will be made, the local geodatabase has been unregistered per best practice.", "OK");
 
                 // Re-enable generate button.
                 myGenerateButton.IsEnabled = true;

--- a/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -130,7 +130,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 // Show a message for the exception encountered
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    ((Page)Parent).DisplayAlert("Generate Geodatabase","Unable to create offline database: " + ex.Message,"OK");
+                    Application.Current.MainPage.DisplayAlert("Generate Geodatabase","Unable to create offline database: " + ex.Message,"OK");
                 });
             }
         }
@@ -166,7 +166,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 }
                 catch (Exception e)
                 {
-                    await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
                 }
             }
 
@@ -321,7 +321,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
             // Warn the user if disabling transactions while a transaction is active
             if (!mustHaveTransaction && _localGeodatabase.IsInTransaction)
             {
-                ((Page)Parent).DisplayAlert("Stop editing to end the current transaction.", "Current Transaction", "OK");
+                Application.Current.MainPage.DisplayAlert("Stop editing to end the current transaction.", "Current Transaction", "OK");
                 RequireTransactionCheckBox.IsToggled = true;
                 return;
             }

--- a/src/Forms/Shared/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ListRelatedFeatures/ListRelatedFeatures.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGISRuntime.Samples.ListRelatedFeatures
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -132,7 +132,7 @@ namespace ArcGISRuntime.Samples.ListRelatedFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/RasterLayerGeoPackage/RasterLayerGeoPackage.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGISRuntime.Samples.RasterLayerGeoPackage
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -76,7 +76,7 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ReadShapefileMetadata/ReadShapefileMetadata.xaml.cs
@@ -86,7 +86,7 @@ namespace ArcGISRuntime.Samples.ReadShapefileMetadata
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/ServiceFeatureTableManualCache.xaml.cs
@@ -89,7 +89,7 @@ namespace ArcGISRuntime.Samples.ServiceFeatureTableManualCache
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/StatisticalQuery/StatisticalQuery.xaml.cs
@@ -114,7 +114,7 @@ namespace ArcGISRuntime.Samples.StatisticalQuery
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
@@ -250,7 +250,7 @@ namespace ArcGISRuntime.Samples.StatsQueryGroupAndSort
             string selectedFieldName = GroupFieldsListBox.SelectedItem.ToString();
             if (!_groupByFields.Contains(selectedFieldName))
             {
-                ((Page)Parent).DisplayAlert("Only fields used for grouping can be used to order results.", "Query", "OK");
+                Application.Current.MainPage.DisplayAlert("Only fields used for grouping can be used to order results.", "Query", "OK");
                 return;
             }
 

--- a/src/Forms/Shared/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/StatsQueryGroupAndSort/StatsQueryGroupAndSort.xaml.cs
@@ -72,7 +72,7 @@ namespace ArcGISRuntime.Samples.StatsQueryGroupAndSort
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -82,7 +82,7 @@ namespace ArcGISRuntime.Samples.StatsQueryGroupAndSort
             // Verify that there is at least one statistic definition
             if (!_statDefinitions.Any())
             {
-                await ((Page)Parent).DisplayAlert("Please define at least one statistic for the query.", "Statistical Query","OK");
+                await Application.Current.MainPage.DisplayAlert("Please define at least one statistic for the query.", "Statistical Query","OK");
                 return;
             }
 
@@ -138,7 +138,7 @@ namespace ArcGISRuntime.Samples.StatsQueryGroupAndSort
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }        
 

--- a/src/Forms/Shared/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/SymbolizeShapefile/SymbolizeShapefile.xaml.cs
@@ -89,7 +89,7 @@ namespace ArcGISRuntime.Samples.SymbolizeShapefile
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Data/UpdateAttributes/UpdateAttributes.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/UpdateAttributes/UpdateAttributes.xaml.cs
@@ -116,7 +116,7 @@ namespace ArcGISRuntimeXamarin.Samples.UpdateAttributes
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error selecting feature.", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error selecting feature.", ex.ToString(), "OK");
             }
         }
 
@@ -160,11 +160,11 @@ namespace ArcGISRuntimeXamarin.Samples.UpdateAttributes
                 ServiceFeatureTable table = (ServiceFeatureTable) _selectedFeature.FeatureTable;
                 await table.ApplyEditsAsync();
 
-                await ((Page)Parent).DisplayAlert("Success!", $"Edited feature {_selectedFeature.Attributes["objectid"]}", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", $"Edited feature {_selectedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Failed to edit feature", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Failed to edit feature", ex.ToString(), "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Data/UpdateGeometries/UpdateGeometries.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/UpdateGeometries/UpdateGeometries.xaml.cs
@@ -96,11 +96,11 @@ namespace ArcGISRuntimeXamarin.Samples.UpdateGeometries
                 // Push the update to the service.
                 ServiceFeatureTable serviceTable = (ServiceFeatureTable) _selectedFeature.FeatureTable;
                 await serviceTable.ApplyEditsAsync();
-                await ((Page) Parent).DisplayAlert("Success!", $"Moved feature {_selectedFeature.Attributes["objectid"]}", "OK");
+                await Application.Current.MainPage.DisplayAlert("Success!", $"Moved feature {_selectedFeature.Attributes["objectid"]}", "OK");
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error when moving feature", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error when moving feature", ex.ToString(), "OK");
             }
             finally
             {
@@ -131,7 +131,7 @@ namespace ArcGISRuntimeXamarin.Samples.UpdateGeometries
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Problem selecting feature", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Problem selecting feature", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml.cs
@@ -119,7 +119,7 @@ namespace ArcGISRuntime.Samples.Buffer
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem generating the buffers.
-                await ((Page)Parent).DisplayAlert("Error creating buffers", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error creating buffers", ex.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Geometry/ClipGeometry/ClipGeometry.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/ClipGeometry/ClipGeometry.xaml.cs
@@ -200,7 +200,7 @@ namespace ArcGISRuntime.Samples.ClipGeometry
             catch (Exception ex)
             {
                 // Display an error message if there is a problem generating clip operation.
-                ((Page)Parent).DisplayAlert("Geometry Engine Failed", "Error performing clip: " + ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error performing clip: " + ex.Message, "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -94,7 +94,7 @@ namespace ArcGISRuntime.Samples.ConvexHull
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem adding user tapped graphics.
-                ((Page)Parent).DisplayAlert("Error", "Can't add user tapped graphic: " + ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Error", "Can't add user tapped graphic: " + ex.Message, "OK");
             }
         }
 
@@ -136,7 +136,7 @@ namespace ArcGISRuntime.Samples.ConvexHull
             catch (System.Exception ex)
             {
                 // Display an error message if there is a problem generating convex hull operation.
-                ((Page)Parent).DisplayAlert("Geometry Engine Failed", "Error performing convex hull: " + ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error performing convex hull: " + ex.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/ConvexHullList/ConvexHullList.xaml.cs
@@ -190,7 +190,7 @@ namespace ArcGISRuntime.Samples.ConvexHullList
             catch (Exception ex)
             {
                 // Display an error message if there is a problem generating convex hull operation.
-                ((Page)Parent).DisplayAlert("Geometry Engine Failed", "Error creating convex hull: " + ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error creating convex hull: " + ex.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Geometry/CutGeometry/CutGeometry.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/CutGeometry/CutGeometry.xaml.cs
@@ -114,7 +114,7 @@ namespace ArcGISRuntime.Samples.CutGeometry
             catch (Exception ex)
             {
                 // Display an error message if there is a problem generating cut operation.
-                ((Page)Parent).DisplayAlert("Geometry Engine Failed", "Error performing cut: " + ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Geometry Engine Failed", "Error performing cut: " + ex.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -167,7 +167,7 @@ namespace ArcGISRuntime.Samples.FormatCoordinates
             catch (Exception ex)
             {
                 // The coordinate is malformed, warn and return
-                ((Page)Parent).DisplayAlert("Invalid Format", ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Invalid Format", ex.Message, "OK");
                 return;
             }
 

--- a/src/Forms/Shared/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/ListTransformations/ListTransformations.xaml.cs
@@ -102,7 +102,7 @@ namespace ArcGISRuntime.Samples.ListTransformations
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/SpatialRelationships/SpatialRelationships.xaml.cs
@@ -119,7 +119,7 @@ namespace ArcGISRuntime.Samples.SpatialRelationships
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
 
             // Return if there are no results

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntime.Samples.AnalyzeHotspots
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -71,7 +71,7 @@ namespace ArcGISRuntime.Samples.AnalyzeHotspots
             if (EndDate.Date <= StartDate.Date.AddDays(1))
             {
                 // Show error message
-                await ((Page)Parent).DisplayAlert("Invalid date range", "Please select valid time range. There has to be at least one day in between To and From dates.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Invalid date range", "Please select valid time range. There has to be at least one day in between To and From dates.", "OK");
 
                 // Remove the busy activity indication
                 MyActivityIndicator.IsRunning = false;
@@ -114,11 +114,11 @@ namespace ArcGISRuntime.Samples.AnalyzeHotspots
                 // Display error messages if the geoprocessing task fails
                 if (_hotspotJob.Status == JobStatus.Failed && _hotspotJob.Error != null)
                 {
-                    await ((Page)Parent).DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + _hotspotJob.Error.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + _hotspotJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -90,7 +90,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -150,11 +150,11 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
                 // Display an error message if there is a problem
                 if (myViewshedJob.Status == JobStatus.Failed && myViewshedJob.Error != null)
                 {
-                    await ((Page)Parent).DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + myViewshedJob.Error.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + myViewshedJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/Forms/Shared/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/ListGeodatabaseVersions/ListGeodatabaseVersions.xaml.cs
@@ -78,7 +78,7 @@ namespace ArcGISRuntime.Samples.ListGeodatabaseVersions
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
 
             // Set the UI to indicate that the geoprocessing is not running
@@ -114,11 +114,11 @@ namespace ArcGISRuntime.Samples.ListGeodatabaseVersions
                 // Error handling if something goes wrong
                 if (listVersionsJob.Status == JobStatus.Failed && listVersionsJob.Error != null)
                 {
-                    await ((Page)Parent).DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + listVersionsJob.Error.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + listVersionsJob.Error.Message, "OK");
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
+                    await Application.Current.MainPage.DisplayAlert("Sample error", "An error occurred. " + ex.ToString(), "OK");
                 }
             }
             finally

--- a/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/Animate3DGraphic/Animate3DGraphic.xaml.cs
@@ -174,7 +174,7 @@ namespace ArcGISRuntime.Samples.Animate3DGraphic
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntimeXamarin.Samples.DictionaryRendererGraphicsOverlay
             catch (Exception e)
             {
                 Console.WriteLine(e);
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/IdentifyGraphics/IdentifyGraphics.xaml.cs
@@ -101,13 +101,13 @@ namespace ArcGISRuntime.Samples.IdentifyGraphics
                 {
                     // Make sure that the UI changes are done in the UI thread
                     Device.BeginInvokeOnMainThread(async () => {
-                        await ((Page)Parent).DisplayAlert("", "Tapped on graphic", "OK");
+                        await Application.Current.MainPage.DisplayAlert("", "Tapped on graphic", "OK");
                     });
                 }
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -170,7 +170,7 @@ namespace ArcGISRuntime.Samples.SketchOnMap
             catch (Exception ex)
             {
                 // Report exceptions
-                await ((Page)Parent).DisplayAlert("Error", "Error drawing graphic shape: " + ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Error drawing graphic shape: " + ex.Message, "OK");
             }
         }
 
@@ -214,7 +214,7 @@ namespace ArcGISRuntime.Samples.SketchOnMap
             catch (Exception ex)
             {
                 // Report exceptions
-                await ((Page)Parent).DisplayAlert("Error", "Error editing shape: " + ex.Message,"OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Error editing shape: " + ex.Message,"OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
+++ b/src/Forms/Shared/Samples/Hydrography/AddEncExchangeSet/AddEncExchangeSet.xaml.cs
@@ -77,7 +77,7 @@ namespace ArcGISRuntimeXamarin.Samples.AddEncExchangeSet
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
+++ b/src/Forms/Shared/Samples/Hydrography/ChangeEncDisplaySettings/ChangeEncDisplaySettings.xaml.cs
@@ -93,7 +93,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChangeEncDisplaySettings
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Hydrography/SelectEncFeatures/SelectEncFeatures.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGISRuntime.Samples.SelectEncFeatures
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -139,7 +139,7 @@ namespace ArcGISRuntime.Samples.SelectEncFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml.cs
@@ -110,7 +110,7 @@ namespace ArcGISRuntimeXamarin.Samples.BrowseWfsLayers
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
-                await ((Page)Parent).DisplayAlert("Failed to load layer", exception.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Failed to load layer", exception.ToString(), "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeBlendRenderer/ChangeBlendRenderer.xaml.cs
@@ -95,7 +95,7 @@ namespace ArcGISRuntime.Samples.ChangeBlendRenderer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntime.Samples.ChangeStretchRenderer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -146,7 +146,7 @@ namespace ArcGISRuntime.Samples.ChangeStretchRenderer
             }
             catch (Exception ex)
             {
-                ((Page)Parent).DisplayAlert("Alert", ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
                 return;
             }
 

--- a/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.xaml.cs
@@ -106,7 +106,7 @@ namespace ArcGISRuntime.Samples.ChangeSublayerVisibility
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
 
             }
         }

--- a/src/Forms/Shared/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/CreateFeatureCollectionLayer/CreateFeatureCollectionLayer.xaml.cs
@@ -116,7 +116,7 @@ namespace ArcGISRuntime.Samples.CreateFeatureCollectionLayer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
@@ -82,7 +82,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKml
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKmlNetworkLinks
             // The dispatcher takes an Action, provided here as a lambda function.
             Device.BeginInvokeOnMainThread(async () =>
             {
-                await ((Page) Parent).DisplayAlert("KML layer message", e.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("KML layer message", e.Message, "OK");
             });
         }
     }

--- a/src/Forms/Shared/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayWfs/DisplayWfs.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayWfs
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "Couldn't load sample.");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "Couldn't load sample.");
                 Debug.WriteLine(e);
             }
         }
@@ -100,7 +100,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayWfs
             }
             catch (Exception exception)
             {
-                await ((Page)Parent).DisplayAlert("Error", exception.ToString(), "Couldn't populate table.");
+                await Application.Current.MainPage.DisplayAlert("Error", exception.ToString(), "Couldn't populate table.");
                 Debug.WriteLine(exception);
             }
             finally

--- a/src/Forms/Shared/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ExportTiles/ExportTiles.xaml.cs
@@ -103,7 +103,7 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -193,7 +193,7 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
@@ -251,7 +251,7 @@ namespace ArcGISRuntime.Samples.ExportTiles
             else if (job.Status == Esri.ArcGISRuntime.Tasks.JobStatus.Failed)
             {
                 // Notify the user.
-                await ((Page)Parent).DisplayAlert("Error", "Job Failed", "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Job Failed", "OK");
 
                 // Change the export button text.
                 MyExportPreviewButton.Text = "Export Tiles";
@@ -324,7 +324,7 @@ namespace ArcGISRuntime.Samples.ExportTiles
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromPortal/FeatureCollectionLayerFromPortal.xaml.cs
@@ -67,12 +67,12 @@ namespace ArcGISRuntime.Samples.FeatureCollectionLayerFromPortal
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Feature Collection", "Portal item with ID '" + itemId + "' is not a feature collection.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Feature Collection", "Portal item with ID '" + itemId + "' is not a feature collection.", "OK");
                 }
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", "Unable to open item with ID '" + itemId + "': " + ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Unable to open item with ID '" + itemId + "': " + ex.Message, "OK");
             }
         }
 
@@ -84,7 +84,7 @@ namespace ArcGISRuntime.Samples.FeatureCollectionLayerFromPortal
             // Make sure an Id was entered.
             if (String.IsNullOrEmpty(collectionItemId))
             {
-                await ((Page)Parent).DisplayAlert("Feature Collection ID", "Please enter a portal item ID", "OK");
+                await Application.Current.MainPage.DisplayAlert("Feature Collection ID", "Please enter a portal item ID", "OK");
                 return;
             }
 

--- a/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureCollectionLayerFromQuery/FeatureCollectionLayerFromQuery.xaml.cs
@@ -71,7 +71,7 @@ namespace ArcGISRuntime.Samples.FeatureCollectionLayerFromQuery
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerDictionaryRenderer/FeatureLayerDictionaryRenderer.xaml.cs
@@ -87,7 +87,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerDictionaryRenderer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerRenderingModeMap/FeatureLayerRenderingModeMap.xaml.cs
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerRenderingModeMap
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/FeatureLayerSelection/FeatureLayerSelection.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerSelection
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -121,7 +121,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerSelection
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.xaml.cs
@@ -81,7 +81,7 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyKmlFeatures
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
@@ -70,7 +70,7 @@ namespace ArcGISRuntimeXamarin.Samples.ListKmlContents
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -104,7 +104,7 @@ namespace ArcGISRuntimeXamarin.Samples.ListKmlContents
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/MapImageLayerTables/MapImageLayerTables.xaml.cs
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.Samples.MapImageLayerTables
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -129,7 +129,7 @@ namespace ArcGISRuntime.Samples.MapImageLayerTables
                 ArcGISFeature serviceRequestFeature = result.FirstOrDefault() as ArcGISFeature;
                 if (serviceRequestFeature == null)
                 {
-                    await ((Page)Parent).DisplayAlert("No Feature", "Related feature not found.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("No Feature", "Related feature not found.", "OK");
                     return;
                 }
 
@@ -151,7 +151,7 @@ namespace ArcGISRuntime.Samples.MapImageLayerTables
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/MapImageSublayerQuery/MapImageSublayerQuery.xaml.cs
@@ -137,7 +137,7 @@ namespace ArcGISRuntime.Samples.MapImageSublayerQuery
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/PlayKmlTours/PlayKmlTours.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGISRuntimeXamarin.Samples.PlayKmlTours
             catch (Exception e)
             {
                 Debug.WriteLine(e.ToString());
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterHillshade/RasterHillshade.xaml.cs
@@ -94,7 +94,7 @@ namespace ArcGISRuntime.Samples.RasterHillshade
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterLayerFile/RasterLayerFile.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGISRuntime.Samples.RasterLayerFile
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterLayerRasterFunction/RasterLayerRasterFunction.xaml.cs
@@ -121,7 +121,7 @@ namespace ArcGISRuntime.Samples.RasterLayerRasterFunction
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterRenderingRule/RasterRenderingRule.xaml.cs
@@ -90,7 +90,7 @@ namespace ArcGISRuntime.Samples.RasterRenderingRule
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/RasterRgbRenderer/RasterRgbRenderer.xaml.cs
@@ -106,7 +106,7 @@ namespace ArcGISRuntime.Samples.RasterRgbRenderer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/SceneLayerSelection/SceneLayerSelection.xaml.cs
@@ -62,7 +62,7 @@ namespace ArcGISRuntime.Samples.SceneLayerSelection
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -97,7 +97,7 @@ namespace ArcGISRuntime.Samples.SceneLayerSelection
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/SceneLayerUrl/SceneLayerUrl.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntime.Samples.SceneLayerUrl
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -134,7 +134,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/StyleWmsLayer/StyleWmsLayer.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntime.Samples.StyleWmsLayer
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/TimeBasedQuery/TimeBasedQuery.xaml.cs
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.Samples.TimeBasedQuery
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/WMTSLayer/WMTSLayer.xaml.cs
@@ -102,7 +102,7 @@ namespace ArcGISRuntime.Samples.WMTSLayer
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Sample error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Sample error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/WfsXmlQuery/WfsXmlQuery.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGISRuntimeXamarin.Samples.WfsXmlQuery
             catch (Exception e)
             {
                 Debug.WriteLine(e.ToString());
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "Couldn't populate table with XML query.");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "Couldn't populate table with XML query.");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/WmsIdentify/WmsIdentify.xaml.cs
@@ -67,7 +67,7 @@ namespace ArcGISRuntime.Samples.WmsIdentify
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -103,7 +103,7 @@ namespace ArcGISRuntime.Samples.WmsIdentify
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntime.Samples.WmsServiceCatalog
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -106,7 +106,7 @@ namespace ArcGISRuntime.Samples.WmsServiceCatalog
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -105,7 +105,7 @@ namespace ArcGISRuntime.Samples.DisplayDeviceLocation
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await ((Page) Parent).DisplayAlert("Couldn't start location", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Couldn't start location", ex.Message, "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/Forms/Shared/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -165,7 +165,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
 
         private async void ShowMessage(string title, string detail)
         {
-            await ((Page) Parent).DisplayAlert(title, detail, "OK");
+            await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -27,6 +27,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 #endif
 

--- a/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/AuthorMap/AuthorMap.xaml.cs
@@ -221,7 +221,7 @@ namespace ArcGISRuntime.Samples.AuthorMap
                     await myMap.SaveAsAsync(agsOnline, null, title, description, tags, thumbnailImage);
 
                     // Report a successful save
-                    await ((Page)Parent).DisplayAlert("Map Saved", "Saved '" + title + "' to ArcGIS Online!", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Map Saved", "Saved '" + title + "' to ArcGIS Online!", "OK");
                 }
                 else
                 {
@@ -236,13 +236,13 @@ namespace ArcGISRuntime.Samples.AuthorMap
                     await myMap.SaveAsync();
 
                     // Report update was successful
-                    await ((Page)Parent).DisplayAlert("Updates Saved", "Saved changes to '" + myMap.Item.Title + "'", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Updates Saved", "Saved changes to '" + myMap.Item.Title + "'", "OK");
                 }
             }
             catch (Exception ex)
             {
                 // Show the exception message
-                await ((Page)Parent).DisplayAlert("Unable to save map", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Unable to save map", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/AuthorMap/SaveMapPage.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/AuthorMap/SaveMapPage.xaml.cs
@@ -60,7 +60,7 @@ namespace ArcGISRuntime.Samples.AuthorMap
             catch (Exception ex)
             {
                 // Show the exception message (dialog will stay open so user can try again)
-                ((Page)Parent).DisplayAlert("Error", ex.Message, "OK");
+                Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/DownloadPreplannedMap/DownloadPreplannedMap.xaml.cs
@@ -96,7 +96,7 @@ namespace ArcGISRuntimeXamarin.Samples.DownloadPreplannedMap
             {
                 // Something unexpected happened, show the error message.
                 Debug.WriteLine(ex);
-                await ((Page) Parent).DisplayAlert("There was an error.", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("There was an error.", ex.Message, "OK");
             }
         }
 
@@ -130,7 +130,7 @@ namespace ArcGISRuntimeXamarin.Samples.DownloadPreplannedMap
                 catch (Exception e)
                 {
                     Debug.WriteLine(e);
-                    await ((Page) Parent).DisplayAlert("Couldn't open offline area. Proceeding to take area offline.", e.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Couldn't open offline area. Proceeding to take area offline.", e.Message, "OK");
                 }
             }
 
@@ -165,7 +165,7 @@ namespace ArcGISRuntimeXamarin.Samples.DownloadPreplannedMap
                     }
 
                     // Show the message.
-                    await ((Page) Parent).DisplayAlert("Warning!", errors, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Warning!", errors, "OK");
                 }
 
                 // Show the downloaded map.
@@ -178,7 +178,7 @@ namespace ArcGISRuntimeXamarin.Samples.DownloadPreplannedMap
             {
                 // Report any errors.
                 Debug.WriteLine(ex);
-                await ((Page) Parent).DisplayAlert("Downloading map area failed.", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Downloading map area failed.", ex.Message, "OK");
             }
             finally
             {
@@ -239,7 +239,7 @@ namespace ArcGISRuntimeXamarin.Samples.DownloadPreplannedMap
             catch (Exception ex)
             {
                 // Report the error.
-                await ((Page) Parent).DisplayAlert("Deleting map areas failed.", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Deleting map areas failed.", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
@@ -102,7 +102,7 @@ namespace ArcGISRuntime.Samples.GenerateOfflineMap
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Alert", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -161,7 +161,7 @@ namespace ArcGISRuntime.Samples.GenerateOfflineMap
                 // Check for job failure (writing the output was denied, e.g.).
                 if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                 {
-                    await ((Page)Parent).DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                     busyIndicator.IsVisible = false;
                 }
 
@@ -177,7 +177,7 @@ namespace ArcGISRuntime.Samples.GenerateOfflineMap
 
                     // Show layer errors.
                     string errorText = errorBuilder.ToString();
-                    await ((Page)Parent).DisplayAlert("Alert", errorText, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
                 }
 
                 // Display the offline map.
@@ -198,12 +198,12 @@ namespace ArcGISRuntime.Samples.GenerateOfflineMap
             catch (TaskCanceledException)
             {
                 // Generate offline map task was canceled.
-                await ((Page)Parent).DisplayAlert("Alert", "Taking map offline was canceled", "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled", "OK");
             }
             catch (Exception ex)
             {
                 // Exception while taking the map offline.
-                await ((Page)Parent).DisplayAlert("Alert", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
@@ -30,6 +30,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 using System.IO;
 #endif

--- a/src/Forms/Shared/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
@@ -100,7 +100,7 @@ namespace ArcGISRuntimeXamarin.Samples.GenerateOfflineMapWithOverrides
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Alert", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -171,7 +171,7 @@ namespace ArcGISRuntimeXamarin.Samples.GenerateOfflineMapWithOverrides
                     // Check for job failure (writing the output was denied, e.g.).
                     if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                     {
-                        await ((Page) Parent).DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                        await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                         busyIndicator.IsVisible = false;
                     }
 
@@ -187,7 +187,7 @@ namespace ArcGISRuntimeXamarin.Samples.GenerateOfflineMapWithOverrides
 
                         // Show layer errors.
                         string errorText = errorBuilder.ToString();
-                        await ((Page) Parent).DisplayAlert("Alert", errorText, "OK");
+                        await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
                     }
 
                     // Display the offline map.
@@ -216,12 +216,12 @@ namespace ArcGISRuntimeXamarin.Samples.GenerateOfflineMapWithOverrides
             catch (TaskCanceledException)
             {
                 // Generate offline map task was canceled.
-                await ((Page) Parent).DisplayAlert("Alert", "Taking map offline was canceled", "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled", "OK");
             }
             catch (Exception ex)
             {
                 // Exception while taking the map offline.
-                await ((Page) Parent).DisplayAlert("Alert", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
@@ -28,6 +28,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 using System.IO;
 #endif

--- a/src/Forms/Shared/Samples/Map/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
@@ -118,7 +118,7 @@ namespace ArcGISRuntimeXamarin.Samples.GetElevationAtPoint
             catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message);
-                await ((Page)Parent).DisplayAlert("Error", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
@@ -136,7 +136,7 @@ namespace ArcGISRuntimeXamarin.Samples.MobileMapSearchAndRoute
             catch (Exception exception)
             {
                 Console.WriteLine(exception);
-                await ((Page)Parent).DisplayAlert("Error", "Couldn't geocode or route.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Couldn't geocode or route.", "OK");
             }
         }
 
@@ -234,7 +234,7 @@ namespace ArcGISRuntimeXamarin.Samples.MobileMapSearchAndRoute
             catch (Exception exception)
             {
                 Debug.WriteLine(exception);
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
             }
 
             // Wait for the user to choose whether to use the offline basemap.
-            bool useBasemap = await ((Page) Parent).DisplayAlert("Basemap choice", "Use the offline basemap?", "Yes", "No");
+            bool useBasemap = await Application.Current.MainPage.DisplayAlert("Basemap choice", "Use the offline basemap?", "Yes", "No");
 
             if (useBasemap)
             {
@@ -138,7 +138,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Alert", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.ToString(), "OK");
             }
         }
 
@@ -200,7 +200,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
                 // Check for job failure (writing the output was denied, e.g.).
                 if (_generateOfflineMapJob.Status != JobStatus.Succeeded)
                 {
-                    await ((Page) Parent).DisplayAlert("Alert", "Generate offline map package failed.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Alert", "Generate offline map package failed.", "OK");
                     BusyIndicator.IsVisible = false;
                 }
 
@@ -216,7 +216,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
 
                     // Show layer errors.
                     string errorText = errorBuilder.ToString();
-                    await ((Page) Parent).DisplayAlert("Alert", errorText, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Alert", errorText, "OK");
                 }
 
                 // Display the offline map.
@@ -237,12 +237,12 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
             catch (TaskCanceledException)
             {
                 // Generate offline map task was canceled.
-                await ((Page) Parent).DisplayAlert("Alert", "Taking map offline was canceled", "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", "Taking map offline was canceled", "OK");
             }
             catch (Exception ex)
             {
                 // Exception while taking the map offline.
-                await ((Page) Parent).DisplayAlert("Alert", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Alert", ex.Message, "OK");
             }
             finally
             {

--- a/src/Forms/Shared/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
@@ -30,6 +30,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 using System.IO;
 #endif

--- a/src/Forms/Shared/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenMobileMap/OpenMobileMap.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.Samples.OpenMobileMap
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Map/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenMobileScenePackage/OpenMobileScenePackage.xaml.cs
@@ -69,7 +69,7 @@ namespace ArcGISRuntimeXamarin.Samples.OpenMobileScenePackage
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Couldn't open scene", e.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Couldn't open scene", e.Message, "OK");
                 Debug.WriteLine(e);
             }
         }

--- a/src/Forms/Shared/Samples/Map/OpenScene/OpenScene.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/OpenScene/OpenScene.xaml.cs
@@ -47,7 +47,7 @@ namespace ArcGISRuntime.Samples.OpenScene
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
@@ -134,7 +134,7 @@ namespace ArcGISRuntime.Samples.SearchPortalMaps
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -174,7 +174,7 @@ namespace ArcGISRuntime.Samples.SearchPortalMaps
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
         
@@ -206,7 +206,7 @@ namespace ArcGISRuntime.Samples.SearchPortalMaps
                 Exception err = map.LoadError;
                 if (err != null)
                 {
-                    Device.BeginInvokeOnMainThread(() => ((Page)Parent).DisplayAlert(err.Message, "Map Load Error", "OK"));
+                    Device.BeginInvokeOnMainThread(() => Application.Current.MainPage.DisplayAlert(err.Message, "Map Load Error", "OK"));
                 }
             }
         }
@@ -243,7 +243,7 @@ namespace ArcGISRuntime.Samples.SearchPortalMaps
             catch (Exception ex)
             {
                 // Login failure
-                await ((Page)Parent).DisplayAlert("Login Error", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Login Error", ex.Message, "OK");
             }
 
             return loggedIn;

--- a/src/Forms/Shared/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/SearchPortalMaps/SearchPortalMaps.xaml.cs
@@ -26,6 +26,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 #endif
 

--- a/src/Forms/Shared/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/ChangeViewpoint/ChangeViewpoint.xaml.cs
@@ -120,7 +120,7 @@ namespace ArcGISRuntime.Samples.ChangeViewpoint
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/MapView/ChooseCameraController/ChooseCameraController.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/ChooseCameraController/ChooseCameraController.xaml.cs
@@ -146,7 +146,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChooseCameraController
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/FeatureLayerTimeOffset/FeatureLayerTimeOffset.xaml.cs
@@ -80,7 +80,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerTimeOffset
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/IdentifyLayers/IdentifyLayers.xaml.cs
@@ -55,7 +55,7 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyLayers
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -76,12 +76,12 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyLayers
 
                 if (!String.IsNullOrEmpty(result))
                 {
-                    await ((Page) Parent).DisplayAlert("Identify result", result, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Identify result", result, "OK");
                 }
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/TakeScreenshot/TakeScreenshot.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGISRuntime.Samples.TakeScreenshot
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Network Analysis/ClosestFacility/ClosestFacility.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/ClosestFacility/ClosestFacility.xaml.cs
@@ -117,7 +117,7 @@ namespace ArcGISRuntime.Samples.ClosestFacility
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -171,11 +171,11 @@ namespace ArcGISRuntime.Samples.ClosestFacility
             {
                 if (exception.Message.Equals("Unable to complete operation."))
                 {
-                    await ((Page)Parent).DisplayAlert("Error", "Incident not within San Diego area!", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", "Incident not within San Diego area!", "OK");
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
                 }
             }
         }

--- a/src/Forms/Shared/Samples/Network Analysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/ClosestFacilityStatic/ClosestFacilityStatic.xaml.cs
@@ -133,7 +133,7 @@ namespace ArcGISRuntime.Samples.ClosestFacilityStatic
             }
             catch (Exception exception)
             {
-                await ((Page)Parent).DisplayAlert("Error", "An exception has occurred.\n" + exception.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "An exception has occurred.\n" + exception.Message, "OK");
             }
         }
 
@@ -193,7 +193,7 @@ namespace ArcGISRuntime.Samples.ClosestFacilityStatic
             }
             catch (Esri.ArcGISRuntime.Http.ArcGISWebException exception)
             {
-                await ((Page)Parent).DisplayAlert("Error", "An ArcGIS web exception occurred.\n" + exception.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred.\n" + exception.Message, "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Network Analysis/FindRoute/FindRoute.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/FindRoute/FindRoute.xaml.cs
@@ -137,7 +137,7 @@ namespace ArcGISRuntime.Samples.FindRoute
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Network Analysis/FindServiceArea/FindServiceArea.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/FindServiceArea/FindServiceArea.xaml.cs
@@ -100,7 +100,7 @@ namespace ArcGISRuntime.Samples.FindServiceArea
             catch (Exception ex)
             {
                 // Report exceptions.
-                await ((Page)Parent).DisplayAlert("Error", "Error drawing facility:\n" + ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Error drawing facility:\n" + ex.Message, "OK");
             }
         }
 
@@ -143,7 +143,7 @@ namespace ArcGISRuntime.Samples.FindServiceArea
             catch (Exception ex)
             {
                 // Report exceptions.
-                await ((Page)Parent).DisplayAlert("Error", "Error drawing barrier:\n" + ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Error drawing barrier:\n" + ex.Message, "OK");
             }
         }
 
@@ -168,7 +168,7 @@ namespace ArcGISRuntime.Samples.FindServiceArea
             // Check that there is at least 1 facility to find a service area for.
             if (!serviceAreaFacilities.Any())
             {
-                await ((Page)Parent).DisplayAlert("Error", "Must have at least one Facility!", "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", "Must have at least one Facility!", "OK");
                 return;
             }
 
@@ -243,11 +243,11 @@ namespace ArcGISRuntime.Samples.FindServiceArea
             {
                 if (exception.Message.ToString().Equals("Unable to complete operation."))
                 {
-                    await ((Page)Parent).DisplayAlert("Error", "Facility not within San Diego area!", "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", "Facility not within San Diego area!", "OK");
                 }
                 else
                 {
-                    await ((Page)Parent).DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
+                    await Application.Current.MainPage.DisplayAlert("Error", "An ArcGIS web exception occurred. \n" + exception.Message, "OK");
                 }
             }
         }

--- a/src/Forms/Shared/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.xaml.cs
@@ -185,7 +185,7 @@ namespace ArcGISRuntimeXamarin.Samples.FindServiceAreasForMultipleFacilities
 
         private async void ShowMessage(string title, string detail)
         {
-            await ((Page) Parent).DisplayAlert(title, detail, "OK");
+            await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/Forms/Shared/Samples/Network Analysis/OfflineRouting/OfflineRouting.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/OfflineRouting/OfflineRouting.xaml.cs
@@ -282,7 +282,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineRouting
 
         private async void ShowMessage(string title, string detail)
         {
-            await ((Page) Parent).DisplayAlert(title, detail, "OK");
+            await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/Forms/Shared/Samples/Network Analysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/Forms/Shared/Samples/Network Analysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -373,7 +373,7 @@ namespace ArcGISRuntimeXamarin.Samples.RouteAroundBarriers
 
         private async void ShowMessage(string title, string detail)
         {
-            await ((Page)Parent).DisplayAlert(title, detail, "OK");
+            await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/Forms/Shared/Samples/Search/FindAddress/FindAddress.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/FindAddress/FindAddress.xaml.cs
@@ -74,7 +74,7 @@ namespace ArcGISRuntime.Samples.FindAddress
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -123,7 +123,7 @@ namespace ArcGISRuntime.Samples.FindAddress
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -196,7 +196,7 @@ namespace ArcGISRuntime.Samples.FindAddress
             }
             catch (Exception ex)
             {
-                await ((Page)Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -75,7 +75,7 @@ namespace ArcGISRuntime.Samples.FindPlace
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await ((Page) Parent).DisplayAlert("Couldn't start location", ex.Message, "OK");
+                await Application.Current.MainPage.DisplayAlert("Couldn't start location", ex.Message, "OK");
             }
 
             // Initialize the LocatorTask with the provided service Uri.
@@ -299,7 +299,7 @@ namespace ArcGISRuntime.Samples.FindPlace
         private void ShowStatusMessage(string message)
         {
             // Display the message to the user.
-            ((Page)Parent).DisplayAlert("Alert", message, "OK");
+            Application.Current.MainPage.DisplayAlert("Alert", message, "OK");
         }
 
         private async void MyLocationBox_TextChanged(object sender, TextChangedEventArgs e)

--- a/src/Forms/Shared/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/OfflineGeocode/OfflineGeocode.xaml.cs
@@ -83,7 +83,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -115,7 +115,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
                 // Stop if there are no suggestions.
                 if (!geocodeResults.Any())
                 {
-                    await ((Page) Parent).DisplayAlert("No results", "No results found.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("No results", "No results found.", "OK");
                     return;
                 }
 
@@ -138,7 +138,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 
@@ -198,7 +198,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
                 // Skip if there are no results.
                 if (!addresses.Any())
                 {
-                    await ((Page) Parent).DisplayAlert("No results", "No results found.", "OK");
+                    await Application.Current.MainPage.DisplayAlert("No results", "No results found.", "OK");
                     return;
                 }
 
@@ -217,7 +217,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineGeocode
             }
             catch (Exception ex)
             {
-                await ((Page) Parent).DisplayAlert("Error", ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
     }

--- a/src/Forms/Shared/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/ReverseGeocode/ReverseGeocode.xaml.cs
@@ -63,7 +63,7 @@ namespace ArcGISRuntimeXamarin.Samples.ReverseGeocode
             }
             catch (Exception e)
             {
-                await ((Page) Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
 
             // Set the initial viewpoint.
@@ -108,7 +108,7 @@ namespace ArcGISRuntimeXamarin.Samples.ReverseGeocode
             catch (Exception ex)
             {
                 Debug.WriteLine(ex);
-                await ((Page) Parent).DisplayAlert("No results", "No results found", "OK");
+                await Application.Current.MainPage.DisplayAlert("No results", "No results found", "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Security/OAuth/OAuth.xaml.cs
+++ b/src/Forms/Shared/Samples/Security/OAuth/OAuth.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.Samples.OAuth
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Security/OAuth/OAuth.xaml.cs
+++ b/src/Forms/Shared/Samples/Security/OAuth/OAuth.xaml.cs
@@ -24,6 +24,7 @@ using UIKit;
 
 #if __ANDROID__
 using Android.App;
+using Application = Xamarin.Forms.Application;
 using Xamarin.Auth;
 using System.IO;
 #endif

--- a/src/Forms/Shared/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
+++ b/src/Forms/Shared/Samples/Security/TokenSecuredChallenge/LoginPage.xaml.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.Samples.TokenSecuredChallenge
             // Make sure the user entered all values.
             if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(password))
             {
-                ((Page)Parent).DisplayAlert("Login", "Please enter a username and password", "OK");
+                Application.Current.MainPage.DisplayAlert("Login", "Please enter a username and password", "OK");
                 return;
             }
 

--- a/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
             catch (Exception ex)
             {
                 // Something went wrong, display the error
-                await ((Page)Parent).DisplayAlert("Error",ex.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error",ex.ToString(), "OK");
             }
         }
 

--- a/src/Forms/Shared/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/RenderPictureMarkers/RenderPictureMarkers.xaml.cs
@@ -63,7 +63,7 @@ namespace ArcGISRuntime.Samples.RenderPictureMarkers
             }
             catch (Exception e)
             {
-                await ((Page)Parent).DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
             }
         }
 


### PR DESCRIPTION
Fixes null reference exception that can occur when calling `DisplayAlert` from `Initialize()`. Changed the display alert call to use `Application.Current.MainPage.DisplayAlert` for every instance in the forms samples. The DisplayAlert from the main page will always work, even if a sample is loading.