### PR TITLE
Fix for Distance Measurement sample

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
@@ -82,7 +82,6 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            _mySceneView.SetViewpointCamera(new Camera(start, 200, 45, 45, 0));
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += (o, e) =>
@@ -111,6 +110,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
 
             // Show the scene in the view.
             _mySceneView.Scene = myScene;
+            _mySceneView.SetViewpointCamera(new Camera(start, 200, 45, 45, 0));
 
             // Subscribe to tap events to enable updating the measurement.
             _mySceneView.GeoViewTapped += MySceneView_GeoViewTapped;

--- a/src/Forms/Shared/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/Forms/Shared/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -68,7 +68,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
+            
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += (o, e) =>
@@ -98,6 +98,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
 
             // Show the scene in the view.
             MySceneView.Scene = myScene;
+            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
 
             // Subscribe to tap events to enable updating the measurement.
             MySceneView.GeoViewTapped += MySceneView_GeoViewTapped;

--- a/src/Forms/Shared/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/Forms/Shared/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -68,7 +68,6 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += (o, e) =>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -70,7 +70,6 @@ namespace ArcGISRuntime.UWP.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += async (o, e) =>
@@ -97,6 +96,7 @@ namespace ArcGISRuntime.UWP.Samples.DistanceMeasurement
 
             // Show the scene in the view.
             MySceneView.Scene = myScene;
+            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
 
             // Enable the 'New measurement' button.
             NewMeasureButton.IsEnabled = true;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -67,7 +67,6 @@ namespace ArcGISRuntime.WPF.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += (o, e) =>
@@ -98,6 +97,7 @@ namespace ArcGISRuntime.WPF.Samples.DistanceMeasurement
 
             // Show the scene in the view.
             MySceneView.Scene = myScene;
+            MySceneView.SetViewpointCamera(new Camera(start, 200, 0, 45, 0));
 
             // Enable the 'New measurement' button.
             NewMeasureButton.IsEnabled = true;

--- a/src/iOS/Xamarin.iOS/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
@@ -69,7 +69,6 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             MapPoint end = new MapPoint(-4.495646, 48.384377, 58.501115, SpatialReferences.Wgs84);
             _distanceMeasurement = new LocationDistanceMeasurement(start, end);
             measureAnalysisOverlay.Analyses.Add(_distanceMeasurement);
-            _mySceneView.SetViewpointCamera(new Camera(start, 200, 45, 45, 0));
 
             // Keep the UI updated.
             _distanceMeasurement.MeasurementChanged += (o, e) =>
@@ -90,6 +89,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
 
             // Show the scene in the view.
             _mySceneView.Scene = myScene;
+            _mySceneView.SetViewpointCamera(new Camera(start, 200, 45, 45, 0));
 
             // Subscribe to tap events to enable updating the measurement.
             _mySceneView.GeoViewTapped += MySceneView_GeoViewTapped;


### PR DESCRIPTION
SetViewpointCamera is now called after the Scene is set for SceneView. This fixes a bug with Xamarin.Forms.