### PR TITLE
Revert v.next to Local Server 100.5

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.csproj
@@ -2082,7 +2082,7 @@
       <Version>100.6.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices">
-      <Version>100.6.0</Version>
+      <Version>100.5.0</Version>
     </PackageReference>
     <PackageReference Include="Esri.ArcGISRuntime.WPF">
       <Version>100.6.0</Version>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/readme.metadata.json
@@ -13,7 +13,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [
         "ea619b4f0f8f4d108c5b87e90c1b5be0",

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/readme.metadata.json
@@ -13,7 +13,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [
         "ea619b4f0f8f4d108c5b87e90c1b5be0",

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/readme.metadata.json
@@ -13,7 +13,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [
         "4e94fec734434d1288e6ebe36c3c461f"

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/readme.metadata.json
@@ -15,7 +15,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [
         "da9e565a52ca41c1937cff1a01017068"

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/readme.metadata.json
@@ -13,7 +13,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [
         "dee5d8060a6048a4b063484199a9546b"

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/readme.metadata.json
@@ -15,7 +15,7 @@
     ],
     "nuget_packages": {
         "Esri.ArcGISRuntime": "100.6.0",
-        "Esri.ArcGISRuntime.LocalServices": "100.6.0"
+        "Esri.ArcGISRuntime.LocalServices": "100.5.0"
     },
     "offline_data": [],
     "redirect_from": [


### PR DESCRIPTION
100.6 version of Local Server won't be ready in time for the Runtime 100.6, so we should stay with 100.5 for now.