### PR TITLE
Allow UWP viewer to build with .NET Native

### DIFF
--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
@@ -10,7 +10,6 @@
 using ArcGISRuntime.Samples.Shared.Attributes;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -18,11 +17,14 @@ namespace ArcGISRuntime.Samples.Shared.Models
 {
     public partial class SampleInfo
     {
-        #if NETFX_CORE
-        private string _pathStub = Directory.GetParent(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).FullName;
-        #else
-        private string _pathStub = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        #endif
+        static SampleInfo()
+        {
+#if NETFX_CORE
+            PathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
+#else
+            PathStub = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+#endif
+        }
 
         /// <summary>
         /// Gets the path to the sample on disk.
@@ -31,7 +33,7 @@ namespace ArcGISRuntime.Samples.Shared.Models
         {
             get
             {
-                return System.IO.Path.Combine(_pathStub, "Samples", Category, FormalName);
+                return System.IO.Path.Combine(PathStub, "Samples", Category, FormalName);
             }
         }
 
@@ -95,11 +97,7 @@ namespace ArcGISRuntime.Samples.Shared.Models
         /// <summary>
         /// Base directory for the samples; defaults to executable directory
         /// </summary>
-        public string PathStub
-        {
-            get { return _pathStub; }
-            set { _pathStub = value; }
-        }
+        public static string PathStub { get; set; }
 
         /// <summary>
         /// This constructor is for use when the sample 

--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
@@ -10,6 +10,7 @@
 using ArcGISRuntime.Samples.Shared.Attributes;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -17,14 +18,11 @@ namespace ArcGISRuntime.Samples.Shared.Models
 {
     public partial class SampleInfo
     {
-        static SampleInfo()
-        {
-#if NETFX_CORE
-            PathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
-#else
-            PathStub = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-#endif
-        }
+        #if NETFX_CORE
+        private string _pathStub = Windows.ApplicationModel.Package.Current.Installed­Location.Path;
+        #else
+        private string _pathStub = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        #endif
 
         /// <summary>
         /// Gets the path to the sample on disk.
@@ -33,7 +31,7 @@ namespace ArcGISRuntime.Samples.Shared.Models
         {
             get
             {
-                return System.IO.Path.Combine(PathStub, "Samples", Category, FormalName);
+                return System.IO.Path.Combine(_pathStub, "Samples", Category, FormalName);
             }
         }
 
@@ -97,7 +95,11 @@ namespace ArcGISRuntime.Samples.Shared.Models
         /// <summary>
         /// Base directory for the samples; defaults to executable directory
         /// </summary>
-        public static string PathStub { get; set; }
+        public string PathStub
+        {
+            get { return _pathStub; }
+            set { _pathStub = value; }
+        }
 
         /// <summary>
         /// This constructor is for use when the sample 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!-- Build Configurations -->
@@ -115,6 +115,7 @@
   <ItemGroup>
     <!-- Screenshots -->
     <Content Include="Assets\banner-background-black.png" />
+    <Content Include="Default.rd.xml" />
     <Content Include="Samples\Layers\RasterColormapRenderer\RasterColormapRenderer.jpg" />
     <Content Include="Samples\MapView\ChooseCameraController\ChooseCameraController.jpg" />
     <Content Include="Samples\Location\ShowLocationHistory\ShowLocationHistory.jpg" />

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Default.rd.xml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Default.rd.xml
@@ -1,0 +1,22 @@
+﻿<!--
+    To fully enable reflection for App1.MyClass and all of its public/private members
+    <Type Name="App1.MyClass" Dynamic="Required All"/>
+    
+    To enable dynamic creation of the specific instantiation of AppClass<T> over System.Int32
+    <TypeInstantiation Name="App1.AppClass" Arguments="System.Int32" Activate="Required Public" />
+    
+    Using the Namespace directive to apply reflection policy to all the types in a particular namespace
+    <Namespace Name="DataClasses.ViewModels" Serialize="All" />
+
+    Runtime Directives are documented at http://go.microsoft.com/fwlink/?LinkID=391919
+-->
+
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Namespace Name="ArcGISRuntime.Samples.Shared.Attributes" >
+      <Type Name="SampleAttribute">
+        <AttributeImplies Activate="Required Public" />
+      </Type>
+    </Namespace>
+  </Application>
+</Directives>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/SettingsPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/SettingsPage.xaml.cs
@@ -39,12 +39,20 @@ namespace ArcGISRuntime
             this.InitializeComponent();
 
             // Set up version info and About section.
-            if (string.IsNullOrWhiteSpace(_runtimeVersion))
+            try
             {
-                var runtimeTypeInfo = typeof(ArcGISRuntimeEnvironment).GetTypeInfo();
-                var rtVersion = FileVersionInfo.GetVersionInfo(runtimeTypeInfo.Assembly.Location);
-                _runtimeVersion = rtVersion.FileVersion;
+                if (string.IsNullOrWhiteSpace(_runtimeVersion))
+                {
+                    var rtVersion = FileVersionInfo.GetVersionInfo(Path.Combine(Windows.ApplicationModel.Package.Current.Installed­Location.Path, "RuntimeCoreNet.dll"));
+                    _runtimeVersion = rtVersion.FileVersion;
+                }
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                _runtimeVersion = "Couldn't find ArcGIS Runtime version.";
+            }
+
             string aboutPath = "Resources\\about.md";
             AboutBlock.Text = File.ReadAllText(aboutPath) + _runtimeVersion;
             AboutBlock.Background = new ImageBrush() { Opacity = 0 };


### PR DESCRIPTION
There are two parts to this fix:

1. Prevent NET Native from optimizing away SamplePage constructors, by adding a [runtime directives file](https://docs.microsoft.com/en-us/dotnet/framework/net-native/runtime-directives-rd-xml-configuration-file-reference).
2. Fix the way SampleInfo looks up the base path. `Assembly.Location` does not work inside .NET Native.