### PR TITLE
Minor UWP enhancements

### DIFF
--- a/src/Forms/UWP/Package.appxmanifest
+++ b/src/Forms/UWP/Package.appxmanifest
@@ -15,7 +15,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="FPCL.WIndows.App">
-      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for .NET" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Viewer application to browse ArcGIS Runtime SDK for Xamarin samples." BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for .NET Samples (Forms UWP)" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Sample viewer for the ArcGIS Runtime SDK for .NET, implemented with Xamarin.Forms targeting UWP." BackgroundColor="transparent">
         <uap:LockScreen Notification="badge" BadgeLogo="Assets\BadgeLogo.png" />
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" ShortName="ArcGIS Samples" Square310x310Logo="Assets\Square310x310Logo.png" Square71x71Logo="Assets\Square71x71Logo.png">
           <uap:ShowNameOnTiles>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
@@ -165,9 +165,13 @@ namespace ArcGISRuntime.UWP.Viewer
             {
                 // Set the items source of the grid to the first category from the search.
                 SamplesGridView.ItemsSource = CategoriesTree.RootNodes[0].Children.ToList().Select(x => (SampleInfo)x.Content).ToList();
-                foreach (muxc.TreeViewNode node in CategoriesTree.RootNodes)
+
+                if (!String.IsNullOrWhiteSpace(searchBox.Text))
                 {
-                    node.IsExpanded = true;
+                    foreach (muxc.TreeViewNode node in CategoriesTree.RootNodes)
+                    {
+                        node.IsExpanded = true;
+                    }
                 }
             }
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Package.appxmanifest
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Package.appxmanifest
@@ -15,7 +15,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="ArcGISRuntime.UWP.Viewer.App">
-      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for .NET Samples" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Viewer application to browse ArcGIS Runtime SDK for .NET samples." BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="ArcGIS Runtime SDK for .NET Samples (UWP)" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Sample viewer for the ArcGIS Runtime SDK for .NET, implemented with UWP." BackgroundColor="transparent">
         <uap:LockScreen Notification="badgeAndTileText" BadgeLogo="Assets\BadgeLogo.png" />
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square71x71Logo="Assets\square-71-400.png" Square310x310Logo="Assets\square-310-400.png" ShortName="ArcGIS .NET Samples">
           <uap:ShowNameOnTiles>


### PR DESCRIPTION

* Append platform to app title: We have three apps installed as Windows packages: WPF viewer for Store, UWP, and Forms UWP. This PR updates the app manifests to include a label for each to make it clear which one you're looking at.
* Collapse tree view when canceling search - matches WPF viewer behavior