### PR TITLE
UWP Crash fix

### DIFF
--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
@@ -105,6 +105,8 @@ namespace ArcGISRuntime.UWP.Viewer
             // Clear the previous sample.
             SamplePageContainer.Content = new Page();
             GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             // Call a function to clear existing credentials
             ClearCredentials();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
@@ -101,9 +101,9 @@ namespace ArcGISRuntime.UWP.Viewer
             _loadFlag = true;
 
             CategoriesTree.IsEnabled = false;
-
+            
             // Clear the previous sample.
-            SamplePageContainer.Content = new Page();
+            SamplePageContainer.Content = null;
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
@@ -135,14 +135,14 @@ namespace ArcGISRuntime.UWP.Viewer
             }
             catch (Exception exception)
             {
-                // failed to create new instance of the sample
+                // Failed to create new instance of the sample.
                 SamplePageContainer.Visibility = Visibility.Collapsed;
                 SampleSelectionGrid.Visibility = Visibility.Visible;
                 await new MessageDialog(exception.Message).ShowAsync();
             }
             finally
             {
-                await Task.Delay(1500);
+                await Task.Delay(5000);
                 _loadFlag = false;
                 CategoriesTree.IsEnabled = true;
             }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/MainPage.xaml.cs
@@ -29,6 +29,7 @@ namespace ArcGISRuntime.UWP.Viewer
     {
         private readonly SystemNavigationManager _currentView;
         private bool _waitFlag;
+        private bool _loadFlag;
 
         public MainPage()
         {
@@ -95,6 +96,16 @@ namespace ArcGISRuntime.UWP.Viewer
 
         private async Task SelectSample(SampleInfo selectedSample)
         {
+            // Prevent multiple samples from being selected concurrently.
+            if (_loadFlag) { return; }
+            _loadFlag = true;
+
+            CategoriesTree.IsEnabled = false;
+
+            // Clear the previous sample.
+            SamplePageContainer.Content = new Page();
+            GC.Collect();
+
             // Call a function to clear existing credentials
             ClearCredentials();
 
@@ -126,6 +137,12 @@ namespace ArcGISRuntime.UWP.Viewer
                 SamplePageContainer.Visibility = Visibility.Collapsed;
                 SampleSelectionGrid.Visibility = Visibility.Visible;
                 await new MessageDialog(exception.Message).ShowAsync();
+            }
+            finally
+            {
+                await Task.Delay(1500);
+                _loadFlag = false;
+                CategoriesTree.IsEnabled = true;
             }
         }
 


### PR DESCRIPTION
Fixes the viewer crash that can happen when rapidly switching between samples.