### PR TITLE
Update TOC markdown format for links

### DIFF
--- a/src/Android/readme.md
+++ b/src/Android/readme.md
@@ -184,13 +184,13 @@
 
 ## Network Analysis
 
-* [Find closest facility to an incident (interactive)](Xamarin.Android/Samples/Network Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
-* [Find closest facility to multiple incidents (service)](Xamarin.Android/Samples/Network Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
-* [Find route](Xamarin.Android/Samples/Network Analysis/FindRoute/readme.md) - Display directions for a route between two points.
-* [Find service area](Xamarin.Android/Samples/Network Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
-* [Find service areas for multiple facilities](Xamarin.Android/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
-* [Offline routing](Xamarin.Android/Samples/Network Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
-* [Route around barriers](Xamarin.Android/Samples/Network Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
+* [Find closest facility to an incident (interactive)](Xamarin.Android/Samples/Network%20Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
+* [Find closest facility to multiple incidents (service)](Xamarin.Android/Samples/Network%20Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
+* [Find route](Xamarin.Android/Samples/Network%20Analysis/FindRoute/readme.md) - Display directions for a route between two points.
+* [Find service area](Xamarin.Android/Samples/Network%20Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
+* [Find service areas for multiple facilities](Xamarin.Android/Samples/Network%20Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
+* [Offline routing](Xamarin.Android/Samples/Network%20Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
+* [Route around barriers](Xamarin.Android/Samples/Network%20Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
 
 ## Search
 

--- a/src/Forms/readme.md
+++ b/src/Forms/readme.md
@@ -184,13 +184,13 @@
 
 ## Network Analysis
 
-* [Find closest facility to an incident (interactive)](Shared/Samples/Network Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
-* [Find closest facility to multiple incidents (service)](Shared/Samples/Network Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
-* [Find route](Shared/Samples/Network Analysis/FindRoute/readme.md) - Display directions for a route between two points.
-* [Find service area](Shared/Samples/Network Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
-* [Find service areas for multiple facilities](Shared/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
-* [Offline routing](Shared/Samples/Network Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
-* [Route around barriers](Shared/Samples/Network Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
+* [Find closest facility to an incident (interactive)](Shared/Samples/Network%20Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
+* [Find closest facility to multiple incidents (service)](Shared/Samples/Network%20Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
+* [Find route](Shared/Samples/Network%20Analysis/FindRoute/readme.md) - Display directions for a route between two points.
+* [Find service area](Shared/Samples/Network%20Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
+* [Find service areas for multiple facilities](Shared/Samples/Network%20Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
+* [Offline routing](Shared/Samples/Network%20Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
+* [Route around barriers](Shared/Samples/Network%20Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
 
 ## Search
 

--- a/src/UWP/readme.md
+++ b/src/UWP/readme.md
@@ -184,13 +184,13 @@
 
 ## Network Analysis
 
-* [Find closest facility to an incident (interactive)](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
-* [Find closest facility to multiple incidents (service)](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
-* [Find route](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/FindRoute/readme.md) - Display directions for a route between two points.
-* [Find service area](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
-* [Find service areas for multiple facilities](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
-* [Offline routing](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
-* [Route around barriers](ArcGISRuntime.UWP.Viewer/Samples/Network Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
+* [Find closest facility to an incident (interactive)](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
+* [Find closest facility to multiple incidents (service)](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
+* [Find route](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/FindRoute/readme.md) - Display directions for a route between two points.
+* [Find service area](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
+* [Find service areas for multiple facilities](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
+* [Offline routing](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
+* [Route around barriers](ArcGISRuntime.UWP.Viewer/Samples/Network%20Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
 
 ## Search
 

--- a/src/WPF/readme.md
+++ b/src/WPF/readme.md
@@ -133,12 +133,12 @@
 
 ## Local Server
 
-* [Local server dynamic workspace raster](ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceRaster/readme.md) - Dynamically add a local raster file to a map using Local Server.
-* [Local server dynamic workspace shapefile](ArcGISRuntime.WPF.Viewer/Samples/Local Server/DynamicWorkspaceShapefile/readme.md) - Dynamically add a local shapefile to a map using Local Server.
-* [Local server feature layer](ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerFeatureLayer/readme.md) - Start a local feature service and display its features in a map.
-* [Local server geoprocessing](ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerGeoprocessing/readme.md) - Create contour lines from local raster data using a local geoprocessing package `.gpk` and the contour geoprocessing tool.
-* [Local Server map image layer](ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerMapImageLayer/readme.md) - Start the Local Server and Local Map Service, create an ArcGIS Map Image Layer from the Local Map Service, and add it to a map.
-* [Local server services](ArcGISRuntime.WPF.Viewer/Samples/Local Server/LocalServerServices/readme.md) - Demonstrates how to start and stop the Local Server and start and stop a local map, feature, and geoprocessing service running on the Local Server.
+* [Local server dynamic workspace raster](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/DynamicWorkspaceRaster/readme.md) - Dynamically add a local raster file to a map using Local Server.
+* [Local server dynamic workspace shapefile](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/DynamicWorkspaceShapefile/readme.md) - Dynamically add a local shapefile to a map using Local Server.
+* [Local server feature layer](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/LocalServerFeatureLayer/readme.md) - Start a local feature service and display its features in a map.
+* [Local server geoprocessing](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/LocalServerGeoprocessing/readme.md) - Create contour lines from local raster data using a local geoprocessing package `.gpk` and the contour geoprocessing tool.
+* [Local Server map image layer](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/LocalServerMapImageLayer/readme.md) - Start the Local Server and Local Map Service, create an ArcGIS Map Image Layer from the Local Map Service, and add it to a map.
+* [Local server services](ArcGISRuntime.WPF.Viewer/Samples/Local%20Server/LocalServerServices/readme.md) - Demonstrates how to start and stop the Local Server and start and stop a local map, feature, and geoprocessing service running on the Local Server.
 
 ## Location
 
@@ -193,13 +193,13 @@
 
 ## Network Analysis
 
-* [Find closest facility to an incident (interactive)](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
-* [Find closest facility to multiple incidents (service)](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
-* [Find route](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/FindRoute/readme.md) - Display directions for a route between two points.
-* [Find service area](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
-* [Find service areas for multiple facilities](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
-* [Offline routing](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
-* [Route around barriers](ArcGISRuntime.WPF.Viewer/Samples/Network Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
+* [Find closest facility to an incident (interactive)](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
+* [Find closest facility to multiple incidents (service)](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
+* [Find route](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/FindRoute/readme.md) - Display directions for a route between two points.
+* [Find service area](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
+* [Find service areas for multiple facilities](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
+* [Offline routing](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
+* [Route around barriers](ArcGISRuntime.WPF.Viewer/Samples/Network%20Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
 
 ## Search
 

--- a/src/iOS/readme.md
+++ b/src/iOS/readme.md
@@ -184,13 +184,13 @@
 
 ## Network Analysis
 
-* [Find closest facility to an incident (interactive)](Xamarin.iOS/Samples/Network Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
-* [Find closest facility to multiple incidents (service)](Xamarin.iOS/Samples/Network Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
-* [Find route](Xamarin.iOS/Samples/Network Analysis/FindRoute/readme.md) - Display directions for a route between two points.
-* [Find service area](Xamarin.iOS/Samples/Network Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
-* [Find service areas for multiple facilities](Xamarin.iOS/Samples/Network Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
-* [Offline routing](Xamarin.iOS/Samples/Network Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
-* [Route around barriers](Xamarin.iOS/Samples/Network Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
+* [Find closest facility to an incident (interactive)](Xamarin.iOS/Samples/Network%20Analysis/ClosestFacility/readme.md) - Find a route to the closest facility from a location.
+* [Find closest facility to multiple incidents (service)](Xamarin.iOS/Samples/Network%20Analysis/ClosestFacilityStatic/readme.md) - Find routes from several locations to the respective closest facility.
+* [Find route](Xamarin.iOS/Samples/Network%20Analysis/FindRoute/readme.md) - Display directions for a route between two points.
+* [Find service area](Xamarin.iOS/Samples/Network%20Analysis/FindServiceArea/readme.md) - Find the service area within a network from a given point.
+* [Find service areas for multiple facilities](Xamarin.iOS/Samples/Network%20Analysis/FindServiceAreasForMultipleFacilities/readme.md) - Find the service areas of several facilities from a feature service.
+* [Offline routing](Xamarin.iOS/Samples/Network%20Analysis/OfflineRouting/readme.md) - Solve a route on-the-fly using offline data.
+* [Route around barriers](Xamarin.iOS/Samples/Network%20Analysis/RouteAroundBarriers/readme.md) - Find a route that reaches all stops without crossing any barriers.
 
 ## Search
 

--- a/tools/metadata_tools/process_metadata.py
+++ b/tools/metadata_tools/process_metadata.py
@@ -1,4 +1,5 @@
 from sample_metadata import *
+import urllib.parse
 import sys
 
 import os
@@ -76,7 +77,9 @@ def write_samples_toc(platform_dir, relative_path_to_samples, samples_in_categor
     for category in samples_in_categories.keys():
         readme_text += f"## {category}\n\n"
         for sample in samples_in_categories[category]:
-            readme_text += f"* [{sample.friendly_name}]({relative_path_to_samples}/{sample.category}/{sample.formal_name}/readme.md) - {sample.description}\n"
+            entry_url = f"{relative_path_to_samples}/{sample.category}/{sample.formal_name}/readme.md"
+            entry_url = urllib.parse.quote(entry_url)
+            readme_text += f"* [{sample.friendly_name}]({entry_url}) - {sample.description}\n"
         readme_text += "\n"
     
     readme_path = os.path.join(platform_dir, "../..", "readme.md")


### PR DESCRIPTION
Per the markdown spec, URLs can't have spaces in them. This PR fixes both the markdown TOC files and the script that generates them.