### PR TITLE
Forms.iOS: Fix for iOS devices with curved bottoms

### DIFF
--- a/src/Forms/Shared/SamplePage.xaml
+++ b/src/Forms/Shared/SamplePage.xaml
@@ -1,29 +1,49 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            x:Class="ArcGISRuntime.SamplePage"
-            >
+<ContentPage
+    x:Class="ArcGISRuntime.SamplePage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+    ios:Page.UseSafeArea="true">
     <ContentPage.ToolbarItems>
-        <ToolbarItem x:Name="DetailToolbarItem" Text="Details" Icon="Info.png"></ToolbarItem>
+        <ToolbarItem
+            x:Name="DetailToolbarItem"
+            Icon="Info.png"
+            Text="Details" />
     </ContentPage.ToolbarItems>
     <RelativeLayout>
-        <Frame x:Name="SampleContentPage"
-               RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent,Factor=1, Property=Width}"
-               RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Factor=1,Property=Height}"
-               RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Constant=0}"
-               RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Constant=0}"
-               Padding="0"
-               CornerRadius="0">
-        </Frame>
-        <Frame x:Name="SampleDetailPage"
-               RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent,Factor=.9,Property=Width}"
-               RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent,Factor=.05,Property=Width}"
-               RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent, Factor=.9,Property=Height}"
-               RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent, Factor=.05,Property=Height}"
-               Padding="0"
-               IsVisible="False"
-               CornerRadius="0">
-            <WebView x:Name="DescriptionView"/>
+        <Frame
+            x:Name="SampleContentPage"
+            Padding="0"
+            CornerRadius="0"
+            RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                                   Factor=1,
+                                                                   Property=Height}"
+            RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                                  Factor=1,
+                                                                  Property=Width}"
+            RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                              Constant=0}"
+            RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                              Constant=0}" />
+        <Frame
+            x:Name="SampleDetailPage"
+            Padding="0"
+            CornerRadius="0"
+            IsVisible="False"
+            RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                                   Factor=.9,
+                                                                   Property=Height}"
+            RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                                  Factor=.9,
+                                                                  Property=Width}"
+            RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                              Factor=.05,
+                                                              Property=Width}"
+            RelativeLayout.YConstraint="{ConstraintExpression Type=RelativeToParent,
+                                                              Factor=.05,
+                                                              Property=Height}">
+            <WebView x:Name="DescriptionView" />
         </Frame>
     </RelativeLayout>
 </ContentPage>

--- a/src/Forms/Shared/SamplePage.xaml
+++ b/src/Forms/Shared/SamplePage.xaml
@@ -16,6 +16,7 @@
             x:Name="SampleContentPage"
             Padding="0"
             CornerRadius="0"
+            HasShadow="False"
             RelativeLayout.HeightConstraint="{ConstraintExpression Type=RelativeToParent,
                                                                    Factor=1,
                                                                    Property=Height}"

--- a/src/Forms/Shared/SamplePage.xaml.cs
+++ b/src/Forms/Shared/SamplePage.xaml.cs
@@ -7,15 +7,11 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGISRuntime.Samples.Shared.Models;
 using System;
 using System.Diagnostics;
-using ArcGISRuntime.Samples.Shared.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
-
-#if __IOS__
-using UIKit;
-#endif
 
 namespace ArcGISRuntime
 {
@@ -41,14 +37,6 @@ namespace ArcGISRuntime
 
             // Update the content - this displays the sample.
             SampleContentPage.Content = sample.Content;
-
-#if __IOS__
-            // Move the bottom of the sample up on iOS devices without home buttons.
-            if (UIApplication.SharedApplication.Delegate.GetWindow()?.SafeAreaInsets.Top > 20 || UIApplication.SharedApplication.Delegate.GetWindow()?.SafeAreaInsets.Top == 0)
-            {
-                SampleContentPage.Padding = new Thickness() { Bottom = 34 };
-            }
-#endif
 
             // Because the sample control isn't navigated to (its content is displayed directly),
             //    navigation won't work from within the sample until the parent is manually set.

--- a/src/Forms/Shared/SamplePage.xaml.cs
+++ b/src/Forms/Shared/SamplePage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Esri.
+﻿// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -12,6 +12,10 @@ using System.Diagnostics;
 using ArcGISRuntime.Samples.Shared.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+
+#if __IOS__
+using UIKit;
+#endif
 
 namespace ArcGISRuntime
 {
@@ -38,11 +42,19 @@ namespace ArcGISRuntime
             // Update the content - this displays the sample.
             SampleContentPage.Content = sample.Content;
 
+#if __IOS__
+            // Move the bottom of the sample up on iOS devices without home buttons.
+            if (UIApplication.SharedApplication.Delegate.GetWindow()?.SafeAreaInsets.Top > 20 || UIApplication.SharedApplication.Delegate.GetWindow()?.SafeAreaInsets.Top == 0)
+            {
+                SampleContentPage.Padding = new Thickness() { Bottom = 34 };
+            }
+#endif
+
             // Because the sample control isn't navigated to (its content is displayed directly),
             //    navigation won't work from within the sample until the parent is manually set.
             sample.Parent = this;
 
-            // Set the title. If the sample control didn't 
+            // Set the title. If the sample control didn't
             // define the title, use the name from the sample metadata.
             if (!String.IsNullOrWhiteSpace(sample.Title))
             {


### PR DESCRIPTION
This is a UI fix for xamarin forms iOS. It adds padding to the bottom to prevent the map from overlapping with the bottom control on iOS devices. 34 is not a magic number, it is the actual safe value for from the bottom control.