### PR TITLE
Simple Renderer implementation update

### DIFF
--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
@@ -1,10 +1,10 @@
-// Copyright 2016 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Android.App;
@@ -15,12 +15,12 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
-using System;
+using System.Drawing;
 
 namespace ArcGISRuntime.Samples.AddGraphicsRenderer
 {
-    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
-    [ArcGISRuntime.Samples.Shared.Attributes.Sample(
+    [Activity(ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
+    [Shared.Attributes.Sample(
         "Add graphics (SimpleRenderer)",
         "GraphicsOverlay",
         "This sample demonstrates how you add graphics and set a renderer on a graphic overlays.",
@@ -35,81 +35,64 @@ namespace ArcGISRuntime.Samples.AddGraphicsRenderer
             base.OnCreate(bundle);
 
             Title = "Add graphics (Renderer)";
-            
-            // Create the UI, setup the control references and execute initialization 
+
+            // Create the UI, setup the control references and execute initialization
             CreateLayout();
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, 34.056295, -117.195800, 14);
+            // Create a map with 'Imagery with Labels' basemap.
+            Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
-            // Create graphics when MapView's viewpoint is initialized
-            _myMapView.ViewpointChanged += OnViewpointChanged;
-
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             _myMapView.Map = myMap;
-        }
 
-        private void OnViewpointChanged(object sender, EventArgs e)
-        {
-            // Unhook the event
-            _myMapView.ViewpointChanged -= OnViewpointChanged;
+            // Create a center point for the graphics.
+            MapPoint centerPoint = new MapPoint(-117.195800, 34.056295, SpatialReferences.Wgs84);
 
-            // Get area that is shown in a MapView
-            Polygon visibleArea = _myMapView.VisibleArea;
+            // Create an envelope from that center point.
+            Envelope pointExtent = new Envelope(centerPoint, .07, .035);
 
-            // Get extent of that area
-            Envelope extent = visibleArea.Extent;
-   
-            // Get central point of the extent
-            MapPoint centerPoint = extent.GetCenter();
+            // Create a collection of points on the corners of the envelope.
+            PointCollection points = new PointCollection(SpatialReferences.Wgs84)
+            {
+                new MapPoint(pointExtent.XMax, pointExtent.YMax),
+                new MapPoint(pointExtent.XMax, pointExtent.YMin),
+                new MapPoint(pointExtent.XMin, pointExtent.YMax),
+                new MapPoint(pointExtent.XMin, pointExtent.YMin),
+            };
 
-            // Create values inside the visible extent for creating graphic
-            double extentWidth = extent.Width / 5;
-            double extentHeight = extent.Height / 10;
-
-            // Create point collection
-            PointCollection points = new PointCollection(SpatialReferences.WebMercator)
-                {
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y - extentHeight * 2),
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y - extentHeight * 2)
-                };
-
-            // Create overlay to where graphics are shown
+            // Create overlay to where graphics are shown.
             GraphicsOverlay overlay = new GraphicsOverlay();
 
-            // Add points to the graphics overlay
+            // Add points to the graphics overlay.
             foreach (MapPoint point in points)
             {
-                // Create new graphic and add it to the overlay
+                // Create new graphic and add it to the overlay.
                 overlay.Graphics.Add(new Graphic(point));
             }
 
-            // Create symbol for points
+            // Create symbol for points.
             SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol()
             {
-                Color = System.Drawing.Color.Yellow,
+                Color = Color.Yellow,
                 Size = 30,
                 Style = SimpleMarkerSymbolStyle.Square
             };
 
-            // Create simple renderer with symbol
+            // Create simple renderer with symbol.
             SimpleRenderer renderer = new SimpleRenderer(pointSymbol);
 
-            // Set renderer to graphics overlay
+            // Set renderer to graphics overlay.
             overlay.Renderer = renderer;
 
-            // Make sure that the UI changes are done in the UI thread
-            RunOnUiThread(() =>
-            {
-                // Add created overlay to the MapView
-                _myMapView.GraphicsOverlays.Add(overlay);
-            });
+            // Add created overlay to the MapView.
+            _myMapView.GraphicsOverlays.Add(overlay);
+
+            // Center the MapView on the points.
+            _myMapView.SetViewpointGeometryAsync(pointExtent, 50);
         }
 
         private void CreateLayout()

--- a/src/Forms/Shared/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
@@ -1,23 +1,21 @@
-// Copyright 2016 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
-using System;
 using Xamarin.Forms;
-using Colors = System.Drawing.Color;
 
 namespace ArcGISRuntime.Samples.AddGraphicsRenderer
 {
-    [ArcGISRuntime.Samples.Shared.Attributes.Sample(
+    [Shared.Attributes.Sample(
         "Add graphics (SimpleRenderer)",
         "GraphicsOverlay",
         "This sample demonstrates how you add graphics and set a renderer on a graphic overlays.",
@@ -27,80 +25,61 @@ namespace ArcGISRuntime.Samples.AddGraphicsRenderer
         public AddGraphicsRenderer()
         {
             InitializeComponent();
-
-            // Create the UI, setup the control references and execute initialization 
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, 34.056295, -117.195800, 14);
+            // Create a map with 'Imagery with Labels' basemap.
+            Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
-            // Create graphics when MapView's viewpoint is initialized
-            MyMapView.ViewpointChanged += OnViewpointChanged; 
-            
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
-        }
 
-        private void OnViewpointChanged(object sender, EventArgs e)
-        {
-            // Unhook the event
-            MyMapView.ViewpointChanged -= OnViewpointChanged;
+            // Create a center point for the graphics.
+            MapPoint centerPoint = new MapPoint(-117.195800, 34.056295, SpatialReferences.Wgs84);
 
-            // Get area that is shown in a MapView
-            Polygon visibleArea = MyMapView.VisibleArea;
+            // Create an envelope from that center point.
+            Envelope pointExtent = new Envelope(centerPoint, .07, .035);
 
-            // Get extent of that area
-            Envelope extent = visibleArea.Extent;
+            // Create a collection of points on the corners of the envelope.
+            PointCollection points = new PointCollection(SpatialReferences.Wgs84)
+            {
+                new MapPoint(pointExtent.XMax, pointExtent.YMax),
+                new MapPoint(pointExtent.XMax, pointExtent.YMin),
+                new MapPoint(pointExtent.XMin, pointExtent.YMax),
+                new MapPoint(pointExtent.XMin, pointExtent.YMin),
+            };
 
-            // Get central point of the extent
-            MapPoint centerPoint = extent.GetCenter();
-
-            // Create values inside the visible extent for creating graphic
-            double extentWidth = extent.Width / 5;
-            double extentHeight = extent.Height / 10;
-
-            // Create point collection
-            PointCollection points = new PointCollection(SpatialReferences.WebMercator)
-                {
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y - extentHeight * 2),
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y - extentHeight * 2)
-                };
-
-            // Create overlay to where graphics are shown
+            // Create overlay to where graphics are shown.
             GraphicsOverlay overlay = new GraphicsOverlay();
 
-            // Add points to the graphics overlay
+            // Add points to the graphics overlay.
             foreach (MapPoint point in points)
             {
-                // Create new graphic and add it to the overlay
+                // Create new graphic and add it to the overlay.
                 overlay.Graphics.Add(new Graphic(point));
             }
 
-            // Create symbol for points
+            // Create symbol for points.
             SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol()
             {
-                Color = Colors.Yellow,
+                Color = Color.Yellow,
                 Size = 30,
                 Style = SimpleMarkerSymbolStyle.Square
             };
 
-            // Create simple renderer with symbol
+            // Create simple renderer with symbol.
             SimpleRenderer renderer = new SimpleRenderer(pointSymbol);
 
-            // Set renderer to graphics overlay
+            // Set renderer to graphics overlay.
             overlay.Renderer = renderer;
 
-            // Make sure that the UI changes are done in the UI thread
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                // Add created overlay to the MapView
-                MyMapView.GraphicsOverlays.Add(overlay);
-            });
+            // Add created overlay to the MapView.
+            MyMapView.GraphicsOverlays.Add(overlay);
+
+            // Center the MapView on the points.
+            MyMapView.SetViewpointGeometryAsync(pointExtent, 50);
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
@@ -1,17 +1,16 @@
-// Copyright 2016 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
-using System;
 using System.Drawing;
 
 namespace ArcGISRuntime.UWP.Samples.AddGraphicsRenderer
@@ -26,61 +25,43 @@ namespace ArcGISRuntime.UWP.Samples.AddGraphicsRenderer
         public AddGraphicsRenderer()
         {
             InitializeComponent();
-
-            // Create the UI, setup the control references and execute initialization 
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, 34.056295, -117.195800, 14);
+            // Create a map with 'Imagery with Labels' basemap.
+            Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
-            // Create graphics when MapView's viewpoint is initialized
-            MyMapView.ViewpointChanged += OnViewpointChanged;
-
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
-        }
 
-        private void OnViewpointChanged(object sender, EventArgs e)
-        {
-            // Unhook the event
-            MyMapView.ViewpointChanged -= OnViewpointChanged;
+            // Create a center point for the graphics.
+            MapPoint centerPoint = new MapPoint(-117.195800, 34.056295, SpatialReferences.Wgs84);
 
-            // Get area that is shown in a MapView
-            Polygon visibleArea = MyMapView.VisibleArea;
+            // Create an envelope from that center point.
+            Envelope pointExtent = new Envelope(centerPoint, .07, .035);
 
-            // Get extent of that area
-            Envelope extent = visibleArea.Extent;
+            // Create a collection of points on the corners of the envelope.
+            PointCollection points = new PointCollection(SpatialReferences.Wgs84)
+            {
+                new MapPoint(pointExtent.XMax, pointExtent.YMax),
+                new MapPoint(pointExtent.XMax, pointExtent.YMin),
+                new MapPoint(pointExtent.XMin, pointExtent.YMax),
+                new MapPoint(pointExtent.XMin, pointExtent.YMin),
+            };
 
-            // Get central point of the extent
-            MapPoint centerPoint = extent.GetCenter();
-
-            // Create values inside the visible extent for creating graphic
-            double extentWidth = extent.Width / 5;
-            double extentHeight = extent.Height / 10;
-
-            // Create point collection
-            PointCollection points = new PointCollection(SpatialReferences.WebMercator)
-                {
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y - extentHeight * 2),
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y - extentHeight * 2)
-                };
-
-            // Create overlay to where graphics are shown
+            // Create overlay to where graphics are shown.
             GraphicsOverlay overlay = new GraphicsOverlay();
 
-            // Add points to the graphics overlay
+            // Add points to the graphics overlay.
             foreach (MapPoint point in points)
             {
-                // Create new graphic and add it to the overlay
+                // Create new graphic and add it to the overlay.
                 overlay.Graphics.Add(new Graphic(point));
             }
 
-            // Create symbol for points
+            // Create symbol for points.
             SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol()
             {
                 Color = Color.Yellow,
@@ -88,14 +69,17 @@ namespace ArcGISRuntime.UWP.Samples.AddGraphicsRenderer
                 Style = SimpleMarkerSymbolStyle.Square
             };
 
-            // Create simple renderer with symbol
+            // Create simple renderer with symbol.
             SimpleRenderer renderer = new SimpleRenderer(pointSymbol);
 
-            // Set renderer to graphics overlay
+            // Set renderer to graphics overlay.
             overlay.Renderer = renderer;
 
-            // Add created overlay to the MapView
+            // Add created overlay to the MapView.
             MyMapView.GraphicsOverlays.Add(overlay);
+
+            // Center the MapView on the points.
+            MyMapView.SetViewpointGeometryAsync(pointExtent, 50);
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
@@ -1,17 +1,16 @@
-// Copyright 2016 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
-using System;
 using System.Drawing;
 
 namespace ArcGISRuntime.WPF.Samples.AddGraphicsRenderer
@@ -26,61 +25,43 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsRenderer
         public AddGraphicsRenderer()
         {
             InitializeComponent();
-
-            // Create the UI, setup the control references and execute initialization 
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, 34.056295, -117.195800, 14);
+            // Create a map with 'Imagery with Labels' basemap and an initial location.
+            Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
-            // Create graphics when MapView's viewpoint is initialized
-            MyMapView.ViewpointChanged += OnViewpointChanged;
-
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
-        }
 
-        private void OnViewpointChanged(object sender, EventArgs e)
-        {
-            // Unhook the event
-            MyMapView.ViewpointChanged -= OnViewpointChanged;
+            // Create a center point for the graphics.
+            MapPoint centerPoint = new MapPoint(-117.195800, 34.056295, SpatialReferences.Wgs84);
 
-            // Get area that is shown in a MapView
-            Polygon visibleArea = MyMapView.VisibleArea;
+            // Create an envelope from that center point.
+            Envelope pointExtent = new Envelope(centerPoint, .07, .035);
 
-            // Get extent of that area
-            Envelope extent = visibleArea.Extent;
+            // Create a collection of points on the corners of the envelope.
+            PointCollection points = new PointCollection(SpatialReferences.Wgs84)
+            {
+                new MapPoint(pointExtent.XMax, pointExtent.YMax),
+                new MapPoint(pointExtent.XMax, pointExtent.YMin),
+                new MapPoint(pointExtent.XMin, pointExtent.YMax),
+                new MapPoint(pointExtent.XMin, pointExtent.YMin),
+            };
 
-            // Get central point of the extent
-            MapPoint centerPoint = extent.GetCenter();
-
-            // Create values inside the visible extent for creating graphic
-            double extentWidth = extent.Width / 5;
-            double extentHeight = extent.Height / 10;
-
-            // Create point collection
-            Esri.ArcGISRuntime.Geometry.PointCollection points = new Esri.ArcGISRuntime.Geometry.PointCollection(SpatialReferences.WebMercator)
-                {
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y - extentHeight * 2),
-                    new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                    new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y - extentHeight * 2)
-                };
-
-            // Create overlay to where graphics are shown
+            // Create overlay to where graphics are shown.
             GraphicsOverlay overlay = new GraphicsOverlay();
 
-            // Add points to the graphics overlay
+            // Add points to the graphics overlay.
             foreach (MapPoint point in points)
             {
-                // Create new graphic and add it to the overlay
+                // Create new graphic and add it to the overlay.
                 overlay.Graphics.Add(new Graphic(point));
             }
 
-            // Create symbol for points
+            // Create symbol for points.
             SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol()
             {
                 Color = Color.Yellow,
@@ -88,14 +69,17 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsRenderer
                 Style = SimpleMarkerSymbolStyle.Square
             };
 
-            // Create simple renderer with symbol
+            // Create simple renderer with symbol.
             SimpleRenderer renderer = new SimpleRenderer(pointSymbol);
 
-            // Set renderer to graphics overlay
+            // Set renderer to graphics overlay.
             overlay.Renderer = renderer;
 
-            // Add created overlay to the MapView
+            // Add created overlay to the MapView.
             MyMapView.GraphicsOverlays.Add(overlay);
+
+            // Center the MapView on the points.
+            MyMapView.SetViewpointGeometryAsync(pointExtent, 50);
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.xaml.cs
@@ -30,7 +30,7 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsRenderer
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location.
+            // Create a map with 'Imagery with Labels' basemap.
             Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
             // Assign the map to the MapView.

--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/AddGraphicsRenderer/AddGraphicsRenderer.cs
@@ -1,25 +1,25 @@
-// Copyright 2016 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
 using Foundation;
+using System.Drawing;
 using UIKit;
 
 namespace ArcGISRuntime.Samples.AddGraphicsRenderer
 {
     [Register("AddGraphicsRenderer")]
-    [ArcGISRuntime.Samples.Shared.Attributes.Sample(
+    [Shared.Attributes.Sample(
         "Add graphics (SimpleRenderer)",
         "GraphicsOverlay",
         "This sample demonstrates how you add graphics and set a renderer on a graphic overlays.",
@@ -36,43 +36,28 @@ namespace ArcGISRuntime.Samples.AddGraphicsRenderer
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location.
-            Map map = new Map(BasemapType.ImageryWithLabels, 34.056295, -117.195800, 14);
-
-            // Create graphics when MapView's viewpoint is initialized.
-            _myMapView.ViewpointChanged += OnViewpointChanged;
+            // Create a map with 'Imagery with Labels' basemap.
+            Map myMap = new Map(Basemap.CreateImageryWithLabels());
 
             // Assign the map to the MapView.
-            _myMapView.Map = map;
-        }
+            _myMapView.Map = myMap;
 
-        private void OnViewpointChanged(object sender, EventArgs e)
-        {
-            // Unhook the event.
-            _myMapView.ViewpointChanged -= OnViewpointChanged;
+            // Create a center point for the graphics.
+            MapPoint centerPoint = new MapPoint(-117.195800, 34.056295, SpatialReferences.Wgs84);
 
-            // Get area that is shown in a MapView.
-            Polygon visibleArea = _myMapView.VisibleArea;
+            // Create an envelope from that center point.
+            Envelope pointExtent = new Envelope(centerPoint, .07, .035);
 
-            // Get extent of that area.
-            Envelope extent = visibleArea.Extent;
-
-            // Get central point of the extent.
-            MapPoint centerPoint = extent.GetCenter();
-
-            // Create values inside the visible extent for creating graphic.
-            double extentWidth = extent.Width / 5;
-            double extentHeight = extent.Height / 10;
-
-            // Create point collection.
-            PointCollection points = new PointCollection(SpatialReferences.WebMercator)
+            // Create a collection of points on the corners of the envelope.
+            PointCollection points = new PointCollection(SpatialReferences.Wgs84)
             {
-                new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y - extentHeight * 2),
-                new MapPoint(centerPoint.X - extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y + extentHeight * 2),
-                new MapPoint(centerPoint.X + extentWidth * 2, centerPoint.Y - extentHeight * 2)
+                new MapPoint(pointExtent.XMax, pointExtent.YMax),
+                new MapPoint(pointExtent.XMax, pointExtent.YMin),
+                new MapPoint(pointExtent.XMin, pointExtent.YMax),
+                new MapPoint(pointExtent.XMin, pointExtent.YMin),
             };
 
+            // Create overlay to where graphics are shown.
             GraphicsOverlay overlay = new GraphicsOverlay();
 
             // Add points to the graphics overlay.
@@ -83,22 +68,24 @@ namespace ArcGISRuntime.Samples.AddGraphicsRenderer
             }
 
             // Create symbol for points.
-            SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol
+            SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol()
             {
-                Color = System.Drawing.Color.Yellow,
+                Color = Color.Yellow,
                 Size = 30,
                 Style = SimpleMarkerSymbolStyle.Square
             };
 
-            // Create and used simple renderer with symbol.
-            overlay.Renderer = new SimpleRenderer(pointSymbol);
+            // Create simple renderer with symbol.
+            SimpleRenderer renderer = new SimpleRenderer(pointSymbol);
 
-            // Make sure that the UI changes are done in the UI thread.
-            InvokeOnMainThread(() =>
-            {
-                // Add created overlay to the MapView.
-                _myMapView.GraphicsOverlays.Add(overlay);
-            });
+            // Set renderer to graphics overlay.
+            overlay.Renderer = renderer;
+
+            // Add created overlay to the MapView.
+            _myMapView.GraphicsOverlays.Add(overlay);
+
+            // Center the MapView on the points.
+            _myMapView.SetViewpointGeometryAsync(pointExtent, 50);
         }
 
         public override void ViewDidLoad()


### PR DESCRIPTION
The Add graphics (SimpleRenderer) sample currently has an inconsistent bug as forms. the `Initialize` method has a race condition with the mapview loading that can put the yellow points outside of the starting viewpoint. I reworked the sample to eliminate this and have a better workflow in general. The corner points are now created from an envelope instead of doing math on a center point.