### PR TITLE
Location data source sample updates

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
@@ -231,5 +231,13 @@ namespace ArcGISRuntime.Samples.DisplayDeviceLocation
             // Show the layout in the app.
             SetContentView(layout);
         }
+
+        protected override void OnDestroy()
+        {
+            // Stop the location data source.
+            _myMapView?.LocationDisplay?.DataSource?.StopAsync();
+
+            base.OnDestroy();
+        }
     }
 }

--- a/src/Android/Xamarin.Android/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
+++ b/src/Android/Xamarin.Android/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
@@ -263,5 +263,13 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
         private void TrackingToggleButtonOnClick(object sender, EventArgs e) => ToggleLocationTracking();
 
         private void ShowMessage(string message, string title) => new AlertDialog.Builder(this).SetTitle(title).SetMessage(message).Show();
+
+        protected override void OnDestroy()
+        {
+            // Stop the location data source.
+            _myMapView?.LocationDisplay?.DataSource?.StopAsync();
+
+            base.OnDestroy();
+        }
     }
 }

--- a/src/Android/Xamarin.Android/Samples/Network analysis/NavigateRoute/NavigateRoute.cs
+++ b/src/Android/Xamarin.Android/Samples/Network analysis/NavigateRoute/NavigateRoute.cs
@@ -266,6 +266,14 @@ namespace ArcGISRuntimeXamarin.Samples.NavigateRoute
         {
             Console.WriteLine(status.ToString());
         }
+
+        protected override void OnDestroy()
+        {
+            // Stop the location data source.
+            _myMapView?.LocationDisplay?.DataSource?.StopAsync();
+
+            base.OnDestroy();
+        }
     }
 
     /*

--- a/src/Android/Xamarin.Android/Samples/Network analysis/NavigateRouteRerouting/NavigateRouteRerouting.cs
+++ b/src/Android/Xamarin.Android/Samples/Network analysis/NavigateRouteRerouting/NavigateRouteRerouting.cs
@@ -298,6 +298,14 @@ namespace ArcGISRuntimeXamarin.Samples.NavigateRouteRerouting
         {
             Console.WriteLine(status.ToString());
         }
+
+        protected override void OnDestroy()
+        {
+            // Stop the location data source.
+            _myMapView?.LocationDisplay?.DataSource?.StopAsync();
+
+            base.OnDestroy();
+        }
     }
 
     // This location data source uses an input data source and a route tracker.

--- a/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
@@ -452,6 +452,14 @@ namespace ArcGISRuntime.Samples.FindPlace
         }
         
         private void ShowMessage(string message, string title = "Error") => new AlertDialog.Builder(this).SetTitle(title).SetMessage(message).Show();
+
+        protected override void OnDestroy()
+        {
+            // Stop the location data source.
+            _myMapView?.LocationDisplay?.DataSource?.StopAsync();
+
+            base.OnDestroy();
+        }
     }
 
     #region Location Display Permissions

--- a/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -25,7 +25,7 @@ namespace ArcGISRuntime.Samples.DisplayDeviceLocation
         "Location",
         "This sample demonstrates how you can enable location services and switch between different types of auto pan modes.",
         "")]
-    public partial class DisplayDeviceLocation : ContentPage
+    public partial class DisplayDeviceLocation : ContentPage, IDisposable
     {
         // String array to store the different device location options.
         private string[] _navigationTypes =
@@ -107,6 +107,12 @@ namespace ArcGISRuntime.Samples.DisplayDeviceLocation
                 Debug.WriteLine(ex);
                 await Application.Current.MainPage.DisplayAlert("Couldn't start location", ex.Message, "OK");
             }
+        }
+
+        public void Dispose()
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/Forms/Shared/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/Forms/Shared/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -24,7 +24,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
         "Display your location history on the map.",
         "")]
     [ArcGISRuntime.Samples.Shared.Attributes.ClassFile("FakeLocationDataSource.cs")]
-    public partial class ShowLocationHistory : ContentPage
+    public partial class ShowLocationHistory : ContentPage, IDisposable
     {
         // URL to the raster dark gray canvas basemap.
         private const string BasemapUrl = "https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45";
@@ -172,6 +172,12 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
         private async void ShowMessage(string title, string detail)
         {
             await Application.Current.MainPage.DisplayAlert(title, detail, "OK");
+        }
+
+        public void Dispose()
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -33,7 +33,7 @@ namespace ArcGISRuntime.Samples.FindPlace
         "This sample demonstrates how to use geocode functionality to search for points of interest, around a location or within an extent.",
         "1. Enter a point of interest you'd like to search for (e.g. 'Starbucks')\n2. Enter a search location or accept the default 'Current Location'\n3. Select 'search all' to get all results, or press 'search view' to only get results within the current extent.")]
     [ArcGISRuntime.Samples.Shared.Attributes.EmbeddedResource(@"PictureMarkerSymbols\pin_star_blue.png")]
-    public partial class FindPlace : ContentPage
+    public partial class FindPlace : ContentPage, IDisposable
     {
         // The LocatorTask provides geocoding services
         private LocatorTask _geocoder;
@@ -440,6 +440,12 @@ namespace ArcGISRuntime.Samples.FindPlace
         {
             // Hide the callout.
             MyMapView.DismissCallout();
+        }
+
+        public void Dispose()
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -40,6 +40,9 @@ namespace ArcGISRuntime.UWP.Samples.DisplayDeviceLocation
 
         private void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Assign the map to the MapView.
             MyMapView.Map = new Map(Basemap.CreateTopographic());
 
@@ -79,6 +82,12 @@ namespace ArcGISRuntime.UWP.Samples.DisplayDeviceLocation
                     MyMapView.LocationDisplay.AutoPanMode = LocationDisplayAutoPanMode.CompassNavigation;
                     break;
             }
+        }
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -52,6 +52,9 @@ namespace ArcGISRuntime.UWP.Samples.ShowLocationHistory
 
         private void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Create new Map with basemap.
             Map myMap = new Map(Basemap.CreateDarkGrayCanvasVector());
 
@@ -159,6 +162,12 @@ namespace ArcGISRuntime.UWP.Samples.ShowLocationHistory
         private async void ShowMessage(string title, string detail)
         {
             await new MessageDialog(detail, title).ShowAsync();
+        }
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -50,6 +50,9 @@ namespace ArcGISRuntime.UWP.Samples.FindPlace
 
         private async void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Create new Map with basemap
             Map myMap = new Map(Basemap.CreateStreets());
 
@@ -409,6 +412,12 @@ namespace ArcGISRuntime.UWP.Samples.FindPlace
         {
             // Hide the callout
             MyMapView.DismissCallout();
+        }
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.xaml.cs
@@ -34,6 +34,9 @@ namespace ArcGISRuntime.WPF.Samples.DisplayDeviceLocation
 
         private void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Create new Map with basemap
             Map myMap = new Map(Basemap.CreateImagery());
 
@@ -105,6 +108,12 @@ namespace ArcGISRuntime.WPF.Samples.DisplayDeviceLocation
                     MyMapView.LocationDisplay.IsEnabled = true;
                     break;
             }
+        }
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -51,6 +51,9 @@ namespace ArcGISRuntime.WPF.Samples.ShowLocationHistory
 
         private void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Create new Map with basemap.
             Map myMap = new Map(Basemap.CreateDarkGrayCanvasVector());
 
@@ -156,5 +159,11 @@ namespace ArcGISRuntime.WPF.Samples.ShowLocationHistory
         private void LocationTrackingButton_OnClick(object sender, RoutedEventArgs e) => ToggleLocationTracking();
 
         private void ShowMessage(string title, string detail) => MessageBox.Show(detail, title);
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
+        }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -53,6 +53,9 @@ namespace ArcGISRuntime.WPF.Samples.FindPlace
 
         private async void Initialize()
         {
+            // Add event handler for when this sample is unloaded.
+            Unloaded += SampleUnloaded;
+
             // Show a map with a streets basemap.
             MyMapView.Map = new Map(Basemap.CreateStreetsVector());
 
@@ -426,6 +429,12 @@ namespace ArcGISRuntime.WPF.Samples.FindPlace
 
             // Run the search.
             UpdateSearch(searchText, locationText);
+        }
+
+        private void SampleUnloaded(object sender, RoutedEventArgs e)
+        {
+            // Stop the location data source.
+            MyMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/iOS/Xamarin.iOS/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Location/DisplayDeviceLocation/DisplayDeviceLocation.cs
@@ -149,6 +149,9 @@ namespace ArcGISRuntime.Samples.DisplayDeviceLocation
             // Unsubscribe from events, per best practice.
             _startButton.Clicked -= OnStartButtonClicked;
             _stopButton.Clicked -= OnStopButtonClicked;
+
+            // Stop the location data source.
+            _myMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 }

--- a/src/iOS/Xamarin.iOS/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
@@ -218,6 +218,9 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
 
             // Unsubscribe from events, per best practice.
             _trackingToggleButton.Clicked -= TrackingToggleButtonOnClicked;
+
+            // Stop the location data source.
+            _myMapView.LocationDisplay?.DataSource?.StopAsync();
         }
 
         private void ShowMessage(string title, string detail)

--- a/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
@@ -626,6 +626,9 @@ namespace ArcGISRuntime.Samples.FindPlace
             _locationBox.AllEditingEvents -= LocationBox_TextChanged;
             _searchBox.ShouldReturn -= HandleTextField;
             _locationBox.ShouldReturn -= HandleTextField;
+
+            // Stop the location data source.
+            _myMapView.LocationDisplay?.DataSource?.StopAsync();
         }
     }
 


### PR DESCRIPTION
Updated the following samples to stop their `LocationDataSource` on close.

- Navigate Route
- Navigate Route (Rerouting)
- Find Place
- Show location history
- Display device location

This is best practice and prevents a leak.