### PR TITLE
UWP: Fix for IWA sample.

### DIFF
--- a/src/Forms/Shared/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.xaml.cs
+++ b/src/Forms/Shared/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.xaml.cs
@@ -85,7 +85,10 @@ namespace ArcGISRuntime.Samples.IntegratedWindowsAuth
             {
                 // Get the value entered for the secure portal URL.
                 string securedPortalUrl = PortalUrlEntry.Text.Trim();
-
+#if WINDOWS_UWP
+                // Create an instance of the IWA-secured portal, the user may be challenged for access.
+                _iwaSecuredPortal = await ArcGISPortal.CreateAsync(new Uri(securedPortalUrl), true);
+#else
                 // Make sure a portal URL has been entered in the text box.
                 if (string.IsNullOrEmpty(securedPortalUrl))
                 {
@@ -104,7 +107,7 @@ namespace ArcGISRuntime.Samples.IntegratedWindowsAuth
 
                 // Create an instance of the IWA-secured portal, the user may be challenged for access.
                 _iwaSecuredPortal = await ArcGISPortal.CreateAsync(new Uri(securedPortalUrl), true);
-
+#endif
                 // Call a function to search the portal.
                 SearchPortal(_iwaSecuredPortal);
 

--- a/src/Forms/UWP/Package.appxmanifest
+++ b/src/Forms/UWP/Package.appxmanifest
@@ -31,6 +31,7 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
+    <uap:Capability Name="enterpriseAuthentication"/>
     <DeviceCapability Name="location" />
   </Capabilities>
 </Package>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Package.appxmanifest
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Package.appxmanifest
@@ -33,6 +33,7 @@
     <Capability Name="privateNetworkClientServer" />
     <uap:Capability Name="picturesLibrary" />
     <uap:Capability Name="sharedUserCertificates"/>
+    <uap:Capability Name="enterpriseAuthentication"/>
     <DeviceCapability Name="location" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
Enabled Enterprise login in the app manifest. This allows the IWA sample to login without a prompt on UWP.