### PR TITLE
Fixes spurious UWP warning

### DIFF
--- a/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
+++ b/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>ArcGISRuntime</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>ArcGISRuntime</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>


### PR DESCRIPTION
This fixes the issue that caused the following warning to appear in Visual Studio:

![image](https://user-images.githubusercontent.com/29742178/74192221-ee9e7480-4c09-11ea-9ebc-086fc8132e34.png)

The updated csproj content more closely matches the templates.