### PR TITLE
Remove isolation trace option from trace utility network

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
+++ b/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
@@ -88,7 +88,8 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
                 _status.Text = "Loading Utility Network...";
 
                 // Setup Map with Feature Layer(s) that contain Utility Network.
-                _myMapView.Map = new Map(Basemap.CreateStreetsNightVector())
+                // Setup Map with Feature Layer(s) that contain Utility Network.
+                _myMapView.Map = new Map(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")))
                 {
                     InitialViewpoint = _startingViewpoint
                 };

--- a/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
+++ b/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
@@ -234,7 +234,7 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
             // Create UI for trace type selection.
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.SetTitle("Select trace type");
-            builder.SetItems(Enum.GetNames(typeof(UtilityTraceType)), ChangeTraceType);
+            builder.SetItems(new string[] { "Connected", "Subnetwork", "Upstream", "Downstream" }, ChangeTraceType);
             builder.SetCancelable(true);
             builder.Show();
         }

--- a/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
+++ b/src/Android/Xamarin.Android/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
@@ -87,8 +87,7 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
                 _progressBar.Visibility = Android.Views.ViewStates.Visible;
                 _status.Text = "Loading Utility Network...";
 
-                // Setup Map with Feature Layer(s) that contain Utility Network.
-                // Setup Map with Feature Layer(s) that contain Utility Network.
+                // Create a map.
                 _myMapView.Map = new Map(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")))
                 {
                     InitialViewpoint = _startingViewpoint

--- a/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -67,7 +67,7 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
                 Status.Text = "Loading Utility Network...";
 
                 // Setup Map with Feature Layer(s) that contain Utility Network.
-                MyMapView.Map = new Map(Basemap.CreateStreetsNightVector())
+                MyMapView.Map = new Map(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")))
                 {
                     InitialViewpoint = _startingViewpoint
                 };

--- a/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
                 BusyIndicator.IsVisible = true;
                 Status.Text = "Loading Utility Network...";
 
-                // Setup Map with Feature Layer(s) that contain Utility Network.
+                // Create a map.
                 MyMapView.Map = new Map(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")))
                 {
                     InitialViewpoint = _startingViewpoint

--- a/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/Forms/Shared/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -314,7 +314,8 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
             try
             {
                 // Prompt the user to select a type of trace.
-                string choice = await ((Page)Parent).DisplayActionSheet("Choose type of trace", "Cancel", null, Enum.GetNames(typeof(UtilityTraceType)));
+                var traceTypes = new string[] { "Connected", "Subnetwork", "Upstream", "Downstream" };
+                string choice = await ((Page)Parent).DisplayActionSheet("Choose type of trace", "Cancel", null, traceTypes);
 
                 // Set the selected trace type.
                 _selectedTraceType = (UtilityTraceType)Enum.Parse(typeof(UtilityTraceType), choice);

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.UWP.Samples.TraceUtilityNetwork
                 IsBusy.Visibility = Visibility.Visible;
                 Status.Text = "Loading Utility Network...";
 
-                // Setup Map with Feature Layer(s) that contain Utility Network.
+                // Create a map.
                 MyMapView.Map = new Map(Basemap.CreateStreetsNightVector())
                 {
                     InitialViewpoint = _startingViewpoint

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -90,7 +90,7 @@ namespace ArcGISRuntime.UWP.Samples.TraceUtilityNetwork
                 _utilityNetwork = await UtilityNetwork.CreateAsync(new Uri(FeatureServiceUrl), MyMapView.Map);
 
                 // Update the trace configuration UI.
-                TraceTypes.ItemsSource = Enum.GetValues(typeof(UtilityTraceType));
+                TraceTypes.ItemsSource = new List<UtilityTraceType>() { UtilityTraceType.Connected, UtilityTraceType.Subnetwork, UtilityTraceType.Upstream, UtilityTraceType.Downstream };
                 TraceTypes.SelectedIndex = 0;
 
                 // Get the utility tier used for traces in this network. For this data set, the "Medium Voltage Radial" tier from the "ElectricDistribution" domain network is used.

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGISRuntime.WPF.Samples.TraceUtilityNetwork
                 IsBusy.Visibility = Visibility.Visible;
                 Status.Text = "Loading Utility Network...";
 
-                // Setup Map with Feature Layer(s) that contain Utility Network.
+                // Create a map.
                 MyMapView.Map = new Map(Basemap.CreateStreetsNightVector())
                 {
                     InitialViewpoint = _startingViewpoint

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.xaml.cs
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.WPF.Samples.TraceUtilityNetwork
                 _utilityNetwork = await UtilityNetwork.CreateAsync(new Uri(FeatureServiceUrl), MyMapView.Map);
 
                 // Update the trace configuration UI.
-                TraceTypes.ItemsSource = Enum.GetValues(typeof(UtilityTraceType));
+                TraceTypes.ItemsSource = new List<UtilityTraceType>() {UtilityTraceType.Connected, UtilityTraceType.Subnetwork, UtilityTraceType.Upstream, UtilityTraceType.Downstream};
                 TraceTypes.SelectedIndex = 0;
 
                 // Get the utility tier used for traces in this network. For this data set, the "Medium Voltage Radial" tier from the "ElectricDistribution" domain network is used.

--- a/src/iOS/Xamarin.iOS/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
@@ -77,7 +77,7 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
                 _activityIndicator.StartAnimating();
                 _statusLabel.Text = "Loading Utility Network...";
 
-                // Setup Map with Feature Layer(s) that contain Utility Network.
+                // Create a map.
                 _myMapView.Map = new Map(Basemap.CreateStreetsNightVector())
                 {
                     InitialViewpoint = _startingViewpoint

--- a/src/iOS/Xamarin.iOS/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Utility network/TraceUtilityNetwork/TraceUtilityNetwork.cs
@@ -245,8 +245,8 @@ namespace ArcGISRuntimeXamarin.Samples.TraceUtilityNetwork
             // Start the UI for the user choosing the trace type.
             UIAlertController prompt = UIAlertController.Create(null, "Choose trace type", UIAlertControllerStyle.ActionSheet);
 
-            // Add a selection action for every trace type.
-            foreach (string name in Enum.GetNames(typeof(UtilityTraceType)))
+            // Add a selection action for every valid trace type.
+            foreach (string name in new string[] { "Connected", "Subnetwork", "Upstream", "Downstream" })
             {
                 prompt.AddAction(UIAlertAction.Create(name, UIAlertActionStyle.Default, TraceTypeClick));
             }


### PR DESCRIPTION
The enum now includes isolation trace, which can't be used in the context of this sample. This PR removes it as an option from the UI. I also removed the vector basemaps from Android platforms, as they load inconsistently.