### PR TITLE
Update Convex hull & Nearest vertex samples

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Geometry/ConvexHull/ConvexHull.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/ConvexHull/ConvexHull.cs
@@ -36,7 +36,7 @@ namespace ArcGISRuntime.Samples.ConvexHull
         private GraphicsOverlay _graphicsOverlay;
 
         // List of geometry values (MapPoints in this case) that will be used by the GeometryEngine.ConvexHull operation.
-        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.Wgs84);
+        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.WebMercator);
 
         // Create a Button to create a convex hull.
         private Button _convexHullButton;
@@ -76,11 +76,11 @@ namespace ArcGISRuntime.Samples.ConvexHull
         {
             try
             {
-                // Project the tapped location to WGS 84.
-                var projectedPoint = (MapPoint)GeometryEngine.Project(e.Location, SpatialReferences.Wgs84);
+                // Normalize the tapped point.
+                var centralizedPoint = (MapPoint)GeometryEngine.NormalizeCentralMeridian(e.Location);
 
                 // Add the map point to the list that will be used by the GeometryEngine.ConvexHull operation.
-                _inputPointCollection.Add(projectedPoint);
+                _inputPointCollection.Add(centralizedPoint);
 
                 // Check if there are at least three points.
                 if (_inputPointCollection.Count > 2)

--- a/src/Android/Xamarin.Android/Samples/Geometry/NearestVertex/NearestVertex.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/NearestVertex/NearestVertex.cs
@@ -109,7 +109,7 @@ namespace ArcGISRuntime.Samples.NearestVertex
         private void MapViewTapped(object sender, GeoViewInputEventArgs geoViewInputEventArgs)
         {
             // Get the tapped location
-            MapPoint tappedLocation = geoViewInputEventArgs.Location;
+            MapPoint tappedLocation = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geoViewInputEventArgs.Location);
 
             // Show the tapped location
             _tappedLocationGraphic.Geometry = tappedLocation;
@@ -146,7 +146,7 @@ namespace ArcGISRuntime.Samples.NearestVertex
 
             // Add the label and map to the view
             layout.AddView(_resultTextView);
-            _myMapView = new MapView(this) { WrapAroundMode = WrapAroundMode.Disabled };
+            _myMapView = new MapView(this);
             layout.AddView(_myMapView);
 
             // Show the layout in the app.

--- a/src/Forms/Shared/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.Samples.ConvexHull
         private GraphicsOverlay _graphicsOverlay;
 
         // List of geometry values (MapPoints in this case) that will be used by the GeometryEngine.ConvexHull operation.
-        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.Wgs84);
+        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.WebMercator);
 
         public ConvexHull()
         {
@@ -65,11 +65,11 @@ namespace ArcGISRuntime.Samples.ConvexHull
         {
             try
             {
-                // Project the tapped location to WGS 84.
-                var projectedPoint = (MapPoint)GeometryEngine.Project(e.Location, SpatialReferences.Wgs84);
+                // Normalize the tapped point.
+                var centralizedPoint = (MapPoint)GeometryEngine.NormalizeCentralMeridian(e.Location);
 
                 // Add the map point to the list that will be used by the GeometryEngine.ConvexHull operation.
-                _inputPointCollection.Add(projectedPoint);
+                _inputPointCollection.Add(centralizedPoint);
 
                 // Check if there are at least three points.
                 if (_inputPointCollection.Count > 2)

--- a/src/Forms/Shared/Samples/Geometry/NearestVertex/NearestVertex.xaml
+++ b/src/Forms/Shared/Samples/Geometry/NearestVertex/NearestVertex.xaml
@@ -16,9 +16,6 @@
             TextColor="Red">
             Tap to see the nearest vertex and point.
         </Label>
-        <forms:MapView
-            x:Name="MyMapView"
-            Grid.Row="1"
-            WrapAroundMode="Disabled" />
+        <forms:MapView x:Name="MyMapView" Grid.Row="1" />
     </Grid>
 </ContentPage>

--- a/src/Forms/Shared/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
@@ -92,7 +92,7 @@ namespace ArcGISRuntime.Samples.NearestVertex
         private void MapViewTapped(object sender, Esri.ArcGISRuntime.Xamarin.Forms.GeoViewInputEventArgs geoViewInputEventArgs)
         {
             // Get the tapped location
-            MapPoint tappedLocation = geoViewInputEventArgs.Location;
+            MapPoint tappedLocation = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geoViewInputEventArgs.Location);
 
             // Show the tapped location
             _tappedLocationGraphic.Geometry = tappedLocation;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.UWP.Samples.ConvexHull
         private GraphicsOverlay _graphicsOverlay;
 
         // List of geometry values (MapPoints in this case) that will be used by the GeometryEngine.ConvexHull operation.
-        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.Wgs84);
+        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.WebMercator);
 
         public ConvexHull()
         {
@@ -65,11 +65,11 @@ namespace ArcGISRuntime.UWP.Samples.ConvexHull
         {
             try
             {
-                // Project the tapped location to WGS 84.
-                var projectedPoint = (MapPoint)GeometryEngine.Project(e.Location, SpatialReferences.Wgs84);
+                // Normalize the tapped point.
+                var centralizedPoint = (MapPoint)GeometryEngine.NormalizeCentralMeridian(e.Location);
 
                 // Add the map point to the list that will be used by the GeometryEngine.ConvexHull operation.
-                _inputPointCollection.Add(projectedPoint);
+                _inputPointCollection.Add(centralizedPoint);
 
                 // Check if there are at least three points.
                 if (_inputPointCollection.Count > 2)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Esri.ArcGISRuntime.UI.Controls">
     <Grid>
-        <controls:MapView x:Name="MyMapView" WrapAroundMode="Disabled" />
+        <controls:MapView x:Name="MyMapView" />
         <Border Style="{StaticResource BorderStyle}">
             <StackPanel>
                 <TextBlock

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
@@ -93,7 +93,7 @@ namespace ArcGISRuntime.UWP.Samples.NearestVertex
         private void MapViewTapped(object sender, GeoViewInputEventArgs geoViewInputEventArgs)
         {
             // Get the tapped location
-            MapPoint tappedLocation = geoViewInputEventArgs.Location;
+            MapPoint tappedLocation = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geoViewInputEventArgs.Location);
 
             // Show the tapped location
             _tappedLocationGraphic.Geometry = tappedLocation;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/ConvexHull/ConvexHull.xaml.cs
@@ -29,7 +29,7 @@ namespace ArcGISRuntime.WPF.Samples.ConvexHull
         private GraphicsOverlay _graphicsOverlay;
 
         // List of geometry values (MapPoints in this case) that will be used by the GeometryEngine.ConvexHull operation.
-        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.Wgs84);
+        private PointCollection _inputPointCollection = new PointCollection(SpatialReferences.WebMercator);
 
         public ConvexHull()
         {
@@ -63,11 +63,11 @@ namespace ArcGISRuntime.WPF.Samples.ConvexHull
         {
             try
             {
-                // Project the tapped location to WGS 84.
-                var projectedPoint = (MapPoint)GeometryEngine.Project(e.Location, SpatialReferences.Wgs84);
+                // Normalize the tapped point.
+                var centralizedPoint = (MapPoint)GeometryEngine.NormalizeCentralMeridian(e.Location);
 
                 // Add the map point to the list that will be used by the GeometryEngine.ConvexHull operation.
-                _inputPointCollection.Add(projectedPoint);
+                _inputPointCollection.Add(centralizedPoint);
 
                 // Check if there are at least three points.
                 if (_inputPointCollection.Count > 2)

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013">
     <Grid>
-        <esri:MapView x:Name="MyMapView" WrapAroundMode="Disabled" />
+        <esri:MapView x:Name="MyMapView" />
         <Border Style="{StaticResource BorderStyle}">
             <StackPanel>
                 <Label

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/NearestVertex/NearestVertex.xaml.cs
@@ -93,7 +93,7 @@ namespace ArcGISRuntime.WPF.Samples.NearestVertex
         private void MapViewTapped(object sender, GeoViewInputEventArgs geoViewInputEventArgs)
         {
             // Get the tapped location
-            MapPoint tappedLocation = geoViewInputEventArgs.Location;
+            MapPoint tappedLocation = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geoViewInputEventArgs.Location);
 
             // Show the tapped location
             _tappedLocationGraphic.Geometry = tappedLocation;

--- a/src/iOS/Xamarin.iOS/Samples/Geometry/ConvexHull/ConvexHull.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geometry/ConvexHull/ConvexHull.cs
@@ -39,7 +39,7 @@ namespace ArcGISRuntime.Samples.ConvexHull
         private GraphicsOverlay _graphicsOverlay;
 
         // List of geometry values (MapPoints in this case) that will be used by the GeometryEngine.ConvexHull operation.
-        private readonly PointCollection _inputPointCollection = new PointCollection(SpatialReferences.Wgs84);
+        private readonly PointCollection _inputPointCollection = new PointCollection(SpatialReferences.WebMercator);
 
         public ConvexHull()
         {
@@ -62,11 +62,11 @@ namespace ArcGISRuntime.Samples.ConvexHull
         {
             try
             {
-                // Project the tapped location to WGS 84.
-                var projectedPoint = (MapPoint)GeometryEngine.Project(e.Location, SpatialReferences.Wgs84);
+                // Normalize the tapped point.
+                var centralizedPoint = (MapPoint)GeometryEngine.NormalizeCentralMeridian(e.Location);
 
                 // Add the map point to the list that will be used by the GeometryEngine.ConvexHull operation.
-                _inputPointCollection.Add(projectedPoint);
+                _inputPointCollection.Add(centralizedPoint);
 
                 // Check if there are at least three points.
                 if (_inputPointCollection.Count > 2)

--- a/src/iOS/Xamarin.iOS/Samples/Geometry/NearestVertex/NearestVertex.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geometry/NearestVertex/NearestVertex.cs
@@ -95,7 +95,7 @@ namespace ArcGISRuntime.Samples.NearestVertex
         private void MyMapView_GeoViewTapped(object sender, GeoViewInputEventArgs geoViewInputEventArgs)
         {
             // Get the tapped location.
-            MapPoint tappedLocation = geoViewInputEventArgs.Location;
+            MapPoint tappedLocation = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geoViewInputEventArgs.Location);
 
             // Show the tapped location.
             _tappedLocationGraphic.Geometry = tappedLocation;
@@ -134,7 +134,7 @@ namespace ArcGISRuntime.Samples.NearestVertex
             // Create the views.
             View = new UIView() { BackgroundColor = UIColor.White };
 
-            _myMapView = new MapView() { WrapAroundMode = WrapAroundMode.Disabled };
+            _myMapView = new MapView();
             _myMapView.TranslatesAutoresizingMaskIntoConstraints = false;
 
             _distanceLabel = new UILabel


### PR DESCRIPTION
This PR updates the samples to use the recommended workflow of using the `GeometryEngine.NormalizeCentralMeridian` call to handle geometry in a wraparound mapview.