### PR TITLE
Android: Hide "Downloading data" dialog if download fails

### DIFF
--- a/src/Android/Xamarin.Android/MainActivity.cs
+++ b/src/Android/Xamarin.Android/MainActivity.cs
@@ -104,11 +104,16 @@ namespace ArcGISRuntime
                     AlertDialog dialog = builder.Create();
                     dialog.Show();
 
-                    // Begin downloading data.
-                    await DataManager.EnsureSampleDataPresent(item);
-
-                    // Hide the progress dialog.
-                    dialog.Dismiss();
+                    try
+                    {
+                        // Begin downloading data.
+                        await DataManager.EnsureSampleDataPresent(item);
+                    }
+                    finally
+                    {
+                        // Hide the progress dialog.
+                        dialog.Dismiss();
+                    }
                 }
 
                 // Each sample is an Activity, so locate it and launch it via an Intent.


### PR DESCRIPTION
Currently, the "Downloading data" dialog will never go away if data download fails.

This PR makes sure that the dialog gets dismissed no matter what happens in EnsureSampleDataPresent.