### PR TITLE
Removed or updated links in the sample ReadMe files

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -6,7 +6,7 @@ Display features from a local geodatabase.
 
 ## Use case
 
-Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage. 
+Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage.
 
 ## How it works
 
@@ -31,7 +31,7 @@ Accessing data from a local geodatabase is useful when working in an environment
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm).
 
 Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -33,7 +33,7 @@ One of the ArcGIS Runtime data set types that can be accessed via the local stor
 
 In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/net/latest/uwp/guide/take-a-layer-offline.htm.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 
 ## Tags
 

--- a/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/readme.md
@@ -32,10 +32,6 @@ When the sample loads, a feature service is taken offline as a geodatabase. When
 
 The sample uses a publicly-editable, sync-enabled [feature service](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer) demonstrating a schema for recording wildlife sightings.
 
-## Additional information
-
-You can learn more about geodatabase transactions in the [Use geodatabase transactions](https://developers.arcgis.com/net/latest/uwp/guide/use-geodatabase-transactions.htm) guide topic.
-
 ## Tags
 
 commit, database, geodatabase, transact, transactions

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableCache/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) in the *ArcGIS Runtime SDK for .NET* guide to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. 
 
 ## How to use the sample
 

--- a/src/Android/Xamarin.Android/Samples/Layers/ExportTiles/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Layers/ExportTiles/readme.md
@@ -30,7 +30,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGIS Online Developer's portal](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [Layer types](https://developers.arcgis.com/net/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 ## Tags
 

--- a/src/Android/Xamarin.Android/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -30,7 +30,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for .NET* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/src/Android/Xamarin.Android/Samples/Map/ApplyScheduledUpdates/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Map/ApplyScheduledUpdates/readme.md
@@ -46,7 +46,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline (preplanned)](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for .NET* guide.
+**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see the [Download preplanned map area](https://developers.arcgis.com/net/android/sample-code/download-preplanned-map-area/) sample. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/Android/Xamarin.Android/Samples/Map/DownloadPreplannedMap/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Map/DownloadPreplannedMap/readme.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `SyncWithFeatureServices` - Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `DownloadScheduledUpdates` - Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-on-demand.htm) or refer to the sample 'Generate Offline Map' to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/Android/Xamarin.Android/Samples/Symbology/CustomDictionaryStyle/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Symbology/CustomDictionaryStyle/readme.md
@@ -36,7 +36,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/net/latest/uwp/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for Java* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -6,7 +6,7 @@ Display features from a local geodatabase.
 
 ## Use case
 
-Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage. 
+Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage.
 
 ## How it works
 
@@ -31,9 +31,9 @@ Accessing data from a local geodatabase is useful when working in an environment
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm).
 
-Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -33,7 +33,7 @@ One of the ArcGIS Runtime data set types that can be accessed via the local stor
 
 In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/net/latest/uwp/guide/take-a-layer-offline.htm.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/readme.md
+++ b/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/readme.md
@@ -32,10 +32,6 @@ When the sample loads, a feature service is taken offline as a geodatabase. When
 
 The sample uses a publicly-editable, sync-enabled [feature service](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer) demonstrating a schema for recording wildlife sightings.
 
-## Additional information
-
-You can learn more about geodatabase transactions in the [Use geodatabase transactions](https://developers.arcgis.com/net/latest/uwp/guide/use-geodatabase-transactions.htm) guide topic.
-
 ## Tags
 
 commit, database, geodatabase, transact, transactions

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableCache/readme.md
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/readme.md
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/readme.md
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) in the *ArcGIS Runtime SDK for .NET* guide to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. 
 
 ## How to use the sample
 

--- a/src/Forms/Shared/Samples/Layers/ExportTiles/readme.md
+++ b/src/Forms/Shared/Samples/Layers/ExportTiles/readme.md
@@ -30,7 +30,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGIS Online Developer's portal](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [Layer types](https://developers.arcgis.com/net/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/Forms/Shared/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -30,7 +30,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for .NET* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/src/Forms/Shared/Samples/Map/ApplyScheduledUpdates/readme.md
+++ b/src/Forms/Shared/Samples/Map/ApplyScheduledUpdates/readme.md
@@ -46,7 +46,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline (preplanned)](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for .NET* guide.
+**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see the [Download preplanned map area](https://developers.arcgis.com/net/forms/sample-code/download-preplanned-map-area/) sample. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Map/DownloadPreplannedMap/readme.md
+++ b/src/Forms/Shared/Samples/Map/DownloadPreplannedMap/readme.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `SyncWithFeatureServices` - Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `DownloadScheduledUpdates` - Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-on-demand.htm) or refer to the sample 'Generate Offline Map' to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/Forms/Shared/Samples/Symbology/CustomDictionaryStyle/readme.md
+++ b/src/Forms/Shared/Samples/Symbology/CustomDictionaryStyle/readme.md
@@ -36,7 +36,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/net/latest/uwp/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for Java* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -6,7 +6,7 @@ Display features from a local geodatabase.
 
 ## Use case
 
-Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage. 
+Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage.
 
 ## How it works
 
@@ -31,7 +31,7 @@ Accessing data from a local geodatabase is useful when working in an environment
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm).
 
 Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -33,7 +33,7 @@ One of the ArcGIS Runtime data set types that can be accessed via the local stor
 
 In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/net/latest/uwp/guide/take-a-layer-offline.htm.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 
 ## Tags
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GeodatabaseTransactions/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GeodatabaseTransactions/readme.md
@@ -32,10 +32,6 @@ When the sample loads, a feature service is taken offline as a geodatabase. When
 
 The sample uses a publicly-editable, sync-enabled [feature service](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer) demonstrating a schema for recording wildlife sightings.
 
-## Additional information
-
-You can learn more about geodatabase transactions in the [Use geodatabase transactions](https://developers.arcgis.com/net/latest/uwp/guide/use-geodatabase-transactions.htm) guide topic.
-
 ## Tags
 
 commit, database, geodatabase, transact, transactions

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableCache/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableManualCache/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableManualCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableNoCache/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ServiceFeatureTableNoCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) in the *ArcGIS Runtime SDK for .NET* guide to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. 
 
 ## How to use the sample
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ExportTiles/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ExportTiles/readme.md
@@ -30,7 +30,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGIS Online Developer's portal](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [Layer types](https://developers.arcgis.com/net/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 ## Tags
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -30,7 +30,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for .NET* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/ApplyScheduledUpdates/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/ApplyScheduledUpdates/readme.md
@@ -46,7 +46,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline (preplanned)](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for .NET* guide.
+**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see the [Download preplanned map area](https://developers.arcgis.com/net/uwp/sample-code/download-preplanned-map-area/) sample. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/DownloadPreplannedMap/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/DownloadPreplannedMap/readme.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `SyncWithFeatureServices` - Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `DownloadScheduledUpdates` - Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-on-demand.htm) or refer to the sample 'Generate Offline Map' to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/CustomDictionaryStyle/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/CustomDictionaryStyle/readme.md
@@ -36,7 +36,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/net/latest/uwp/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for Java* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -6,7 +6,7 @@ Display features from a local geodatabase.
 
 ## Use case
 
-Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage. 
+Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage.
 
 ## How it works
 
@@ -31,9 +31,9 @@ Accessing data from a local geodatabase is useful when working in an environment
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm).
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -33,7 +33,7 @@ One of the ArcGIS Runtime data set types that can be accessed via the local stor
 
 In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/net/latest/wpf/guide/take-a-layer-offline.htm.
+Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/GeodatabaseTransactions/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/GeodatabaseTransactions/readme.md
@@ -32,10 +32,6 @@ When the sample loads, a feature service is taken offline as a geodatabase. When
 
 The sample uses a publicly-editable, sync-enabled [feature service](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer) demonstrating a schema for recording wildlife sightings.
 
-## Additional information
-
-You can learn more about geodatabase transactions in the [Use geodatabase transactions](https://developers.arcgis.com/net/latest/wpf/guide/use-geodatabase-transactions.htm) guide topic.
-
 ## Tags
 
 commit, database, geodatabase, transact, transactions

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableCache/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/net/latest/wpf/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableManualCache/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableManualCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/net/latest/wpf/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableNoCache/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ServiceFeatureTableNoCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/net/latest/wpf/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) in the *ArcGIS Runtime SDK for .NET* guide to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. 
 
 ## How to use the sample
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ExportTiles/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ExportTiles/readme.md
@@ -30,7 +30,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGIS Online Developer's portal](https://developers.arcgis.com/net/latest/wpf/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [Layer types](https://developers.arcgis.com/net/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -30,7 +30,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/net/latest/wpf/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for .NET* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/ApplyScheduledUpdates/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/ApplyScheduledUpdates/readme.md
@@ -46,7 +46,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline (preplanned)](https://developers.arcgis.com/net/latest/wpf/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for .NET* guide.
+**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see the [Download preplanned map area](https://developers.arcgis.com/net/wpf/sample-code/download-preplanned-map-area/) sample. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/DownloadPreplannedMap/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/DownloadPreplannedMap/readme.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `SyncWithFeatureServices` - Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `DownloadScheduledUpdates` - Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/net/latest/wpf/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/net/latest/wpf/guide/take-map-offline-on-demand.htm) or refer to the sample 'Generate Offline Map' to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/CustomDictionaryStyle/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/CustomDictionaryStyle/readme.md
@@ -36,7 +36,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/net/latest/wpf/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for Java* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/readme.md
@@ -2,8 +2,8 @@
 
 The WPF sample viewer includes samples that depend on Local Server. 
 If you would like to use those samples, you must install Local Server. 
-See https://developers.arcgis.com/net/latest/wpf/guide/local-server.htm 
-for details and instructions.
+See the [Local Server](https://developers.arcgis.com/net/local-server/)
+topic in the developers guide for more information.
 
 If you do not want to install Local Server, you may proceed without it. 
 When you try to build the project, you will get a build error:

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -6,7 +6,7 @@ Display features from a local geodatabase.
 
 ## Use case
 
-Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage. 
+Accessing data from a local geodatabase is useful when working in an environment that has an inconsistent internet connection or that does not have an internet connection at all. For example, a department of transportation field worker might source map data from a local geodatabase when conducting signage inspections in rural areas with poor network coverage.
 
 ## How it works
 
@@ -31,7 +31,7 @@ Accessing data from a local geodatabase is useful when working in an environment
 
 One of the ArcGIS Runtime data set types that can be accessed via the local storage of the device (i.e. hard drive, flash drive, micro SD card, USB stick, etc.) is a mobile geodatabase. A mobile geodatabase can be provisioned for use in an ArcGIS Runtime application by ArcMap. The following provide some helpful tips on how to create a mobile geodatabase file:
 
-In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
+In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm).
 
 Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/readme.md
@@ -33,7 +33,7 @@ One of the ArcGIS Runtime data set types that can be accessed via the local stor
 
 In ArcMap, choose File > Share As > ArcGIS Runtime Content from the menu items to create the .geodatabase file (see the document: http://desktop.arcgis.com/en/arcmap/latest/map/working-with-arcmap/creating-arcgis-runtime-content.htm). 
 
-Note: You could also use the 'Services Pattern' and access the Geodatabase class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the Geodatabase class to access the .geodatabase file on disk, you would use GeodatabaseSyncTask point to a Uri instead. For more information review the document: https://developers.arcgis.com/net/latest/uwp/guide/take-a-layer-offline.htm.
+Note: You could also use the 'Services Pattern' and access the `Geodatabase` class via a Feature Service served up via ArcGIS Online or ArcGIS Enterprise. Instead of using the `Geodatabase` class to access the .geodatabase file on disk, you would use `GeodatabaseSyncTask` point to a Uri instead.
 
 ## Tags
 

--- a/src/iOS/Xamarin.iOS/Samples/Data/GeodatabaseTransactions/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/GeodatabaseTransactions/readme.md
@@ -32,10 +32,6 @@ When the sample loads, a feature service is taken offline as a geodatabase. When
 
 The sample uses a publicly-editable, sync-enabled [feature service](https://sampleserver6.arcgisonline.com/arcgis/rest/services/Sync/SaveTheBaySync/FeatureServer) demonstrating a schema for recording wildlife sightings.
 
-## Additional information
-
-You can learn more about geodatabase transactions in the [Use geodatabase transactions](https://developers.arcgis.com/net/latest/uwp/guide/use-geodatabase-transactions.htm) guide topic.
-
 ## Tags
 
 commit, database, geodatabase, transact, transactions

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableCache/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **on interaction cache** featur
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **On interaction cache** in scenarios with large amounts of infrequently edited data.
 
 ## How to use the sample
 

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **manual cache** feature reques
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **manual cache** in scenarios where you want to explicitly control requests for features.
 
 ## How to use the sample
 

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/readme.md
@@ -6,7 +6,7 @@ Display a feature layer from a service using the **no cache** feature request mo
 
 ## Use case
 
-`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. See [Table performance concepts](https://developers.arcgis.com/net/latest/uwp/guide/layers.htm#ESRI_SECTION1_40F10593308A4718971C9A8F5FB9EC7D) in the *ArcGIS Runtime SDK for .NET* guide to learn more.
+`ServiceFeatureTable` supports three request modes, which define how features are requested from the service and stored in the local table. The feature request modes have different performance characteristics. Use **no cache** in scenarios where you always want the freshest data. 
 
 ## How to use the sample
 

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ExportTiles/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ExportTiles/readme.md
@@ -30,7 +30,7 @@ Pan and zoom into the desired area, making sure the area is within the red bound
 
 ## Additional information
 
-ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. Visit the [ArcGIS Online Developer's portal](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_30E7379BE7FE4EC2AF7D8FBFEA7BB4CC) to learn more about the characteristics of ArcGIS tiled layers.
+ArcGIS tiled layers do not support reprojection, query, select, identify, or editing. See the [Layer types](https://developers.arcgis.com/net/layers/#layer-types) discussion in the developers guide to learn more about the characteristics of ArcGIS tiled layers.
 
 ## Tags
 

--- a/src/iOS/Xamarin.iOS/Samples/Layers/OpenStreetMapLayer/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/OpenStreetMapLayer/readme.md
@@ -30,7 +30,7 @@ When the sample opens, it will automatically display the map with the OpenStreet
 
 The attribution text will be set to the required OpenStreetMap attribution automatically.
 
-Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class. See [layer types described](https://developers.arcgis.com/net/latest/uwp/guide/layer-types-described.htm#ESRI_SECTION1_B995CCAB20584F91890B3614CF16CF43) in the *ArcGIS Runtime SDK for .NET* documentation for more information on OpenStreetMap usage restrictions and alternatives.
+Apps that expect to make many requests to OpenStreetMap should consider using an alternative tile server via the `WebTiledLayer` class.
 
 Esri now hosts an [OpenStreetMap vector layer on ArcGIS Online](http://www.arcgis.com/home/item.html?id=3e1a00aeae81496587988075fe529f71) that uses recent OpenStreetMap data in conjunction with a style matching the default OpenStreetMap style. This layer is not subject to the tile access restrictions that apply to tiles fetched from OpenStreetMap.org.
 

--- a/src/iOS/Xamarin.iOS/Samples/Map/ApplyScheduledUpdates/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Map/ApplyScheduledUpdates/readme.md
@@ -46,7 +46,7 @@ The data in this sample shows the roads and trails in the Canyonlands National P
 
 ## Additional information
 
-**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see [Take a map offline (preplanned)](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) in the *ArcGIS Runtime SDK for .NET* guide.
+**Note:** preplanned areas using the Scheduled Updates workflow are read-only. For preplanned areas that can be edited on the end-user device, see the [Download preplanned map area](https://developers.arcgis.com/net/ios/sample-code/download-preplanned-map-area/) sample. For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/iOS/Xamarin.iOS/Samples/Map/DownloadPreplannedMap/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Map/DownloadPreplannedMap/readme.md
@@ -45,7 +45,7 @@ The [Naperville stormwater network map](https://arcgisruntime.maps.arcgis.com/ho
 * `SyncWithFeatureServices` - Changes, including local edits, will be synced directly with the underlying feature services. This is the default update mode.
 * `DownloadScheduledUpdates` - Scheduled, read-only updates will be downloaded from the online map area and applied to the local mobile geodatabases.
 
-See [Take a map offline - preplanned](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-preplanned.htm) to learn about preplanned workflows, including how to define preplanned areas in ArcGIS Online. Alternatively, visit [Take a map offline - on demand](https://developers.arcgis.com/net/latest/uwp/guide/take-map-offline-on-demand.htm) or refer to the sample 'Generate Offline Map' to learn about the on-demand workflow and see how the workflows differ.
+For more information about offline workflows, see [Offline maps, scenes, and data](https://developers.arcgis.com/documentation/mapping-apis-and-location-services/offline-maps-scenes-and-data/) in the *ArcGIS Developers* guide.
 
 ## Tags
 

--- a/src/iOS/Xamarin.iOS/Samples/Symbology/CustomDictionaryStyle/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Symbology/CustomDictionaryStyle/readme.md
@@ -36,7 +36,7 @@ The data used in this sample is from a feature layer showing a subset of [restau
 
 ## Additional information
 
-To learn more about how styles in dictionary renderers work, see the topic [Display symbols from a style with a dictionary renderer](https://developers.arcgis.com/net/latest/uwp/guide/display-military-symbols-with-a-dictionary-renderer.htm) in the *ArcGIS Runtime SDK for Java* guide. For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
+For information about creating your own custom dictionary style, see the open source [dictionary renderer toolkit](https://esriurl.com/DictionaryToolkit) on *GitHub*.
 
 ## Tags
 

--- a/tools/readme_copy/readme_copy.py
+++ b/tools/readme_copy/readme_copy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import os
+import copy
 
 def get_platform_samples_root(platform, sample_root):
     '''
@@ -29,19 +30,23 @@ def replace_readmes(category, formal_name, sample_root):
         # Loop through the other platforms.
         plats = ["UWP", "Android", "iOS", "Forms"]
         for platform in plats:
+            # Copy the original WPF text into a new string
+            platformcontent = copy.copy(wpfcontent)
+
             # Fix the guide doc url for the platform
-            wpfcontent = wpfcontent.replace("wpf/guide", str.lower(platform)+"/guide")
+            platformcontent = platformcontent.replace("wpf/guide", str.lower(platform)+"/guide")
+            platformcontent = platformcontent.replace("wpf/sample-code/", str.lower(platform)+"/sample-code/")
 
             # Change `click` to `tap` for mobile platforms
             if  not platform == "UWP":
-                wpfcontent = wpfcontent.replace("click ", "tap ")
-                wpfcontent = wpfcontent.replace("Click ", "Tap ")
+                platformcontent = platformcontent.replace("click ", "tap ")
+                platformcontent = platformcontent.replace("Click ", "Tap ")
 
             # Write the WPF readme to other platform
             platform_path = os.path.join(get_platform_samples_root(platform, sample_root), category, formal_name, ("readme.md"))
             with open(platform_path, "r+") as file:
                 file.seek(0)
-                file.write(wpfcontent)
+                file.write(platformcontent)
                 file.truncate()
                 print(f"{formal_name} written to {platform}")
     except OSError as e:


### PR DESCRIPTION
Several links in the sample readme's are pointing to guide topics that have been moved, renamed, or are currently missing from the guide. I updated the links where I could and removed them if the topic is missing.

Note: I did not remove the AR links, even though they are currently broken and there is no topic to link them to. We plan to add the AR topics back to the guide soon and then fix those links.

@nCastle1 - Please take a look and let me know if this looks OK. You may have some suggestions for some of the links I used or ideas for updating the ones I completely removed. Thanks!