### PR TITLE
iOS: Fix NullReferenceException in ApiKeyPrompt

### DIFF
--- a/src/iOS/Xamarin.iOS/ViewControllers/ApiKeyPrompt.cs
+++ b/src/iOS/Xamarin.iOS/ViewControllers/ApiKeyPrompt.cs
@@ -60,8 +60,9 @@ namespace ArcGISRuntime
 
         public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
         {
+            base.TraitCollectionDidChange(previousTraitCollection);
             // Reload the html pages when switching to and from dark mode.
-            if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle) LoadHTML();
+            if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle) LoadHTML();
         }
 
         private async Task UpdateValidityText()


### PR DESCRIPTION
Mini bugfix. The `previousTraitCollection` can be `null` the first time this method is called, which would currently cause a NullReferenceException.

Also, both Apple and Xamarin docs recommend calling base implementation first.