### PR TITLE
Label definition sample updates

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
@@ -14,11 +14,12 @@ using ArcGISRuntime;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI.Controls;
 using System;
-using System.Diagnostics;
+using System.Drawing;
 
 namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
 {
@@ -41,9 +42,6 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
 
         // Reference to a sublayer.
         private SubtypeSublayer _sublayer;
-
-        // JSON for labeling features from the sublayer.
-        private const string _labelJSON = "{ \"labelExpression\":\"[nominalvoltage]\",\"labelPlacement\":\"esriServerPointLabelPlacementAboveRight\",\"useCodedValues\":true,\"symbol\":{\"angle\":0,\"backgroundColor\":[0,0,0,0],\"borderLineColor\":[0,0,0,0],\"borderLineSize\":0,\"color\":[0,0,255,255],\"font\":{\"decoration\":\"none\",\"size\":10.5,\"style\":\"normal\",\"weight\":\"normal\"},\"haloColor\":[255,255,255,255],\"haloSize\":2,\"horizontalAlignment\":\"center\",\"kerning\":false,\"type\":\"esriTS\",\"verticalAlignment\":\"middle\",\"xoffset\":0,\"yoffset\":0}}";
 
         // Renderers for the sublayer.
         private Renderer _defaultRenderer;
@@ -95,9 +93,26 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
 
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
+                // Create a text symbol for styling the sublayer label definition.
+                TextSymbol textSymbol = new TextSymbol
+                {
+                    Size = 12,
+                    OutlineColor = Color.White,
+                    Color = Color.Blue,
+                    HaloColor = Color.White,
+                    HaloWidth = 3,
+                };
 
-                // Set the label definitions using the JSON.
-                _sublayer.LabelDefinitions.Add(LabelDefinition.FromJson(_labelJSON));
+                // Create a label definition with a simple label expression.
+                LabelExpression simpleLabelExpression = new SimpleLabelExpression("[nominalvoltage]");
+                LabelDefinition labelDefinition = new LabelDefinition(simpleLabelExpression, textSymbol)
+                {
+                    Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PointAboveRight,
+                    UseCodedValues = true,
+                };
+
+                // Add the label definition to the sublayer.
+                _sublayer.LabelDefinitions.Add(labelDefinition);
 
                 // Enable labels for the sub layer.
                 _sublayer.LabelsEnabled = true;

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
@@ -93,6 +93,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
 
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
+                
                 // Create a text symbol for styling the sublayer label definition.
                 TextSymbol textSymbol = new TextSymbol
                 {

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -27,6 +27,7 @@
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",
+        "SimpleLabelExpression",
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],

--- a/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
@@ -1,24 +1,27 @@
-// Copyright 2018 Esri.
+// Copyright 2021 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
 using Android.App;
 using Android.OS;
 using Android.Widget;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
+using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI.Controls;
+using System;
+using System.Drawing;
 
 namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
 {
-    [Activity (ConfigurationChanges=Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
+    [Activity(ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation | Android.Content.PM.ConfigChanges.ScreenSize)]
     [ArcGISRuntime.Samples.Shared.Attributes.Sample(
         name: "Show labels on layers",
         category: "Layers",
@@ -29,68 +32,6 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
     {
         // Create and hold reference to the used MapView.
         private MapView _myMapView;
-        
-            // Help regarding the Json syntax for defining the LabelDefinition.FromJson syntax can be found here:
-            // https://developers.arcgis.com/web-map-specification/objects/labelingInfo/
-            private const string RedLabelJson =
-             @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Republican'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[255,0,0,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
-            private const string BlueLabelJson =
-                @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Democrat'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[0,0,255,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
 
         protected override void OnCreate(Bundle bundle)
         {
@@ -98,7 +39,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
 
             Title = "Show labels on layer";
 
-            // Create the UI, setup the control references and execute initialization. 
+            // Create the UI, setup the control references and execute initialization.
             CreateLayout();
             Initialize();
         }
@@ -115,7 +56,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
             string layerUrl = "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_115th_Congressional_Districts/FeatureServer/0";
 
             // Create a service feature table from the URL.
-            ServiceFeatureTable featureTable = new ServiceFeatureTable(new System.Uri(layerUrl));
+            ServiceFeatureTable featureTable = new ServiceFeatureTable(new Uri(layerUrl));
 
             // Create a feature layer from the service feature table.
             FeatureLayer districtFeatureLabel = new FeatureLayer(featureTable);
@@ -130,22 +71,43 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
 
                 // Zoom the map view to the extent of the feature layer.
                 await _myMapView.SetViewpointCenterAsync(new MapPoint(-10846309.950860, 4683272.219411, SpatialReferences.WebMercator), 20000000);
-            
-                // Create a label definition from the JSON string. 
-                LabelDefinition redLabelDefinition = LabelDefinition.FromJson(RedLabelJson);
-                LabelDefinition blueLabelDefinition = LabelDefinition.FromJson(BlueLabelJson);
+
+                // create label definitions for each party.
+                LabelDefinition republicanLabelDefinition = MakeLabelDefinition("Republican", Color.Red);
+                LabelDefinition democratLabelDefinition = MakeLabelDefinition("Democrat", Color.Blue);
 
                 // Add the label definition to the feature layer's label definition collection.
-                districtFeatureLabel.LabelDefinitions.Add(redLabelDefinition);
-                districtFeatureLabel.LabelDefinitions.Add(blueLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(republicanLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(democratLabelDefinition);
 
                 // Enable the visibility of labels to be seen.
                 districtFeatureLabel.LabelsEnabled = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                new AlertDialog.Builder(this).SetMessage(e.ToString()).SetTitle("Error").Show();
+                new AlertDialog.Builder(this).SetMessage(ex.Message).SetTitle("Error").Show();
             }
+        }
+
+        private LabelDefinition MakeLabelDefinition(string partyName, Color color)
+        {
+            // Create a text symbol for styling the label.
+            TextSymbol textSymbol = new TextSymbol
+            {
+                Size = 12,
+                Color = color,
+                HaloColor = Color.White,
+                HaloWidth = 2,
+            };
+
+            // Create a label expression using an Arcade expression script.
+            LabelExpression arcadeLabelExpression = new ArcadeLabelExpression("$feature.NAME + \" (\" + left($feature.PARTY,1) + \")\\nDistrict \" + $feature.CDFIPS");
+
+            return new LabelDefinition(arcadeLabelExpression, textSymbol)
+            {
+                Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PolygonAlwaysHorizontal,
+                WhereClause = $"PARTY = '{partyName}'",
+            };
         }
 
         private void CreateLayout()

--- a/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
         category: "Layers",
         description: "Display custom labels on a feature layer.",
         instructions: "Pan and zoom around the United States. Labels for congressional districts will be shown in red for Republican districts and blue for Democrat districts. Notice how labels pop into view as you zoom in.",
-        tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
+        tags: new[] { "arcade", "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public class ShowLabelsOnLayer : Activity
     {
         // Create and hold reference to the used MapView.

--- a/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -7,6 +7,7 @@
         "ShowLabelsOnLayer.jpg"
     ],
     "keywords": [
+        "arcade",
         "attribute",
         "deconfliction",
         "label",
@@ -25,6 +26,7 @@
         "/net/latest/android/sample-code/showlabelsonlayer.htm"
     ],
     "relevant_apis": [
+        "ArcadeLabelExpression",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"

--- a/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -10,6 +10,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Symbology;
 using System;
@@ -29,9 +30,6 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
     {
         // Reference to a sublayer.
         private SubtypeSublayer _sublayer;
-
-        // JSON for labeling features from the sublayer.
-        private const string _labelJSON = "{ \"labelExpression\":\"[nominalvoltage]\",\"labelPlacement\":\"esriServerPointLabelPlacementAboveRight\",\"useCodedValues\":true,\"symbol\":{\"angle\":0,\"backgroundColor\":[0,0,0,0],\"borderLineColor\":[0,0,0,0],\"borderLineSize\":0,\"color\":[0,0,255,255],\"font\":{\"decoration\":\"none\",\"size\":10.5,\"style\":\"normal\",\"weight\":\"normal\"},\"haloColor\":[255,255,255,255],\"haloSize\":2,\"horizontalAlignment\":\"center\",\"kerning\":false,\"type\":\"esriTS\",\"verticalAlignment\":\"middle\",\"xoffset\":0,\"yoffset\":0}}";
 
         // Renderers for the sublayer.
         private Renderer _defaultRenderer;
@@ -80,8 +78,26 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
 
-                // Set the label definitions using the JSON.
-                _sublayer.LabelDefinitions.Add(LabelDefinition.FromJson(_labelJSON));
+                // Create a text symbol for styling the sublayer label definition.
+                TextSymbol textSymbol = new TextSymbol
+                {
+                    Size = 12,
+                    OutlineColor = Color.White,
+                    Color = Color.Blue,
+                    HaloColor = Color.White,
+                    HaloWidth = 3,
+                };
+
+                // Create a label definition with a simple label expression.
+                LabelExpression simpleLabelExpression = new SimpleLabelExpression("[nominalvoltage]");
+                LabelDefinition labelDefinition = new LabelDefinition(simpleLabelExpression, textSymbol)
+                {
+                    Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PointAboveRight,
+                    UseCodedValues = true,
+                };
+
+                // Add the label definition to the sublayer.
+                _sublayer.LabelDefinitions.Add(labelDefinition);
 
                 // Enable labels for the sub layer.
                 _sublayer.LabelsEnabled = true;

--- a/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/Forms/Shared/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -30,6 +30,7 @@
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",
+        "SimpleLabelExpression",
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],

--- a/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -1,16 +1,18 @@
-// Copyright 2018 Esri.
+// Copyright 2021 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
+using Esri.ArcGISRuntime.Symbology;
+using System;
 using Xamarin.Forms;
 
 namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
@@ -23,73 +25,11 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
         tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer : ContentPage
     {
-        // Help regarding the Json syntax for defining the LabelDefinition.FromJson syntax can be found here:
-        // https://developers.arcgis.com/web-map-specification/objects/labelingInfo/
-        private const string RedLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Republican'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[255,0,0,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
-        private const string BlueLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Democrat'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[0,0,255,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
         public ShowLabelsOnLayer()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization
             Initialize();
         }
 
@@ -121,21 +61,42 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
                 // Zoom the map view to the extent of the feature layer.
                 await MyMapView.SetViewpointCenterAsync(new MapPoint(-10846309.950860, 4683272.219411, SpatialReferences.WebMercator), 20000000);
 
-                // Create a label definition from the JSON string. 
-                LabelDefinition redLabelDefinition = LabelDefinition.FromJson(RedLabelJson);
-                LabelDefinition blueLabelDefinition = LabelDefinition.FromJson(BlueLabelJson);
+                // create label definitions for each party.
+                LabelDefinition republicanLabelDefinition = MakeLabelDefinition("Republican", Color.Red);
+                LabelDefinition democratLabelDefinition = MakeLabelDefinition("Democrat", Color.Blue);
 
                 // Add the label definition to the feature layer's label definition collection.
-                districtFeatureLabel.LabelDefinitions.Add(redLabelDefinition);
-                districtFeatureLabel.LabelDefinitions.Add(blueLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(republicanLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(democratLabelDefinition);
 
                 // Enable the visibility of labels to be seen.
                 districtFeatureLabel.LabelsEnabled = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                await Application.Current.MainPage.DisplayAlert("Error", e.ToString(), "OK");
+                await Application.Current.MainPage.DisplayAlert("Error", ex.Message, "OK");
             }
+        }
+
+        private LabelDefinition MakeLabelDefinition(string partyName, Color color)
+        {
+            // Create a text symbol for styling the label.
+            TextSymbol textSymbol = new TextSymbol
+            {
+                Size = 12,
+                Color = color,
+                HaloColor = Color.White,
+                HaloWidth = 2,
+            };
+
+            // Create a label expression using an Arcade expression script.
+            LabelExpression arcadeLabelExpression = new ArcadeLabelExpression("$feature.NAME + \" (\" + left($feature.PARTY,1) + \")\\nDistrict \" + $feature.CDFIPS");
+
+            return new LabelDefinition(arcadeLabelExpression, textSymbol)
+            {
+                Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PolygonAlwaysHorizontal,
+                WhereClause = $"PARTY = '{partyName}'",
+            };
         }
     }
 }

--- a/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -22,7 +22,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
         category: "Layers",
         description: "Display custom labels on a feature layer.",
         instructions: "Pan and zoom around the United States. Labels for congressional districts will be shown in red for Republican districts and blue for Democrat districts. Notice how labels pop into view as you zoom in.",
-        tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
+        tags: new[] { "arcade", "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer : ContentPage
     {
         public ShowLabelsOnLayer()

--- a/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/Forms/Shared/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -7,6 +7,7 @@
         "ShowLabelsOnLayer.jpg"
     ],
     "keywords": [
+        "arcade",
         "attribute",
         "deconfliction",
         "label",
@@ -28,6 +29,7 @@
         "/net/latest/forms/sample-code/showlabelsonlayer.htm"
     ],
     "relevant_apis": [
+        "ArcadeLabelExpression",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -10,6 +10,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Symbology;
 using System;
@@ -30,9 +31,6 @@ namespace ArcGISRuntime.UWP.Samples.DisplaySubtypeFeatureLayer
     {
         // Reference to a sublayer.
         private SubtypeSublayer _sublayer;
-
-        // JSON for labeling features from the sublayer.
-        private const string _labelJSON = "{ \"labelExpression\":\"[nominalvoltage]\",\"labelPlacement\":\"esriServerPointLabelPlacementAboveRight\",\"useCodedValues\":true,\"symbol\":{\"angle\":0,\"backgroundColor\":[0,0,0,0],\"borderLineColor\":[0,0,0,0],\"borderLineSize\":0,\"color\":[0,0,255,255],\"font\":{\"decoration\":\"none\",\"size\":10.5,\"style\":\"normal\",\"weight\":\"normal\"},\"haloColor\":[255,255,255,255],\"haloSize\":2,\"horizontalAlignment\":\"center\",\"kerning\":false,\"type\":\"esriTS\",\"verticalAlignment\":\"middle\",\"xoffset\":0,\"yoffset\":0}}";
 
         // Renderers for the sublayer.
         private Renderer _defaultRenderer;
@@ -81,8 +79,26 @@ namespace ArcGISRuntime.UWP.Samples.DisplaySubtypeFeatureLayer
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
 
-                // Set the label definitions using the JSON.
-                _sublayer.LabelDefinitions.Add(LabelDefinition.FromJson(_labelJSON));
+                // Create a text symbol for styling the sublayer label definition.
+                TextSymbol textSymbol = new TextSymbol
+                {
+                    Size = 12,
+                    OutlineColor = Color.White,
+                    Color = Color.Blue,
+                    HaloColor = Color.White,
+                    HaloWidth = 3,
+                };
+
+                // Create a label definition with a simple label expression.
+                LabelExpression simpleLabelExpression = new SimpleLabelExpression("[nominalvoltage]");
+                LabelDefinition labelDefinition = new LabelDefinition(simpleLabelExpression, textSymbol)
+                {
+                    Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PointAboveRight,
+                    UseCodedValues = true,
+                };
+
+                // Add the label definition to the sublayer.
+                _sublayer.LabelDefinitions.Add(labelDefinition);
 
                 // Enable labels for the sub layer.
                 _sublayer.LabelsEnabled = true;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -27,6 +27,7 @@
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",
+        "SimpleLabelExpression",
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntime.UWP.Samples.ShowLabelsOnLayer
         category: "Layers",
         description: "Display custom labels on a feature layer.",
         instructions: "Pan and zoom around the United States. Labels for congressional districts will be shown in red for Republican districts and blue for Democrat districts. Notice how labels pop into view as you zoom in.",
-        tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
+        tags: new[] { "arcade", "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer
     {
         public ShowLabelsOnLayer()

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Esri.
+// Copyright 2021 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,11 +7,14 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using Windows.UI.Popups;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
+using Esri.ArcGISRuntime.Symbology;
+using System;
+using System.Drawing;
+using Windows.UI.Popups;
 
 namespace ArcGISRuntime.UWP.Samples.ShowLabelsOnLayer
 {
@@ -23,68 +26,6 @@ namespace ArcGISRuntime.UWP.Samples.ShowLabelsOnLayer
         tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer
     {
-        // Help regarding the Json syntax for defining the LabelDefinition.FromJson syntax can be found here:
-        // https://developers.arcgis.com/web-map-specification/objects/labelingInfo/
-        private const string RedLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Republican'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[255,0,0,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
-        private const string BlueLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Democrat'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[0,0,255,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
         public ShowLabelsOnLayer()
         {
             InitializeComponent();
@@ -103,7 +44,7 @@ namespace ArcGISRuntime.UWP.Samples.ShowLabelsOnLayer
             string layerUrl = "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_115th_Congressional_Districts/FeatureServer/0";
 
             // Create a service feature table from the URL.
-            ServiceFeatureTable featureTable = new ServiceFeatureTable(new System.Uri(layerUrl));
+            ServiceFeatureTable featureTable = new ServiceFeatureTable(new Uri(layerUrl));
 
             // Create a feature layer from the service feature table.
             FeatureLayer districtFeatureLabel = new FeatureLayer(featureTable);
@@ -119,21 +60,42 @@ namespace ArcGISRuntime.UWP.Samples.ShowLabelsOnLayer
                 // Zoom the map view to the extent of the feature layer.
                 await MyMapView.SetViewpointCenterAsync(new MapPoint(-10846309.950860, 4683272.219411, SpatialReferences.WebMercator), 20000000);
 
-                // Create a label definition from the JSON string. 
-                LabelDefinition redLabelDefinition = LabelDefinition.FromJson(RedLabelJson);
-                LabelDefinition blueLabelDefinition = LabelDefinition.FromJson(BlueLabelJson);
+                // create label definitions for each party.
+                LabelDefinition republicanLabelDefinition = MakeLabelDefinition("Republican", Color.Red);
+                LabelDefinition democratLabelDefinition = MakeLabelDefinition("Democrat", Color.Blue);
 
                 // Add the label definition to the feature layer's label definition collection.
-                districtFeatureLabel.LabelDefinitions.Add(redLabelDefinition);
-                districtFeatureLabel.LabelDefinitions.Add(blueLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(republicanLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(democratLabelDefinition);
 
                 // Enable the visibility of labels to be seen.
                 districtFeatureLabel.LabelsEnabled = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                await new MessageDialog(e.ToString(), "Error").ShowAsync();
+                await new MessageDialog(ex.Message, "Error").ShowAsync();
             }
+        }
+
+        private LabelDefinition MakeLabelDefinition(string partyName, Color color)
+        {
+            // Create a text symbol for styling the label.
+            TextSymbol textSymbol = new TextSymbol
+            {
+                Size = 12,
+                Color = color,
+                HaloColor = Color.White,
+                HaloWidth = 2,
+            };
+
+            // Create a label expression using an Arcade expression script.
+            LabelExpression arcadeLabelExpression = new ArcadeLabelExpression("$feature.NAME + \" (\" + left($feature.PARTY,1) + \")\\nDistrict \" + $feature.CDFIPS");
+
+            return new LabelDefinition(arcadeLabelExpression, textSymbol)
+            {
+                Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PolygonAlwaysHorizontal,
+                WhereClause = $"PARTY = '{partyName}'",
+            };
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -7,6 +7,7 @@
         "ShowLabelsOnLayer.jpg"
     ],
     "keywords": [
+        "arcade",
         "attribute",
         "deconfliction",
         "label",
@@ -25,6 +26,7 @@
         "/net/latest/uwp/sample-code/showlabelsonlayer.htm"
     ],
     "relevant_apis": [
+        "ArcadeLabelExpression",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.xaml.cs
@@ -10,6 +10,7 @@
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Symbology;
 using System;
@@ -29,9 +30,6 @@ namespace ArcGISRuntime.WPF.Samples.DisplaySubtypeFeatureLayer
     {
         // Reference to a sublayer.
         private SubtypeSublayer _sublayer;
-
-        // JSON for labeling features from the sublayer.
-        private const string _labelJSON = "{ \"labelExpression\":\"[nominalvoltage]\",\"labelPlacement\":\"esriServerPointLabelPlacementAboveRight\",\"useCodedValues\":true,\"symbol\":{\"angle\":0,\"backgroundColor\":[0,0,0,0],\"borderLineColor\":[0,0,0,0],\"borderLineSize\":0,\"color\":[0,0,255,255],\"font\":{\"decoration\":\"none\",\"size\":10.5,\"style\":\"normal\",\"weight\":\"normal\"},\"haloColor\":[255,255,255,255],\"haloSize\":2,\"horizontalAlignment\":\"center\",\"kerning\":false,\"type\":\"esriTS\",\"verticalAlignment\":\"middle\",\"xoffset\":0,\"yoffset\":0}}";
 
         // Renderers for the sublayer.
         private Renderer _defaultRenderer;
@@ -80,8 +78,26 @@ namespace ArcGISRuntime.WPF.Samples.DisplaySubtypeFeatureLayer
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
 
-                // Set the label definitions using the JSON.
-                _sublayer.LabelDefinitions.Add(LabelDefinition.FromJson(_labelJSON));
+                // Create a text symbol for styling the sublayer label definition.
+                TextSymbol textSymbol = new TextSymbol
+                {
+                    Size = 12,
+                    OutlineColor = Color.White,
+                    Color = Color.Blue,
+                    HaloColor = Color.White,
+                    HaloWidth = 3,
+                };
+
+                // Create a label definition with a simple label expression.
+                LabelExpression simpleLabelExpression = new SimpleLabelExpression("[nominalvoltage]");
+                LabelDefinition labelDefinition = new LabelDefinition(simpleLabelExpression, textSymbol)
+                {
+                    Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PointAboveRight,
+                    UseCodedValues = true,
+                };
+
+                // Add the label definition to the sublayer.
+                _sublayer.LabelDefinitions.Add(labelDefinition);
 
                 // Enable labels for the sub layer.
                 _sublayer.LabelsEnabled = true;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -27,6 +27,7 @@
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",
+        "SimpleLabelExpression",
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntime.WPF.Samples.ShowLabelsOnLayer
         category: "Layers",
         description: "Display custom labels on a feature layer.",
         instructions: "Pan and zoom around the United States. Labels for congressional districts will be shown in red for Republican districts and blue for Democrat districts. Notice how labels pop into view as you zoom in.",
-        tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
+        tags: new[] { "arcade", "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer
     {
         public ShowLabelsOnLayer()

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Esri.
+// Copyright 2021 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -7,11 +7,14 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-using System;
-using System.Windows;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
+using Esri.ArcGISRuntime.Symbology;
+using System;
+using System.Drawing;
+using System.Windows;
 
 namespace ArcGISRuntime.WPF.Samples.ShowLabelsOnLayer
 {
@@ -23,68 +26,6 @@ namespace ArcGISRuntime.WPF.Samples.ShowLabelsOnLayer
         tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public partial class ShowLabelsOnLayer
     {
-        // Help regarding the Json syntax for defining the LabelDefinition.FromJson syntax can be found here:
-        // https://developers.arcgis.com/web-map-specification/objects/labelingInfo/
-        private const string RedLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Republican'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[255,0,0,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
-        private const string BlueLabelJson =
-            @"{
-                    ""labelExpressionInfo"":{""expression"":""$feature.NAME + ' (' + left($feature.PARTY,1) + ')\\nDistrict' + $feature.CDFIPS""},
-                    ""labelPlacement"":""esriServerPolygonPlacementAlwaysHorizontal"",
-                    ""where"":""PARTY = 'Democrat'"",
-                    ""symbol"":
-                        { 
-                            ""angle"":0,
-                            ""backgroundColor"":[0,0,0,0],
-                            ""borderLineColor"":[0,0,0,0],
-                            ""borderLineSize"":0,
-                            ""color"":[0,0,255,255],
-                            ""font"":
-                                {
-                                    ""decoration"":""none"",
-                                    ""size"":10,
-                                    ""style"":""normal"",
-                                    ""weight"":""normal""
-                                },
-                            ""haloColor"":[255,255,255,255],
-                            ""haloSize"":2,
-                            ""horizontalAlignment"":""center"",
-                            ""kerning"":false,
-                            ""type"":""esriTS"",
-                            ""verticalAlignment"":""middle"",
-                            ""xoffset"":0,
-                            ""yoffset"":0
-                        }
-               }";
-
         public ShowLabelsOnLayer()
         {
             InitializeComponent();
@@ -103,7 +44,7 @@ namespace ArcGISRuntime.WPF.Samples.ShowLabelsOnLayer
             string layerUrl = "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_115th_Congressional_Districts/FeatureServer/0";
 
             // Create a service feature table from the URL.
-            ServiceFeatureTable featureTable = new ServiceFeatureTable(new System.Uri(layerUrl));
+            ServiceFeatureTable featureTable = new ServiceFeatureTable(new Uri(layerUrl));
 
             // Create a feature layer from the service feature table.
             FeatureLayer districtFeatureLabel = new FeatureLayer(featureTable);
@@ -117,23 +58,44 @@ namespace ArcGISRuntime.WPF.Samples.ShowLabelsOnLayer
                 await districtFeatureLabel.LoadAsync();
 
                 // Zoom the map view to the extent of the feature layer.
-                MyMapView.SetViewpoint(new Viewpoint(new MapPoint(-10846309.950860, 4683272.219411, SpatialReferences.WebMercator), 20000000));
+                await MyMapView.SetViewpointCenterAsync(new MapPoint(-10846309.950860, 4683272.219411, SpatialReferences.WebMercator), 20000000);
 
-                // Create a label definition from the JSON string. 
-                LabelDefinition redLabelDefinition = LabelDefinition.FromJson(RedLabelJson);
-                LabelDefinition blueLabelDefinition = LabelDefinition.FromJson(BlueLabelJson);
+                // create label definitions for each party.
+                LabelDefinition republicanLabelDefinition = MakeLabelDefinition("Republican", Color.Red);
+                LabelDefinition democratLabelDefinition = MakeLabelDefinition("Democrat", Color.Blue);
 
                 // Add the label definition to the feature layer's label definition collection.
-                districtFeatureLabel.LabelDefinitions.Add(redLabelDefinition);
-                districtFeatureLabel.LabelDefinitions.Add(blueLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(republicanLabelDefinition);
+                districtFeatureLabel.LabelDefinitions.Add(democratLabelDefinition);
 
                 // Enable the visibility of labels to be seen.
                 districtFeatureLabel.LabelsEnabled = true;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                MessageBox.Show(e.ToString(), "Error");
+                MessageBox.Show(ex.Message, "Error");
             }
+        }
+
+        private LabelDefinition MakeLabelDefinition(string partyName, Color color)
+        {
+            // Create a text symbol for styling the label.
+            TextSymbol textSymbol = new TextSymbol
+            {
+                Size = 12,
+                Color = color,
+                HaloColor = Color.White,
+                HaloWidth = 2,
+            };
+
+            // Create a label expression using an Arcade expression script.
+            LabelExpression arcadeLabelExpression = new ArcadeLabelExpression("$feature.NAME + \" (\" + left($feature.PARTY,1) + \")\\nDistrict \" + $feature.CDFIPS");
+
+            return new LabelDefinition(arcadeLabelExpression, textSymbol)
+            {
+                Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PolygonAlwaysHorizontal,
+                WhereClause = $"PARTY = '{partyName}'",
+            };
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -7,6 +7,7 @@
         "ShowLabelsOnLayer.jpg"
     ],
     "keywords": [
+        "arcade",
         "attribute",
         "deconfliction",
         "label",
@@ -25,6 +26,7 @@
         "/net/latest/wpf/sample-code/showlabelsonlayer.htm"
     ],
     "relevant_apis": [
+        "ArcadeLabelExpression",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cs
@@ -11,6 +11,7 @@ using ArcGISRuntime;
 using Esri.ArcGISRuntime.Data;
 using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Mapping.Labeling;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI.Controls;
@@ -41,9 +42,6 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
 
         // Reference to a sublayer.
         private SubtypeSublayer _sublayer;
-
-        // JSON for labeling features from the sublayer.
-        private const string _labelJSON = "{ \"labelExpression\":\"[nominalvoltage]\",\"labelPlacement\":\"esriServerPointLabelPlacementAboveRight\",\"useCodedValues\":true,\"symbol\":{\"angle\":0,\"backgroundColor\":[0,0,0,0],\"borderLineColor\":[0,0,0,0],\"borderLineSize\":0,\"color\":[0,0,255,255],\"font\":{\"decoration\":\"none\",\"size\":10.5,\"style\":\"normal\",\"weight\":\"normal\"},\"haloColor\":[255,255,255,255],\"haloSize\":2,\"horizontalAlignment\":\"center\",\"kerning\":false,\"type\":\"esriTS\",\"verticalAlignment\":\"middle\",\"xoffset\":0,\"yoffset\":0}}";
 
         // Renderers for the sublayer.
         private Renderer _defaultRenderer;
@@ -91,8 +89,26 @@ namespace ArcGISRuntimeXamarin.Samples.DisplaySubtypeFeatureLayer
                 // Select the sublayer of street lights by name.
                 _sublayer = subtypeFeatureLayer.GetSublayerBySubtypeName("Street Light");
 
-                // Set the label definitions using the JSON.
-                _sublayer.LabelDefinitions.Add(LabelDefinition.FromJson(_labelJSON));
+                // Create a text symbol for styling the sublayer label definition.
+                TextSymbol textSymbol = new TextSymbol
+                {
+                    Size = 12,
+                    OutlineColor = Color.White,
+                    Color = Color.Blue,
+                    HaloColor = Color.White,
+                    HaloWidth = 3,
+                };
+
+                // Create a label definition with a simple label expression.
+                LabelExpression simpleLabelExpression = new SimpleLabelExpression("[nominalvoltage]");
+                LabelDefinition labelDefinition = new LabelDefinition(simpleLabelExpression, textSymbol)
+                {
+                    Placement = Esri.ArcGISRuntime.ArcGISServices.LabelingPlacement.PointAboveRight,
+                    UseCodedValues = true,
+                };
+
+                // Add the label definition to the sublayer.
+                _sublayer.LabelDefinitions.Add(labelDefinition);
 
                 // Enable labels for the sub layer.
                 _sublayer.LabelsEnabled = true;

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/readme.md
@@ -16,7 +16,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 1. Create a `SubtypeFeatureLayer` from a `ServiceFeatureTable` that defines a subtype, and add it to the `Map`.
 2. Get a `SubtypeSublayer` from the subtype feature using its name.
-3. Enable the sublayer's labels and define them with `LabelDefinitions`.
+3. Enable the sublayer's labels and define them with a `LabelDefinition`.
 4. Set the visibility status using this sublayer's `IsVisible` property.
 5. Change the sublayer's symbology using this sublayer's `Renderer` property.
 6. Update the sublayer's minimum scale value using the using the mapview's current scale.
@@ -25,6 +25,7 @@ The sample loads with the sublayer visible on the map. Change the sublayer's vis
 
 * LabelDefinition
 * ServiceFeatureTable
+* SimpleLabelExpression
 * SubtypeFeatureLayer
 * SubtypeSublayer
 

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplaySubtypeFeatureLayer/readme.metadata.json
@@ -27,6 +27,7 @@
     "relevant_apis": [
         "LabelDefinition",
         "ServiceFeatureTable",
+        "SimpleLabelExpression",
         "SubtypeFeatureLayer",
         "SubtypeSublayer"
     ],

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/ShowLabelsOnLayer.cs
@@ -26,7 +26,7 @@ namespace ArcGISRuntime.Samples.ShowLabelsOnLayer
         category: "Layers",
         description: "Display custom labels on a feature layer.",
         instructions: "Pan and zoom around the United States. Labels for congressional districts will be shown in red for Republican districts and blue for Democrat districts. Notice how labels pop into view as you zoom in.",
-        tags: new[] { "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
+        tags: new[] { "arcade", "attribute", "deconfliction", "label", "labeling", "string", "symbol", "text", "visualization" })]
     public class ShowLabelsOnLayer : UIViewController
     {
         // Hold references to UI controls.

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/readme.md
@@ -6,7 +6,7 @@ Display custom labels on a feature layer.
 
 ## Use case
 
-Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or street with their names. 
+Labeling features is useful to visually display a key piece of information or attribute of a feature on a map. For example, you may want to label rivers or streets with their names.
 
 ## How to use the sample
 
@@ -17,15 +17,15 @@ Pan and zoom around the United States. Labels for congressional districts will b
 1. Create a `ServiceFeatureTable` using a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
 3. Create a `TextSymbol` to use for displaying the label text.
-4. Create a JSON string for the label definition.
-    * Set the "LabelExpressionInfo.expression" key to express what the text the label should display. You can use fields of the feature by using `$feature.field_name` in the expression.
-    * To use the text symbol, set the "symbol" key to the symbol's JSON representation using `textSymbol.ToJson()`.
-5. Create a label definition from the JSON using `LabelDefinition.FromJson(json)`.
+4. Create an `ArcadeLabelExpression` for the label definition.
+    * You can use fields of the feature by using `$feature.field_name` in the expression.
+5. Create a new `LabelDefinition` from the arcade label expression and text symbol.
 6. Add the definition to the feature layer with `featureLayer.LabelDefinitions.Add(labelDefinition)` .
 7. Lastly, enable labels on the layer using `featureLayer.LabelsEnabled`.
 
 ## Relevant API
 
+* ArcadeLabelExpression
 * FeatureLayer
 * LabelDefinition
 * TextSymbol
@@ -36,8 +36,8 @@ This sample uses the [USA 116th Congressional Districts](https://www.arcgis.com/
 
 ## Additional information
 
-Help regarding the JSON syntax for defining the `LabelDefinition.FromJson` syntax can be found in [labeling info](https://developers.arcgis.com/web-map-specification/objects/labelingInfo/) in the *Web map specification*.
+Help regarding the Arcade label expression script for defining a label definition can be found on the [ArcGIS Developers](https://developers.arcgis.com/arcade/) site.
 
 ## Tags
 
-attribute, deconfliction, label, labeling, string, symbol, text, visualization
+arcade, attribute, deconfliction, label, labeling, string, symbol, text, visualization

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ShowLabelsOnLayer/readme.metadata.json
@@ -7,6 +7,7 @@
         "ShowLabelsOnLayer.jpg"
     ],
     "keywords": [
+        "arcade",
         "attribute",
         "deconfliction",
         "label",
@@ -25,6 +26,7 @@
         "/net/latest/ios/sample-code/showlabelsonlayer.htm"
     ],
     "relevant_apis": [
+        "ArcadeLabelExpression",
         "FeatureLayer",
         "LabelDefinition",
         "TextSymbol"


### PR DESCRIPTION
* Updated `Display subtype feature layer` sample to use label definition constructed using API instead of JSON
* Updated `Show labels on layer` sample to use label definition constructed using Arcade expression instead of JSON