### PR TITLE
EditFeatureAttachment tidy-up

### DIFF
--- a/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
+++ b/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Configurations -->
   <Import Project="..\..\..\packages\Xamarin.Forms.3.0.0.561731\build\netstandard2.0\Xamarin.Forms.props" Condition="Exists('..\..\..\packages\Xamarin.Forms.3.0.0.561731\build\netstandard2.0\Xamarin.Forms.props')" />
@@ -158,9 +158,6 @@
     </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4">
       <Version>1.0.0.7</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Plugin.FilePicker">
-      <Version>2.1.41</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.ViewModel">
       <Version>1.1.1.3</Version>

--- a/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml
+++ b/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml
@@ -1,28 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-
-<ContentPage
-    x:Class="ArcGISRuntimeXamarin.Samples.EditFeatureAttachments.EditFeatureAttachments"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
-    xmlns:resources="clr-namespace:Forms.Resources;assembly=ArcGISRuntime">
+﻿<ContentPage x:Class="ArcGISRuntimeXamarin.Samples.EditFeatureAttachments.EditFeatureAttachments"
+             xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
+             xmlns:resources="clr-namespace:Forms.Resources;assembly=ArcGISRuntime">
     <RelativeLayout>
-        <esriUI:MapView
-            x:Name="MyMapView"
-            BindingContext="{x:Reference Name=ResponsiveFormContainer}"
-            Style="{StaticResource MapWithFormStyle}" />
+        <esriUI:MapView x:Name="MyMapView"
+                        BindingContext="{x:Reference Name=ResponsiveFormContainer}"
+                        Style="{StaticResource MapWithFormStyle}" />
         <resources:ResponsiveFormContainer x:Name="ResponsiveFormContainer">
             <Grid>
                 <StackLayout Orientation="Vertical">
-                    <Label
-                        Margin="0,0,0,5"
-                        FontAttributes="Bold"
-                        HorizontalTextAlignment="Center"
-                        Text="Tap features to select." />
-                    <ListView
-                        x:Name="AttachmentsListBox"
-                        HeightRequest="100"
-                        IsEnabled="False">
+                    <Label Margin="0,0,0,5"
+                           FontAttributes="Bold"
+                           HorizontalTextAlignment="Center"
+                           Text="Tap features to select." />
+                    <ListView x:Name="AttachmentsListBox"
+                              HeightRequest="100"
+                              IsEnabled="False">
                         <!--  ItemTemplate defines how each item (Attachment) is rendered.  -->
                         <ListView.ItemTemplate>
                             <DataTemplate>
@@ -33,38 +27,33 @@
                                             <ColumnDefinition Width="Auto" />
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
-                                        <Label
-                                            Margin="5,0,5,0"
-                                            Text="{Binding Name}"
-                                            VerticalTextAlignment="Center" />
+                                        <Label Margin="5,0,5,0"
+                                               Text="{Binding Name}"
+                                               VerticalTextAlignment="Center" />
                                         <!--  DataTemplate sets the item as the button's DataContext automatically.  -->
-                                        <Button
-                                            Grid.Column="1"
-                                            Margin="0,0,5,0"
-                                            Clicked="DownloadAttachment_Click"
-                                            Text="🔎"
-                                            VerticalOptions="End" />
+                                        <Button Grid.Column="1"
+                                                Margin="0,0,5,0"
+                                                Clicked="DownloadAttachment_Click"
+                                                Text="🔎"
+                                                VerticalOptions="End" />
                                         <!--  These symbols are emojis. Use Win+. on Windows to open the emoji picker.  -->
-                                        <Button
-                                            Grid.Column="2"
-                                            Clicked="DeleteAttachment_Click"
-                                            Text="🗑"
-                                            VerticalOptions="End" />
+                                        <Button Grid.Column="2"
+                                                Clicked="DeleteAttachment_Click"
+                                                Text="🗑"
+                                                VerticalOptions="End" />
                                     </Grid>
                                 </ViewCell>
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
-                    <Button
-                        x:Name="AddAttachmentButton"
-                        Margin="0,5,0,5"
-                        Clicked="AddAttachment_Click"
-                        IsEnabled="False"
-                        Text="Add attachment" />
-                    <ActivityIndicator
-                        x:Name="AttachmentActivityIndicator"
-                        IsRunning="True"
-                        IsVisible="False" />
+                    <Button x:Name="AddAttachmentButton"
+                            Margin="0,5,0,5"
+                            Clicked="AddAttachment_Click"
+                            IsEnabled="False"
+                            Text="Add attachment" />
+                    <ActivityIndicator x:Name="AttachmentActivityIndicator"
+                                       IsRunning="True"
+                                       IsVisible="False" />
                 </StackLayout>
             </Grid>
         </resources:ResponsiveFormContainer>

--- a/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Esri.
+// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -21,8 +21,8 @@ using Xamarin.Forms;
 using Foundation;
 using UIKit;
 #else
-using Plugin.FilePicker;
-using Plugin.FilePicker.Abstractions;
+using Xamarin.Essentials;
+using Map = Esri.ArcGISRuntime.Mapping.Map; // avoid ambiguity with Xamarin.Essentials.Map
 #endif
 
 namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
@@ -151,7 +151,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 filename = _filename ?? "file1.jpeg";
 #else
                 // Show a file picker - this uses the Xamarin.Plugin.FilePicker NuGet package.
-                FileData fileData = await CrossFilePicker.Current.PickFile(new[] {".jpg", ".jpeg"});
+                FileResult fileData = await FilePicker.PickAsync(new PickOptions { FileTypes = FilePickerFileType.Jpeg });
                 if (fileData == null)
                 {
                     return;
@@ -163,7 +163,14 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                     return;
                 }
 
-                attachmentData = fileData.DataArray;
+                using (Stream fileStream = await fileData.OpenReadAsync())
+                {
+                    using (var memoryStream = new MemoryStream())
+                    {
+                        await fileStream.CopyToAsync(memoryStream);
+                        attachmentData = memoryStream.ToArray();
+                    }
+                }
                 filename = fileData.FileName;
 #endif
                 // Add the attachment.

--- a/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Esri.
+﻿// Copyright 2019 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -104,11 +104,8 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 // Load the feature.
                 await tappedFeature.LoadAsync();
 
-                // Get the attachments.
-                IReadOnlyList<Attachment> attachments = await tappedFeature.GetAttachmentsAsync();
-
                 // Populate the UI with a list of attachments that have a content type of image/jpeg.
-                AttachmentsListBox.ItemsSource = attachments.Where(attachment => attachment.ContentType == "image/jpeg");
+                AttachmentsListBox.ItemsSource = await GetJpegAttachmentsAsync(tappedFeature);
                 AttachmentsListBox.IsEnabled = true;
                 AddAttachmentButton.IsEnabled = true;
             }
@@ -185,7 +182,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
 
                 // Update UI.
                 _selectedFeature.Refresh();
-                AttachmentsListBox.ItemsSource = await _selectedFeature.GetAttachmentsAsync();
+                AttachmentsListBox.ItemsSource = await GetJpegAttachmentsAsync(_selectedFeature);
 
                 await Application.Current.MainPage.DisplayAlert("Success!", "Successfully added attachment", "OK");
             }
@@ -222,7 +219,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
 
                 // Update UI.
                 _selectedFeature.Refresh();
-                AttachmentsListBox.ItemsSource = await _selectedFeature.GetAttachmentsAsync();
+                AttachmentsListBox.ItemsSource = await GetJpegAttachmentsAsync(_selectedFeature);
 
                 // Show success message.
                 await Application.Current.MainPage.DisplayAlert("Success!", "Successfully deleted attachment", "OK");
@@ -267,6 +264,12 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
             {
                 await Application.Current.MainPage.DisplayAlert("Error reading attachment", exception.ToString(), "OK");
             }
+        }
+
+        private static async Task<IEnumerable<Attachment>> GetJpegAttachmentsAsync(ArcGISFeature feature)
+        {
+            IReadOnlyList<Attachment> attachments = await feature.GetAttachmentsAsync();
+            return attachments.Where(attachment => attachment.ContentType == "image/jpeg").ToList();
         }
 
         // Image picker implementation.

--- a/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -1,10 +1,10 @@
-﻿// Copyright 2019 Esri.
+﻿// Copyright 2021 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -16,6 +16,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms;
+
 // Custom code is needed for presenting the image picker on iOS.
 #if __IOS__
 using Foundation;
@@ -95,7 +96,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
 
                 // Get the selected feature as an ArcGISFeature. It is assumed that all GeoElements in the result are of type ArcGISFeature.
                 GeoElement tappedElement = identifyResult.GeoElements.First();
-                ArcGISFeature tappedFeature = (ArcGISFeature) tappedElement;
+                ArcGISFeature tappedFeature = (ArcGISFeature)tappedElement;
 
                 // Select the feature in the UI and hold a reference to the tapped feature in a field.
                 _damageLayer.SelectFeature(tappedFeature);
@@ -175,7 +176,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
                 await _selectedFeature.AddAttachmentAsync(filename, contentType, attachmentData);
 
                 // Get a reference to the feature's service feature table.
-                ServiceFeatureTable serviceTable = (ServiceFeatureTable) _selectedFeature.FeatureTable;
+                ServiceFeatureTable serviceTable = (ServiceFeatureTable)_selectedFeature.FeatureTable;
 
                 // Apply the edits to the service feature table.
                 await serviceTable.ApplyEditsAsync();
@@ -205,14 +206,14 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
             try
             {
                 // Get the attachment that should be deleted.
-                Button sendingButton = (Button) sender;
-                Attachment selectedAttachment = (Attachment) sendingButton.BindingContext;
+                Button sendingButton = (Button)sender;
+                Attachment selectedAttachment = (Attachment)sendingButton.BindingContext;
 
                 // Delete the attachment.
                 await _selectedFeature.DeleteAttachmentAsync(selectedAttachment);
 
                 // Get a reference to the feature's service feature table.
-                ServiceFeatureTable serviceTable = (ServiceFeatureTable) _selectedFeature.FeatureTable;
+                ServiceFeatureTable serviceTable = (ServiceFeatureTable)_selectedFeature.FeatureTable;
 
                 // Apply the edits to the service feature table.
                 await serviceTable.ApplyEditsAsync();
@@ -239,10 +240,10 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureAttachments
             try
             {
                 // Get a reference to the button that raised the event.
-                Button sendingButton = (Button) sender;
+                Button sendingButton = (Button)sender;
 
                 // Get the attachment from the button's DataContext. The button's DataContext is set by the list view.
-                Attachment selectedAttachment = (Attachment) sendingButton.BindingContext;
+                Attachment selectedAttachment = (Attachment)sendingButton.BindingContext;
 
                 if (selectedAttachment.ContentType.Contains("image"))
                 {

--- a/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
+++ b/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!-- Build Configurations -->
@@ -186,9 +186,6 @@
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2012</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Plugin.FilePicker">
-      <Version>2.1.41</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
+++ b/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Configurations -->
   <PropertyGroup>
@@ -233,9 +233,6 @@
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2083</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Plugin.FilePicker">
-      <Version>2.1.41</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Remove dependency to deprecated Xamarin.FilePicker plugin. This functionality is now built into Xamarin Essentials. See [migration guide](https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows#migration-guide).
- Filter displayed attachments consistently, to only show jpeg/jpg. Previously the sample would sometimes show non-jpeg attachments after adding or removing an attachment. Now the filtering logic is centralized.