### PR TITLE
UWP: Update XF and XF.Essentials versions to match iOS and Android projects

### DIFF
--- a/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
+++ b/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!-- Build Configurations -->
@@ -182,10 +182,10 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.2012</Version>
+      <Version>5.0.0.2083</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Plugin.FilePicker">
       <Version>2.1.41</Version>


### PR DESCRIPTION
iOS and Android projects are already using XF 5.0.0.2083 and XF.Essentials 1.7.0, but UWP project was lagging behind. Now all three platforms use the same version.