### PR TITLE
XF Transaction sample: Don't enable "Sync" button until gdb is ready

### DIFF
--- a/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml
+++ b/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml
@@ -54,7 +54,7 @@
             <Button x:Name="SyncEditsButton"
                     Grid.Row="0" Grid.Column="3"
                     Text="Sync" 
-                    IsEnabled="True"
+                    IsEnabled="False"
                     MinimumWidthRequest="50" MinimumHeightRequest="35"
                     Margin="2,0"
                     Clicked="SynchronizeEdits"/>

--- a/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -58,7 +58,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 await GetLocalGeodatabase();
 
                 // Once the local geodatabase is available, load the tables as layers to the map
-                LoadLocalGeodatabaseTables();
+                await LoadLocalGeodatabaseTables();
             };
             
             // Create a new map with the oceans basemap and add it to the map view
@@ -131,13 +131,13 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 // Show a message for the exception encountered
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    Application.Current.MainPage.DisplayAlert("Generate Geodatabase","Unable to create offline database: " + ex.Message,"OK");
+                    Application.Current.MainPage.DisplayAlert("Generate Geodatabase", "Unable to create offline database: " + ex.Message, "OK");
                 });
             }
         }
 
         // Function that loads the two point tables from the local geodatabase and displays them as feature layers
-        private async void LoadLocalGeodatabaseTables()
+        private async Task LoadLocalGeodatabaseTables()
         {
             if (_localGeodatabase == null) { return; }
 
@@ -179,6 +179,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
             {
                 MyMapView.SetViewpoint(new Viewpoint(_marineTable.Extent));
                 StartEditingButton.IsEnabled = true;
+                SyncEditsButton.IsEnabled = true;
             });
         }
 


### PR DESCRIPTION
Otherwise, clicking "Sync" would throw a NullReferenceException.