### PR TITLE
XF Branch versioning: Fix a few selection quirks

### DIFF
--- a/src/Forms/Shared/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/EditBranchVersioning/EditBranchVersioning.xaml.cs
@@ -220,6 +220,7 @@ namespace ArcGISRuntimeXamarin.Samples.EditBranchVersioning
             }
             else
             {
+                _featureLayer.ClearSelection();
                 try
                 {
                     // Perform an identify to determine if a user tapped on a feature.
@@ -244,15 +245,13 @@ namespace ArcGISRuntimeXamarin.Samples.EditBranchVersioning
                     DamageBox.SelectedItem = currentAttributeValue;
 
                     MoveText.IsVisible = DamageBox.IsEnabled = _serviceGeodatabase.VersionName != _serviceGeodatabase.DefaultVersionName;
+
+                    // Update the UI for the selection.
+                    SwitchView(AttributeView);
                 }
                 catch (Exception ex)
                 {
                     ShowAlert(ex.Message, ex.GetType().Name);
-                }
-                finally
-                {
-                    // Update the UI for the selection.
-                    SwitchView(AttributeView);
                 }
             }
         }


### PR DESCRIPTION
- Previously when tapping features in default version, each tap _added_ another feature to the selection, while continuing to display first feature's attribute. As far as I can tell, the designed behavior was to only select one feature at a time -- that's what this PR implements.
- Previously when editing a version, tapping on part of the map with no features would still open the AttributeView. However, `_selectedFeature` was still null so NullReferenceException was thrown. Now the AttributeView is not displayed until a feature is selected.