### PR TITLE
XF: Use numeric keyboard for numeric entry fields

### DIFF
--- a/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml
+++ b/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml
@@ -39,6 +39,7 @@
                    Margin="5,0,0,0"/>
             <Entry x:Name="BufferDistanceMilesEntry" 
                    Grid.Row="1" Grid.Column="1"
+                   Keyboard="Numeric"
                    HorizontalTextAlignment="Start"
                    Margin="0,5"
                    Text="1000"/>

--- a/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml
+++ b/src/Forms/Shared/Samples/Geometry/Buffer/Buffer.xaml
@@ -1,66 +1,62 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="ArcGISRuntime.Samples.Buffer.Buffer"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
-             x:Class="ArcGISRuntime.Samples.Buffer.Buffer">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="180"/>
-            <RowDefinition/>
-        </Grid.RowDefinitions>
-        <Grid Grid.Row="0"
-              WidthRequest="400"
-              HorizontalOptions="Center">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition/>
-            </Grid.ColumnDefinitions>
-            <Label Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
-                   HorizontalTextAlignment="Center"
-                   LineBreakMode="WordWrap"
-                   Text="Tap the map to create Planar and Geodesic buffers">
-                <Label.TextColor>
-                    <OnPlatform x:TypeArguments="Color">
-                        <On Platform="iOS, UWP" Value="Blue"/>
-                    </OnPlatform>
-                </Label.TextColor>
-            </Label>
-            <Label Grid.Row="1" Grid.Column="0"
-                   HorizontalOptions="End" VerticalOptions="Center"
-                   Text="Distance (miles):"
-                   Margin="5,0,0,0"/>
-            <Entry x:Name="BufferDistanceMilesEntry" 
-                   Grid.Row="1" Grid.Column="1"
-                   Keyboard="Numeric"
-                   HorizontalTextAlignment="Start"
-                   Margin="0,5"
-                   Text="1000"/>
-            <Button x:Name="ClearBuffersButton"
-                    Grid.Row="1" Grid.Column="2" Grid.ColumnSpan="2"
-                    Text="Clear"
-                    Clicked="ClearBuffersButton_Click"/>
-            <Frame x:Name="BufferSwatchPlanar"
-                   Grid.Row="2" Grid.Column="0"
-                   Margin="100,0,0,0"/>
-            <Label Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" 
-                   HorizontalOptions="Start" VerticalOptions="Center"
-                   Text="Planar buffers"/>
-            <Frame x:Name="BufferSwatchGeodesic"
-                   Grid.Row="3" Grid.Column="0"
-                   Margin="100,0,0,0"/>
-            <Label Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
-                   HorizontalOptions="Start" VerticalOptions="Center"
-                   Text="Geodesic buffers"/>
-        </Grid>
+             xmlns:resources="clr-namespace:Forms.Resources;assembly=ArcGISRuntime">
+    <RelativeLayout>
         <esriUI:MapView x:Name="MyMapView"
-                        Grid.Row="1"/>
-    </Grid>
+                        BindingContext="{x:Reference Name=ResponsiveFormContainer}"
+                        Style="{StaticResource MapWithFormStyle}" />
+        <resources:ResponsiveFormContainer x:Name="ResponsiveFormContainer">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Label Grid.Row="0"
+                       Grid.Column="0"
+                       Grid.ColumnSpan="2"
+                       Text="Tap the map to create Planar and Geodesic buffers" />
+                <Label Grid.Row="1"
+                       Grid.Column="0"
+                       Text="Distance (miles):"
+                       VerticalOptions="Center" />
+                <Entry x:Name="BufferDistanceMilesEntry"
+                       Grid.Row="1"
+                       Grid.Column="1"
+                       Keyboard="Numeric"
+                       Text="1000" />
+                <Button x:Name="ClearBuffersButton"
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Clicked="ClearBuffersButton_Click"
+                        Text="Clear" />
+                <Frame x:Name="BufferSwatchPlanar"
+                       Grid.Row="3"
+                       Grid.Column="0"
+                       Margin="5" />
+                <Label Grid.Row="3"
+                       Grid.Column="1"
+                       Text="Planar buffers"
+                       VerticalOptions="Center" />
+                <Frame x:Name="BufferSwatchGeodesic"
+                       Grid.Row="4"
+                       Grid.Column="0"
+                       Margin="5" />
+                <Label Grid.Row="4"
+                       Grid.Column="1"
+                       Text="Geodesic buffers"
+                       VerticalOptions="Center" />
+            </Grid>
+        </resources:ResponsiveFormContainer>
+    </RelativeLayout>
 </ContentPage>

--- a/src/Forms/Shared/Samples/Geometry/BufferList/BufferList.xaml
+++ b/src/Forms/Shared/Samples/Geometry/BufferList/BufferList.xaml
@@ -1,48 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage
-    x:Class="ArcGISRuntime.Samples.BufferList.BufferList"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms">
+﻿<ContentPage x:Class="ArcGISRuntime.Samples.BufferList.BufferList"
+             xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <Grid
-            Grid.Row="0"
-            Margin="10,0"
-            HorizontalOptions="Center">
+        <Grid Grid.Row="0"
+              Margin="10,0"
+              HorizontalOptions="Center">
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="40" />
                 <RowDefinition Height="40" />
                 <RowDefinition Height="40" />
             </Grid.RowDefinitions>
-            <Label
-                x:Name="BufferInstructionsLabel"
-                Grid.Row="0"
-                Text="Tap the map to add points. Each point uses the buffer distance entered when it was created. The envelope shows the area where you can expect reasonable results for planar buffers with this map's spatial reference." />
+            <Label x:Name="BufferInstructionsLabel"
+                   Grid.Row="0"
+                   Text="Tap the map to add points. Each point uses the buffer distance entered when it was created. The envelope shows the area where you can expect reasonable results for planar buffers with this map's spatial reference." />
             <StackLayout Grid.Row="1" Orientation="Horizontal">
                 <Label Text="Buffer distance (miles):" VerticalOptions="Center" />
-                <Entry x:Name="BufferDistanceMilesEntry" Text="10" Keyboard="Numeric" />
+                <Entry x:Name="BufferDistanceMilesEntry"
+                       HorizontalOptions="FillAndExpand"
+                       Keyboard="Numeric"
+                       Text="10" />
             </StackLayout>
             <StackLayout Grid.Row="2" Orientation="Horizontal">
                 <Label Text="Union the buffers:" VerticalOptions="Center" />
                 <Switch x:Name="UnionSwitch" IsToggled="True" />
             </StackLayout>
             <StackLayout Grid.Row="3" Orientation="Horizontal">
-                <Button
-                    x:Name="BufferButton"
-                    Clicked="BufferButton_Click"
-                    Text="Create buffers"
-                    WidthRequest="120" />
-                <Button
-                    x:Name="ClearButton"
-                    Margin="10,0,0,0"
-                    Clicked="ClearButton_Click"
-                    Text="Clear"
-                    WidthRequest="120" />
+                <Button x:Name="BufferButton"
+                        Clicked="BufferButton_Click"
+                        HorizontalOptions="FillAndExpand"
+                        Text="Create buffers" />
+                <Button x:Name="ClearButton"
+                        Clicked="ClearButton_Click"
+                        HorizontalOptions="FillAndExpand"
+                        Text="Clear" />
             </StackLayout>
         </Grid>
         <esriUI:MapView x:Name="MyMapView" Grid.Row="1" />

--- a/src/Forms/Shared/Samples/Geometry/BufferList/BufferList.xaml
+++ b/src/Forms/Shared/Samples/Geometry/BufferList/BufferList.xaml
@@ -25,7 +25,7 @@
                 Text="Tap the map to add points. Each point uses the buffer distance entered when it was created. The envelope shows the area where you can expect reasonable results for planar buffers with this map's spatial reference." />
             <StackLayout Grid.Row="1" Orientation="Horizontal">
                 <Label Text="Buffer distance (miles):" VerticalOptions="Center" />
-                <Entry x:Name="BufferDistanceMilesEntry" Text="10" />
+                <Entry x:Name="BufferDistanceMilesEntry" Text="10" Keyboard="Numeric" />
             </StackLayout>
             <StackLayout Grid.Row="2" Orientation="Horizontal">
                 <Label Text="Union the buffers:" VerticalOptions="Center" />

--- a/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
+++ b/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
@@ -17,11 +17,11 @@
         <ListView Grid.Row="1" x:Name="RendererTypes" ItemSelected="RendererTypes_SelectionChanged"/>
         <StackLayout Orientation="Horizontal" Grid.Row="2">
             <Label x:Name="Label_Parameter1" Text="Parameter1" />
-            <Entry x:Name="Input_Parameter1" Text="EnterValue1" />
+            <Entry x:Name="Input_Parameter1" Text="EnterValue1" Keyboard="Numeric" />
         </StackLayout>
         <StackLayout Orientation="Horizontal" Grid.Row="3">
             <Label x:Name="Label_Parameter2" Text="Parameter2" />
-            <Entry x:Name="Input_Parameter2" Text="EnterValue2" />
+            <Entry x:Name="Input_Parameter2" Text="EnterValue2" Keyboard="Numeric" />
         </StackLayout>
         <Button Grid.Row="4" x:Name="UpdateRenderer" Clicked="OnUpdateRendererClicked" Text="Update Renderer" />
         <esriUI:MapView Grid.Row="5" x:Name="MyMapView" />

--- a/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
+++ b/src/Forms/Shared/Samples/Layers/ChangeStretchRenderer/ChangeStretchRenderer.xaml
@@ -1,29 +1,47 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="ArcGISRuntime.Samples.ChangeStretchRenderer.ChangeStretchRenderer"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
-             x:Class="ArcGISRuntime.Samples.ChangeStretchRenderer.ChangeStretchRenderer"
              Title="Stretch renderer">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="40"/>
+            <RowDefinition Height="auto" />
             <RowDefinition Height="100" />
-            <RowDefinition Height="40" />
-            <RowDefinition Height="40"/>
-            <RowDefinition Height="40"/>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Label Grid.Row="0">Choose a stretch renderer type from the listbox, adjust the parameter values, then click the 'Update Renderer' button.</Label>
-        <ListView Grid.Row="1" x:Name="RendererTypes" ItemSelected="RendererTypes_SelectionChanged"/>
-        <StackLayout Orientation="Horizontal" Grid.Row="2">
-            <Label x:Name="Label_Parameter1" Text="Parameter1" />
-            <Entry x:Name="Input_Parameter1" Text="EnterValue1" Keyboard="Numeric" />
+        <ListView x:Name="RendererTypes"
+                  Grid.Row="1"
+                  ItemSelected="RendererTypes_SelectionChanged" />
+        <StackLayout Grid.Row="2"
+                     Margin="5"
+                     Orientation="Horizontal">
+            <Label x:Name="Label_Parameter1"
+                   Text="Parameter1"
+                   VerticalOptions="Center" />
+            <Entry x:Name="Input_Parameter1"
+                   HorizontalOptions="FillAndExpand"
+                   Keyboard="Numeric"
+                   Text="EnterValue1" />
         </StackLayout>
-        <StackLayout Orientation="Horizontal" Grid.Row="3">
-            <Label x:Name="Label_Parameter2" Text="Parameter2" />
-            <Entry x:Name="Input_Parameter2" Text="EnterValue2" Keyboard="Numeric" />
+        <StackLayout Grid.Row="3"
+                     Margin="5"
+                     Orientation="Horizontal">
+            <Label x:Name="Label_Parameter2"
+                   Text="Parameter2"
+                   VerticalOptions="Center" />
+            <Entry x:Name="Input_Parameter2"
+                   HorizontalOptions="FillAndExpand"
+                   Keyboard="Numeric"
+                   Text="EnterValue2" />
         </StackLayout>
-        <Button Grid.Row="4" x:Name="UpdateRenderer" Clicked="OnUpdateRendererClicked" Text="Update Renderer" />
-        <esriUI:MapView Grid.Row="5" x:Name="MyMapView" />
+        <Button x:Name="UpdateRenderer"
+                Grid.Row="4"
+                Clicked="OnUpdateRendererClicked"
+                Text="Update Renderer" />
+        <esriUI:MapView x:Name="MyMapView" Grid.Row="5" />
     </Grid>
 </ContentPage>

--- a/src/Forms/Shared/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml
+++ b/src/Forms/Shared/Samples/Layers/QueryCQLFilters/QueryCQLFilters.xaml
@@ -44,7 +44,8 @@
                        Text="Max features:" />
                 <Entry x:Name="MaxFeaturesBox"
                        Grid.Row="2"
-                       Grid.Column="1" />
+                       Grid.Column="1"
+                       Keyboard="Numeric" />
                 <Label Grid.Row="3"
                        Grid.Column="0"
                        Text="Time extent" />


### PR DESCRIPTION
This improves the sample experience of iOS and Android devices -- focusing these fields will now pop up the numeric keyboard. This is a best practice that gives app users a hint that only numbers are expected/allowed, and makes it quicker to enter numbers.