### PR TITLE
Add redirect urls for sample names which have been updated

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -20,7 +20,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/android/sample-code/displaydevicelocation.htm"
+        "/net/latest/android/sample-code/displaydevicelocation.htm",
+        "/net/android/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/Forms/Shared/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -23,7 +23,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/forms/sample-code/displaydevicelocation.htm"
+        "/net/latest/forms/sample-code/displaydevicelocation.htm",
+        "/net/forms/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -20,7 +20,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/uwp/sample-code/displaydevicelocation.htm"
+        "/net/latest/uwp/sample-code/displaydevicelocation.htm",
+        "/net/uwp/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -20,7 +20,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/wpf/sample-code/displaydevicelocation.htm"
+        "/net/latest/wpf/sample-code/displaydevicelocation.htm",
+        "/net/wpf/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -20,7 +20,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/winui/sample-code/displaydevicelocation.htm"
+        "/net/latest/winui/sample-code/displaydevicelocation.htm",
+        "/net/winui/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",

--- a/src/iOS/Xamarin.iOS/Samples/Location/DisplayDeviceLocation/readme.metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Location/DisplayDeviceLocation/readme.metadata.json
@@ -20,7 +20,8 @@
     },
     "offline_data": [],
     "redirect_from": [
-        "/net/latest/ios/sample-code/displaydevicelocation.htm"
+        "/net/latest/ios/sample-code/displaydevicelocation.htm",
+        "/net/ios/sample-code/display-device-location/"
     ],
     "relevant_apis": [
         "LocationDisplay",


### PR DESCRIPTION
The 'Display device location' sample name has been updated. These redirects ensure the previous links for the sample still direct as intended, for instance the card by the same name here: https://developers.arcgis.com/net/maps-2d/#samples