### PR TITLE
WinUI: Fix MessageDialog and file picker problems

### DIFF
--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
@@ -81,6 +81,6 @@ namespace ArcGISRuntime.WinUI.Viewer
 
         private Window m_window;
 
-        public static Window CurrentWindow => ((App)Current).m_window;
+        public static IntPtr CurrentWindowHandle => WinRT.Interop.WindowNative.GetWindowHandle(((App)Current).m_window);
     }
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
@@ -35,6 +35,8 @@ namespace ArcGISRuntime.WinUI.Viewer
             this.InitializeComponent();
         }
 
+        public static IntPtr CurrentWindowHandle { get; private set; }
+
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.
@@ -44,6 +46,8 @@ namespace ArcGISRuntime.WinUI.Viewer
         {
             m_window = new MainWindow();
             Frame rootFrame = m_window.Content as Frame;
+
+            CurrentWindowHandle = WinRT.Interop.WindowNative.GetWindowHandle(m_window);
 
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active
@@ -73,6 +77,7 @@ namespace ArcGISRuntime.WinUI.Viewer
             // Ensure the current window is active
             m_window.Activate();
         }
+
         private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
         {
             throw new Exception("Failed to load Page " + e.SourcePageType.FullName);

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/App.xaml.cs
@@ -35,8 +35,6 @@ namespace ArcGISRuntime.WinUI.Viewer
             this.InitializeComponent();
         }
 
-        public static IntPtr CurrentWindowHandle { get; private set; }
-
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.
@@ -46,8 +44,6 @@ namespace ArcGISRuntime.WinUI.Viewer
         {
             m_window = new MainWindow();
             Frame rootFrame = m_window.Content as Frame;
-
-            CurrentWindowHandle = WinRT.Interop.WindowNative.GetWindowHandle(m_window);
 
             // Do not repeat app initialization when the Window already has content,
             // just ensure that the window is active
@@ -84,5 +80,7 @@ namespace ArcGISRuntime.WinUI.Viewer
         }
 
         private Window m_window;
+
+        public static Window CurrentWindow => ((App)Current).m_window;
     }
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/EditFeatureAttachments/EditFeatureAttachments.xaml.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.UI.Popups;
+using ArcGISRuntime.WinUI.Viewer;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -135,6 +136,7 @@ namespace ArcGISRuntime.WinUI.Samples.EditFeatureAttachments
                 // Show a file picker.
                 // Allow the user to specify a file path - create the picker.
                 FileOpenPicker openPicker = new FileOpenPicker();
+                WinRT.Interop.InitializeWithWindow.Initialize(openPicker, App.CurrentWindowHandle);
                 openPicker.FileTypeFilter.Add(".jpg");
 
                 // Show the picker.
@@ -229,6 +231,7 @@ namespace ArcGISRuntime.WinUI.Samples.EditFeatureAttachments
                 // Show a file dialog.
                 // Allow the user to specify a file path - create the dialog.
                 var savePicker = new FileSavePicker();
+                WinRT.Interop.InitializeWithWindow.Initialize(savePicker, App.CurrentWindowHandle);
                 savePicker.SuggestedStartLocation = PickerLocationId.Downloads;
                 savePicker.FileTypeChoices.Add(selectedAttachment.ContentType, new List<string> {".jpeg", ".jpg"});
                 savePicker.SuggestedFileName = selectedAttachment.Name;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/CreateAndSaveKmlFile/CreateAndSaveKmlFile.xaml.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using Windows.Storage.Pickers;
 using Windows.UI.Popups;
+using ArcGISRuntime.WinUI.Viewer;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Geometry = Esri.ArcGISRuntime.Geometry.Geometry;
@@ -222,6 +223,7 @@ namespace ArcGISRuntime.WinUI.Samples.CreateAndSaveKmlFile
         {
             // Open a save dialog for the user.
             FileSavePicker savePicker = new FileSavePicker();
+            WinRT.Interop.InitializeWithWindow.Initialize(savePicker, App.CurrentWindowHandle);
             savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
             savePicker.FileTypeChoices.Add("KMZ file", new List<string>() { ".kmz" });
             Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
@@ -33,7 +33,7 @@ namespace ArcGISRuntime.WinUI
 
         public IAsyncOperation<IUICommand> ShowAsync()
         {
-            var handle = App.CurrentWindowHandle;
+            var handle = WinRT.Interop.WindowNative.GetWindowHandle(App.CurrentWindow);
             dialog.As<IInitializeWithWindow>().Initialize(handle);
             return dialog.ShowAsync();
         }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
@@ -1,10 +1,7 @@
 ﻿using ArcGISRuntime.WinUI.Viewer;
-using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using Windows.Foundation;
 using Windows.UI.Popups;
-using WinRT;
 
 namespace ArcGISRuntime.WinUI
 {
@@ -33,20 +30,8 @@ namespace ArcGISRuntime.WinUI
 
         public IAsyncOperation<IUICommand> ShowAsync()
         {
-            var handle = WinRT.Interop.WindowNative.GetWindowHandle(App.CurrentWindow);
-            dialog.As<IInitializeWithWindow>().Initialize(handle);
+            WinRT.Interop.InitializeWithWindow.Initialize(dialog, App.CurrentWindowHandle);
             return dialog.ShowAsync();
         }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
-        private interface IInitializeWithWindow
-        {
-            void Initialize(IntPtr hwnd);
-        }
-
-        [DllImport("user32.dll")]
-        private static extern IntPtr GetActiveWindow();
     }
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/WinUIHelpers.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using ArcGISRuntime.WinUI.Viewer;
+using System;
 using System.Collections.Generic;
-using System.Net.Mime;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.Appointments.DataProvider;
 using Windows.Foundation;
 using Windows.UI.Popups;
 using WinRT;
@@ -16,6 +15,7 @@ namespace ArcGISRuntime.WinUI
     public class MessageDialog2
     {
         private readonly MessageDialog dialog;
+
         public MessageDialog2(string content) : this(content, string.Empty) { }
 
         public MessageDialog2(string content, string title)
@@ -33,9 +33,7 @@ namespace ArcGISRuntime.WinUI
 
         public IAsyncOperation<IUICommand> ShowAsync()
         {
-            var handle = GetActiveWindow();
-            if (handle == IntPtr.Zero)
-                throw new InvalidOperationException();
+            var handle = App.CurrentWindowHandle;
             dialog.As<IInitializeWithWindow>().Initialize(handle);
             return dialog.ShowAsync();
         }
@@ -43,7 +41,7 @@ namespace ArcGISRuntime.WinUI
         [ComImport]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
-        internal interface IInitializeWithWindow
+        private interface IInitializeWithWindow
         {
             void Initialize(IntPtr hwnd);
         }


### PR DESCRIPTION
Previous implementation failed (often taking down the whole app) unless the sample viewer is the currently-focused window.  Minimizing the app on some long-running samples was enough to trigger this problem.  With these changes, we can get the HWND even when app is minimized.

File pickers were also crashy (affected by https://github.com/microsoft/WindowsAppSDK/issues/466) and also needed initialization with HWND to work.