### PR TITLE
WinUI: add links to Windows SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following platforms are being kept for reference, but no new sample implemen
 > **IMPORTANT** When you run the samples, you will need to provide an API key. You can get a free developer account and key on the [ArcGIS Developers website](developers.arcgis.com). For more information see https://links.esri.com/arcgis-runtime-security-auth.
 
 - The .NET sample viewers have a prompt for setting an API key. You can also hardcode your API key in the [`GetLocalKey() method`](https://github.com/Esri/arcgis-runtime-samples-dotnet/tree/main/src/ArcGISRuntime.Samples.Shared/Managers/ApiKeyManager.cs#L89) of the [`ApiKeyManager class`](https://github.com/Esri/arcgis-runtime-samples-dotnet/tree/main/src/ArcGISRuntime.Samples.Shared/Managers/ApiKeyManager.cs).
+- Before using WinUI, install the [latest Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) and the [vsix plugin](https://aka.ms/windowsappsdk/stable-vsix-2022-cs).
 - When compiling Universal Windows Platform samples, make sure that you are compiling against x86/x64/ARM platform and not using AnyCPU.
 
 ### Offline data

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer (Package)/ArcGISRuntime.WinUI.Viewer (Package).wapproj
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer (Package)/ArcGISRuntime.WinUI.Viewer (Package).wapproj
@@ -36,7 +36,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>ba503bd0-660a-4ea6-ab0e-11823f9bad96</ProjectGuid>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <AssetTargetFallback>net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/src/WinUI/previewinfo.md
+++ b/src/WinUI/previewinfo.md
@@ -1,6 +1,0 @@
-# ArcGIS Runtime API for .NET - Samples : WinUI (Preview)
-
-ArcGIS Runtime sample viewer for WinUI is a preview intended for evaluation purposes only. Sample viewer project references preview APIs:
-
-- [ArcGIS Runtime SDK for .NET - WinUI Preview 2 `Esri.ArcGISRuntime.WinUI.100.10.0-preview2`](https://community.esri.com/t5/arcgis-runtime-sdks-blog/announcing-arcgis-runtime-sdk-for-net-100-10/ba-p/1019490#toc-hId-1734174535)
-- [Windows UI Library 3 Preview 4 `Microsoft.WinUI.3.0.0-preview4.210210.4`](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/)


### PR DESCRIPTION
Getting WinUI up and running for the first time has been a common blocker. Adding a note to the readme should help our users easily find the prerequisites for getting the WinUI samples running.