### PR TITLE
WPF store package build fixes

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.StorePackage/ArcGISRuntime.WPF.StorePackage.wapproj
+++ b/src/WPF/ArcGISRuntime.WPF.StorePackage/ArcGISRuntime.WPF.StorePackage.wapproj
@@ -130,4 +130,7 @@
     <Content Include="Images\Wide310x150Logo.scale-400.png" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
+  <PropertyGroup>
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+  </PropertyGroup>
 </Project>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -81,10 +81,10 @@ namespace ArcGISRuntime.WPF.Samples.LocationWithNMEA
 
         private void UpdateNmeaMessageLabel(object sender, NmeaMessageEventArgs e)
         {
-            Dispatcher.BeginInvoke(delegate ()
+            Dispatcher.BeginInvoke(new Action(() =>
             {
                 NmeaMessageLabel.Content = e.NmeaMessage;
-            });
+            }));
         }
 
         private void SatellitesChanged(object sender, IReadOnlyList<NmeaSatelliteInfo> infos)
@@ -99,25 +99,25 @@ namespace ArcGISRuntime.WPF.Samples.LocationWithNMEA
                 uniqueSatelliteIds.Add(info.Id);
             }
 
-            Dispatcher.BeginInvoke(delegate ()
+            Dispatcher.BeginInvoke(new Action(() =>
             {
                 // Show the status information in the UI.
                 CountLabel.Content = $"Satellite count: {infos.Count}";
                 SatellitesLabel.Content = $"Satellites: {string.Join(", ", uniqueSatelliteIds)}";
                 SystemLabel.Content = $"System: {infos.First().System}";
-            });
+            }));
         }
 
         private void LocationChanged(object sender, Location loc)
         {
-            Dispatcher.BeginInvoke(delegate ()
+            Dispatcher.BeginInvoke(new Action(() =>
             {
                 // Show the status information in the UI.
                 AccuracyLabel.Content = $"Accuracy: Horizontal {string.Format("{0:0.00}", loc.HorizontalAccuracy)} meters, Vertical  {string.Format("{0:0.00}", loc.VerticalAccuracy)} meters";
 
                 // Recenter on the new location.
                 MyMapView.LocationDisplay.AutoPanMode = LocationDisplayAutoPanMode.Recenter;
-            });
+            }));
         }
 
         private void StartClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- The use of `delegate` in the new NMEA sample breaks the store package build.
- The store package had an issue with an x86 warning that needs to be ignored.