### PR TITLE
Fixed bug where some category paths would be invalid

### DIFF
--- a/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
+++ b/src/ArcGISRuntime.Samples.Shared/Models/SampleInfo.cs
@@ -32,7 +32,11 @@ namespace ArcGISRuntime.Samples.Shared.Models
         {
             get
             {
-                string formalCategory = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Category).Replace(" ", "");
+                string formalCategory = Category;
+                if (formalCategory.Contains(' '))
+                {
+                    formalCategory = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(Category).Replace(" ", "");
+                }
                 return System.IO.Path.Combine(_pathStub, "Samples", formalCategory, FormalName);
             }
         }


### PR DESCRIPTION
The old logic would change "GraphicsOverlay" to "Graphicsoverlay" with the title case call. This broke paths to readmes on Forms.iOS and potentially had other issues.