### PR TITLE
Update the Dictionary renderer graphics overlay to use different portal item and pluralize  to "Ordered Anchor Points".

### DIFF
--- a/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -28,7 +28,7 @@ namespace ArcGISRuntimeXamarin.Samples.DictionaryRendererGraphicsOverlay
         description: "Create graphics from an XML file with key-value pairs for each graphic, and display the military symbols using a MIL-STD-2525D web style in 2D.",
         instructions: "Pan and zoom to explore military symbols on the map.",
         tags: new[] { "defense", "military", "situational awareness", "tactical", "visualization" })]
-    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("1e4ea99af4b440c092e7959cf3957bfa")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("8776cfc26eed4485a03de6316826384c")]
     public partial class DictionaryRendererGraphicsOverlay : ContentPage
     {
         // Hold a reference to the graphics overlay for easy access.
@@ -57,10 +57,10 @@ namespace ArcGISRuntimeXamarin.Samples.DictionaryRendererGraphicsOverlay
                 var symbolStyleUri = new Uri("https://www.arcgis.com/home/item.html?id=d815f3bdf6e6452bb8fd153b654c94ca");
                 DictionarySymbolStyle dictionarySymbolStyle = await DictionarySymbolStyle.OpenAsync(symbolStyleUri);
 
-                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINT".
+                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINTS".
                 if (dictionarySymbolStyle?.Configurations?.FirstOrDefault(config => config.Name == "model") is DictionarySymbolStyleConfiguration configuration)
                 {
-                    configuration.Value = "ORDERED ANCHOR POINT";
+                    configuration.Value = "ORDERED ANCHOR POINTS";
                 }
 
                 // Create a new dictionary renderer from the dictionary symbol style to render graphics with symbol dictionary attributes and set it to the graphics overlay renderer.
@@ -84,7 +84,7 @@ namespace ArcGISRuntimeXamarin.Samples.DictionaryRendererGraphicsOverlay
         private void LoadMilitaryMessages()
         {
             // Get the path to the messages file.
-            string militaryMessagePath = DataManager.GetDataFolder("1e4ea99af4b440c092e7959cf3957bfa", "Mil2525DMessages.xml");
+            string militaryMessagePath = DataManager.GetDataFolder("8776cfc26eed4485a03de6316826384c", "Mil2525DMessages.xml");
 
             // Load the XML document.
             XElement xmlRoot = XElement.Load(militaryMessagePath);

--- a/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
@@ -33,7 +33,7 @@ Pan and zoom to explore military symbols on the map.
 
 ## Offline data
 
-This sample uses the [MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1e4ea99af4b440c092e7959cf3957bfa) hosted on ArcGIS Online.
+This sample uses the [MIL-STD-2525D XML Message File](https://www.arcgis.com/home/item.html?id=8776cfc26eed4485a03de6316826384c) hosted on ArcGIS Online.
 
 ## About the data
 

--- a/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
@@ -14,7 +14,7 @@
         "visualization"
     ],
     "offline_data": [
-        "1e4ea99af4b440c092e7959cf3957bfa"
+        "8776cfc26eed4485a03de6316826384c"
     ],
     "redirect_from": [
         "/net/latest/forms/sample-code/dictionaryrenderergraphicsoverlay.htm"

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -28,7 +28,7 @@ namespace ArcGISRuntime.WPF.Samples.DictionaryRendererGraphicsOverlay
         description: "Create graphics from an XML file with key-value pairs for each graphic, and display the military symbols using a MIL-STD-2525D web style in 2D.",
         instructions: "Pan and zoom to explore military symbols on the map.",
         tags: new[] { "defense", "military", "situational awareness", "tactical", "visualization" })]
-    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("1e4ea99af4b440c092e7959cf3957bfa")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("8776cfc26eed4485a03de6316826384c")]
     public partial class DictionaryRendererGraphicsOverlay
     {
         // Hold a reference to the graphics overlay for easy access.
@@ -57,11 +57,11 @@ namespace ArcGISRuntime.WPF.Samples.DictionaryRendererGraphicsOverlay
                 var symbolStyleUri = new Uri("https://www.arcgis.com/home/item.html?id=d815f3bdf6e6452bb8fd153b654c94ca");
                 DictionarySymbolStyle dictionarySymbolStyle = await DictionarySymbolStyle.OpenAsync(symbolStyleUri);
 
-                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINT".
+                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINTS".
                 //if (dictionarySymbolStyle?.Configurations?.FirstOrDefault(config => config.Name == "model") is DictionarySymbolStyleConfiguration configuration)
                 if (dictionarySymbolStyle?.Configurations?.FirstOrDefault(config => config.Name == "model") is DictionarySymbolStyleConfiguration configuration)
                 {
-                    configuration.Value = "ORDERED ANCHOR POINT";
+                    configuration.Value = "ORDERED ANCHOR POINTS";
                 }
 
                 // Create a new dictionary renderer from the dictionary symbol style to render graphics with symbol dictionary attributes and set it to the graphics overlay renderer.
@@ -85,7 +85,7 @@ namespace ArcGISRuntime.WPF.Samples.DictionaryRendererGraphicsOverlay
         private void LoadMilitaryMessages()
         {
             // Get the path to the messages file.
-            string militaryMessagePath = DataManager.GetDataFolder("1e4ea99af4b440c092e7959cf3957bfa", "Mil2525DMessages.xml");
+            string militaryMessagePath = DataManager.GetDataFolder("8776cfc26eed4485a03de6316826384c", "Mil2525DMessages.xml");
 
             // Load the XML document.
             XElement xmlRoot = XElement.Load(militaryMessagePath);

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
@@ -33,7 +33,7 @@ Pan and zoom to explore military symbols on the map.
 
 ## Offline data
 
-This sample uses the [MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1e4ea99af4b440c092e7959cf3957bfa) hosted on ArcGIS Online.
+This sample uses the [MIL-STD-2525D XML Message File](https://www.arcgis.com/home/item.html?id=8776cfc26eed4485a03de6316826384c) hosted on ArcGIS Online.
 
 ## About the data
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
@@ -14,7 +14,7 @@
         "visualization"
     ],
     "offline_data": [
-        "1e4ea99af4b440c092e7959cf3957bfa"
+        "8776cfc26eed4485a03de6316826384c"
     ],
     "redirect_from": [
         "/net/latest/wpf/sample-code/dictionaryrenderergraphicsoverlay.htm"

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/DictionaryRendererGraphicsOverlay.xaml.cs
@@ -26,7 +26,7 @@ namespace ArcGISRuntime.WinUI.Samples.DictionaryRendererGraphicsOverlay
         description: "Create graphics from an XML file with key-value pairs for each graphic, and display the military symbols using a MIL-STD-2525D web style in 2D.",
         instructions: "Pan and zoom to explore military symbols on the map.",
         tags: new[] { "defense", "military", "situational awareness", "tactical", "visualization" })]
-    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("1e4ea99af4b440c092e7959cf3957bfa")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("8776cfc26eed4485a03de6316826384c")]
     public partial class DictionaryRendererGraphicsOverlay
     {
         // Hold a reference to the graphics overlay for easy access.
@@ -55,10 +55,10 @@ namespace ArcGISRuntime.WinUI.Samples.DictionaryRendererGraphicsOverlay
                 var symbolStyleUri = new Uri("https://www.arcgis.com/home/item.html?id=d815f3bdf6e6452bb8fd153b654c94ca");
                 DictionarySymbolStyle dictionarySymbolStyle = await DictionarySymbolStyle.OpenAsync(symbolStyleUri);
 
-                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINT".
+                // Find the first configuration setting which has the property name "model", and set its value to "ORDERED ANCHOR POINTS".
                 if (dictionarySymbolStyle?.Configurations?.FirstOrDefault(config => config.Name == "model") is DictionarySymbolStyleConfiguration configuration)
                 {
-                    configuration.Value = "ORDERED ANCHOR POINT";
+                    configuration.Value = "ORDERED ANCHOR POINTS";
                 }
 
                 // Create a new dictionary renderer from the dictionary symbol style to render graphics with symbol dictionary attributes and set it to the graphics overlay renderer.
@@ -82,7 +82,7 @@ namespace ArcGISRuntime.WinUI.Samples.DictionaryRendererGraphicsOverlay
         private void LoadMilitaryMessages()
         {
             // Get the path to the messages file.
-            string militaryMessagePath = DataManager.GetDataFolder("1e4ea99af4b440c092e7959cf3957bfa", "Mil2525DMessages.xml");
+            string militaryMessagePath = DataManager.GetDataFolder("8776cfc26eed4485a03de6316826384c", "Mil2525DMessages.xml");
 
             // Load the XML document.
             XElement xmlRoot = XElement.Load(militaryMessagePath);

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.md
@@ -33,7 +33,7 @@ Pan and zoom to explore military symbols on the map.
 
 ## Offline data
 
-This sample uses the [MIL-STD-2525D XML Message File](https://arcgisruntime.maps.arcgis.com/home/item.html?id=1e4ea99af4b440c092e7959cf3957bfa) hosted on ArcGIS Online.
+This sample uses the [MIL-STD-2525D XML Message File](https://www.arcgis.com/home/item.html?id=8776cfc26eed4485a03de6316826384c) hosted on ArcGIS Online.
 
 ## About the data
 

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/DictionaryRendererGraphicsOverlay/readme.metadata.json
@@ -14,7 +14,7 @@
         "visualization"
     ],
     "offline_data": [
-        "1e4ea99af4b440c092e7959cf3957bfa"
+        "8776cfc26eed4485a03de6316826384c"
     ],
     "redirect_from": [
         "/net/latest/winui/sample-code/dictionaryrenderergraphicsoverlay.htm"


### PR DESCRIPTION
# Description

This sample needed an updated portal item to be used and the dictionary configuration value needed to be updated from "ORDERED ANCHOR POINT" to "ORDERED ANCHOR POINTS" (pluralize).

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab