### PR TITLE
Change samples to use URI constructor.

### DIFF
--- a/src/Forms/Shared/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -25,51 +25,46 @@ namespace ArcGISRuntime.Samples.DisplayScene
         {
             InitializeComponent();
 
-            // Execute initialization 
+            // Execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a new scene
+            // Create a new scene.
             Scene myScene = new Scene();
 
-            // Crate a new base map using the static/shared create imagery method
+            // Crate a new base map using the static/shared create imagery method.
             Basemap myBaseMap = new Basemap(BasemapStyle.ArcGISImageryStandard);
 
-            // Add the imagery basemap to the scene's base map property
+            // Add the imagery basemap to the scene's base map property.
             myScene.Basemap = myBaseMap;
 
-            // Add scene (with an imagery basemap) to the scene view's scene property
+            // Add scene (with an imagery basemap) to the scene view's scene property.
             MySceneView.Scene = myScene;
 
-            // Create a new surface
+            // Create a new surface.
             Surface mySurface = new Surface();
 
-            // Define the string that points to the elevation image service
+            // Define the string that points to the elevation image service.
             string myElevationImageService = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
-            // Create a Uri from the elevation image service string
+            // Create a Uri from the elevation image service string.
             Uri myUri = new Uri(myElevationImageService);
 
-            // Create an ArcGIS tiled elevation 
-            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource
-            {
+            // Create an ArcGIS tiled elevation.
+            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource(myUri);
 
-                // Set the ArcGIS tiled elevation sources property to the Uri of the elevation image service
-                Source = myUri
-            };
-
-            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection
+            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection.
             mySurface.ElevationSources.Add(myArcGISTiledElevationSource);
 
-            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source
+            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source.
             myScene.BaseSurface = mySurface;
 
-            // Create camera with an initial camera position (Mount Everest in the Alps mountains)
+            // Create camera with an initial camera position (Mount Everest in the Alps mountains).
             Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
 
-            // Set the scene view's camera position
+            // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);
         }
     }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -24,53 +24,47 @@ namespace ArcGISRuntime.WPF.Samples.DisplayScene
         {
             InitializeComponent();
 
-            // Execute initialization 
+            // Execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a new scene
+            // Create a new scene.
             Scene myScene = new Scene();
 
-            // Crate a new base map using the static/shared create imagery method
+            // Crate a new base map using the static/shared create imagery method.
             Basemap myBaseMap = new Basemap(BasemapStyle.ArcGISImageryStandard);
 
-            // Add the imagery basemap to the scene's base map property
+            // Add the imagery basemap to the scene's base map property.
             myScene.Basemap = myBaseMap;
 
-            // Add scene (with an imagery basemap) to the scene view's scene property
+            // Add scene (with an imagery basemap) to the scene view's scene property.
             MySceneView.Scene = myScene;
 
-            // Create a new surface
+            // Create a new surface.
             Surface mySurface = new Surface();
 
-            // Define the string that points to the elevation image service
+            // Define the string that points to the elevation image service.
             string myElevationImageService = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
-            // Create a Uri from the elevation image service string
+            // Create a Uri from the elevation image service string.
             Uri myUri = new Uri(myElevationImageService);
 
-            // Create an ArcGIS tiled elevation 
-            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource
-            {
+            // Create an ArcGIS tiled elevation.
+            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource(myUri);
 
-                // Set the ArcGIS tiled elevation sources property to the Uri of the elevation image service
-                Source = myUri
-            };
-
-            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection
+            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection.
             mySurface.ElevationSources.Add(myArcGISTiledElevationSource);
 
-            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source
+            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source.
             myScene.BaseSurface = mySurface;
 
-            // Create camera with an initial camera position (Mount Everest in the Alps mountains)
+            // Create camera with an initial camera position (Mount Everest in the Alps mountains).
             Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
 
-            // Set the scene view's camera position
+            // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);
         }
-
     }
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -24,50 +24,46 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayScene
         {
             InitializeComponent();
 
-            // Execute initialization
+            // Execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a new scene
+            // Create a new scene.
             Scene myScene = new Scene();
 
-            // Crate a new base map using the static/shared create imagery method
+            // Crate a new base map using the static/shared create imagery method.
             Basemap myBaseMap = new Basemap(BasemapStyle.ArcGISImageryStandard);
 
-            // Add the imagery basemap to the scene's base map property
+            // Add the imagery basemap to the scene's base map property.
             myScene.Basemap = myBaseMap;
 
-            // Add scene (with an imagery basemap) to the scene view's scene property
+            // Add scene (with an imagery basemap) to the scene view's scene property.
             MySceneView.Scene = myScene;
 
-            // Create a new surface
+            // Create a new surface.
             Surface mySurface = new Surface();
 
-            // Define the string that points to the elevation image service
+            // Define the string that points to the elevation image service.
             string myElevationImageService = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer";
 
-            // Create a Uri from the elevation image service string
+            // Create a Uri from the elevation image service string.
             Uri myUri = new Uri(myElevationImageService);
 
-            // Create an ArcGIS tiled elevation
-            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource
-            {
-                // Set the ArcGIS tiled elevation sources property to the Uri of the elevation image service
-                Source = myUri
-            };
+            // Create an ArcGIS tiled elevation.
+            ArcGISTiledElevationSource myArcGISTiledElevationSource = new ArcGISTiledElevationSource(myUri);
 
-            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection
+            // Add the ArcGIS tiled elevation source to the surface's elevated sources collection.
             mySurface.ElevationSources.Add(myArcGISTiledElevationSource);
 
-            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source
+            // Set the scene's base surface to the surface with the ArcGIS tiled elevation source.
             myScene.BaseSurface = mySurface;
 
-            // Create camera with an initial camera position (Mount Everest in the Alps mountains)
+            // Create camera with an initial camera position (Mount Everest in the Alps mountains).
             Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
 
-            // Set the scene view's camera position
+            // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);
         }
     }


### PR DESCRIPTION
# Description

Converted an old workflow for setting the `Uri` of an `ArcGISTiledElevationSource` to using the constructor for `ArcGISTiledElevationSource` that uses the `Uri` as an input.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [ ] Xamarin.Forms UWP

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [ ] All variable and method names are good and make sense
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab