### PR TITLE
Bug fix: Find place

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/Android/Xamarin.Android/Samples/Search/FindPlace/FindPlace.cs
@@ -100,7 +100,9 @@ namespace ArcGISRuntime.Samples.FindPlace
 
             // Unsubscribe; only want to zoom to location once.
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
-            RunOnUiThread(() => { _myMapView.SetViewpoint(new Viewpoint(e.Position, 10000)); });
+
+            // Zoom to the location.
+            _myMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         private void CreateLayout()

--- a/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/Forms/Shared/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -104,11 +104,8 @@ namespace ArcGISRuntime.Samples.FindPlace
             // Unsubscribe from further events; only want to zoom to location once.
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
-            // Need to use this to interact with UI elements because this function is called from a background thread.
-            Device.BeginInvokeOnMainThread(() =>
-            {
-                MyMapView.SetViewpoint(new Viewpoint(e.Position, 100000));
-            });
+            // Zoom to the location.
+            MyMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         private async Task<MapPoint> GetSearchMapPoint(string locationText)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -87,11 +87,8 @@ namespace ArcGISRuntime.UWP.Samples.FindPlace
             // Unsubscribe from further events; only want to zoom to location once
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
-            // Need to use the dispatcher to interact with UI elements because this function is called from a background thread
-            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-            {
-                MyMapView.SetViewpoint(new Viewpoint(e.Position, 100000));
-            });
+            // Zoom to the location.
+            MyMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         /// <summary>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -90,12 +90,8 @@ namespace ArcGISRuntime.WPF.Samples.FindPlace
             // Unsubscribe from the event (only want to zoom once).
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
-            // Needed because the event is called from a background (non-UI) thread and this code is manipulating UI.
-            Dispatcher.Invoke(() =>
-            {
-                // Zoom to the location.
-                MyMapView.SetViewpointAsync(new Viewpoint(e.Position, 100000));
-            });
+            // Zoom to the location.
+            MyMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         /// <summary>

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -94,11 +94,8 @@ namespace ArcGISRuntime.WinUI.Samples.FindPlace
             // Unsubscribe from further events; only want to zoom to location once
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
-            // Need to use the dispatcher to interact with UI elements because this function is called from a background thread
-            DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
-            {
-                MyMapView.SetViewpoint(new Viewpoint(e.Position, 100000));
-            });
+            // Zoom to the location.
+            MyMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         /// <summary>

--- a/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Search/FindPlace/FindPlace.cs
@@ -96,8 +96,8 @@ namespace ArcGISRuntime.Samples.FindPlace
             // Unsubscribe from further events; only want to zoom to location once.
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
-            // Need to use this to interact with UI elements because this function is called from a background thread.
-            BeginInvokeOnMainThread(() => _myMapView.SetViewpoint(new Viewpoint(e.Position, 100000)));
+            // Zoom to the location.
+            _myMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         // Gets the map point corresponding to the text in the location textbox.


### PR DESCRIPTION
# Description

On WPF, find place crashes when unnecessarily trying to use dispatcher to center the map view. I have updated all versions of the sample to not use a separate thread for this. I also simplified the viewpoint call.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP

- [ ] UWP
- [x] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
