### PR TITLE
Fix bugs with WPF description page

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml.cs
@@ -37,6 +37,9 @@ namespace ArcGISRuntime.WPF.Viewer
             
             // Set the html in web browser.
             DescriptionView.DocumentText = htmlString;
+            
+            // Remove the exisiting handler.
+            DescriptionView.Document.Click -= HyperlinkClick;
 
             // Add an event handler for hyperlink clicks.
             DescriptionView.Document.Click += HyperlinkClick;
@@ -51,7 +54,7 @@ namespace ArcGISRuntime.WPF.Viewer
             System.Windows.Forms.HtmlElement src = DescriptionView.Document?.GetElementFromPoint(e.ClientMousePosition);
 
             // Check if the element is a hyperlink.
-            if (src?.OuterHtml.Contains("http") == true)
+            if (src?.OuterHtml.StartsWith("<A href=") == true)
             {
                 // Parse the url from the hyperlink html.
                 string url = src.OuterHtml.Split('\"')[1];


### PR DESCRIPTION
# Description

Fixes two bugs.
1. Clicking a hyperlink can no longer open multiple browser tabs.
2. You can no longer trigger a bad open of non URL html.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [ ] WPF Framework

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
