### PR TITLE
Bug fix: removed camera roll for Display a scene

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayScene/DisplayScene.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayScene/DisplayScene.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.Samples.DisplayScene
             myScene.BaseSurface = mySurface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains)
-            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position
             _mySceneView.SetViewpointCameraAsync(myCamera);

--- a/src/Forms/Shared/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -62,7 +62,7 @@ namespace ArcGISRuntime.Samples.DisplayScene
             myScene.BaseSurface = mySurface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains).
-            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.UWP.Samples.DisplayScene
             myScene.BaseSurface = mySurface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains)
-            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position
             MySceneView.SetViewpointCameraAsync(myCamera);

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGISRuntime.WPF.Samples.DisplayScene
             myScene.BaseSurface = mySurface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains).
-            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayScene/DisplayScene.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayScene
             myScene.BaseSurface = mySurface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains).
-            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera myCamera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position.
             MySceneView.SetViewpointCameraAsync(myCamera);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplayScene/DisplayScene.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplayScene/DisplayScene.cs
@@ -60,7 +60,7 @@ namespace ArcGISRuntime.Samples.DisplayScene
             _mySceneView.Scene.BaseSurface = surface;
 
             // Create camera with an initial camera position (Mount Everest in the Alps mountains).
-            Camera camera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 300.0);
+            Camera camera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0);
 
             // Set the scene view's camera position.
             _mySceneView.SetViewpointCameraAsync(camera);


### PR DESCRIPTION
# Description

Removed the camera roll value for the Display a scene value.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6


## Checklist

N/A this is a one number change to a camera.
