### PR TITLE
Replace all instances of BasemapType with BasemapStyle

### DIFF
--- a/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
@@ -22,41 +22,42 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeoPackage
         description: "Display features from a local GeoPackage.",
         instructions: "Pan and zoom around the map. View the data loaded from the geopackage.",
         tags: new[] { "OGC", "feature table", "geopackage", "gpkg", "package", "standards" })]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     public partial class FeatureLayerGeoPackage : ContentPage
     {
         public FeatureLayerGeoPackage()
         {
             InitializeComponent();
 
-            // Read data from the GeoPackage
+            // Read data from the GeoPackage.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a new map centered on Aurora Colorado
-            MyMapView.Map = new Map(BasemapType.LightGrayCanvas, 39.7294, -104.8319, 9);
+            // Create a new map centered on Aurora Colorado.
+            MyMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
 
-            // Get the full path
+            // Get the full path.
             string geoPackagePath = GetGeoPackagePath();
 
             try
             {
-                // Open the GeoPackage
+                // Open the GeoPackage.
                 GeoPackage myGeoPackage = await GeoPackage.OpenAsync(geoPackagePath);
 
-                // Read the feature tables and get the first one
+                // Read the feature tables and get the first one.
                 FeatureTable geoPackageTable = myGeoPackage.GeoPackageFeatureTables.FirstOrDefault();
 
-                // Make sure a feature table was found in the package
+                // Make sure a feature table was found in the package.
                 if (geoPackageTable == null) { return; }
 
-                // Create a layer to show the feature table
+                // Create a layer to show the feature table.
                 FeatureLayer newLayer = new FeatureLayer(geoPackageTable);
                 await newLayer.LoadAsync();
 
-                // Add the feature table as a layer to the map (with default symbology)
+                // Add the feature table as a layer to the map (with default symbology).
                 MyMapView.Map.OperationalLayers.Add(newLayer);
             }
             catch (Exception e)

--- a/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -35,7 +35,8 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            MyMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.70, 11);
+            MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/Forms/Shared/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -46,7 +46,8 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         private void Initialize()
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
-            Map myMap = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 15);
+            Map myMap = new Map(BasemapStyle.ArcGISLightGray);
+            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Add the map to the map view.
             MyMapView.Map = myMap;
@@ -84,12 +85,15 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
                 case "Union":
                     resultPolygon = GeometryEngine.Union(polygonOne, polygonTwo);
                     break;
+
                 case "Difference":
                     resultPolygon = GeometryEngine.Difference(polygonOne, polygonTwo);
                     break;
+
                 case "Symmetric difference":
                     resultPolygon = GeometryEngine.SymmetricDifference(polygonOne, polygonTwo);
                     break;
+
                 case "Intersection":
                     resultPolygon = GeometryEngine.Intersection(polygonOne, polygonTwo);
                     break;
@@ -172,5 +176,5 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
             _polygonsOverlay.Graphics.Add(_graphicOne);
             _polygonsOverlay.Graphics.Add(_graphicTwo);
         }
-    }    
+    }
 }

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -29,64 +29,64 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         tags: new[] { "geoprocessing", "heat map", "heatmap", "viewshed" })]
     public partial class AnalyzeViewshed : ContentPage
     {
-
-        // Url for the geoprocessing service
+        // Url for the geoprocessing service.
         private const string _viewshedUrl =
             "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/ESRI_Elevation_World/GPServer/Viewshed";
 
-        // The graphics overlay to show where the user clicked in the map
+        // The graphics overlay to show where the user clicked in the map.
         private GraphicsOverlay _inputOverlay;
 
-        // The graphics overlay to display the result of the viewshed analysis
+        // The graphics overlay to display the result of the viewshed analysis.
         private GraphicsOverlay _resultOverlay;
 
         public AnalyzeViewshed()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with topographic basemap and an initial location
-            Map myMap = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            // Create a map with topographic basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
-            // Hook into the MapView tapped event
+            // Hook into the MapView tapped event.
             MyMapView.GeoViewTapped += MyMapView_GeoViewTapped;
 
-            // Create empty overlays for the user clicked location and the results of the viewshed analysis
+            // Create empty overlays for the user clicked location and the results of the viewshed analysis.
             CreateOverlays();
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
 
         private async void MyMapView_GeoViewTapped(object sender, Esri.ArcGISRuntime.Xamarin.Forms.GeoViewInputEventArgs e)
         {
-            // Indicate that the geoprocessing is running
+            // Indicate that the geoprocessing is running.
             SetBusy();
 
-            // Clear previous user click location and the viewshed geoprocessing task results
+            // Clear previous user click location and the viewshed geoprocessing task results.
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Get the tapped point
+            // Get the tapped point.
             MapPoint geometry = e.Location;
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay 
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay.
             Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Normalize the geometry if wrap-around is enabled
-            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            // Normalize the geometry if wrap-around is enabled.
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime.
             //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
             if (MyMapView.IsWrapAroundEnabled) { geometry = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geometry); }
 
             try
             {
-                // Execute the geoprocessing task using the user click location 
+                // Execute the geoprocessing task using the user click location.
                 await CalculateViewshed(geometry);
             }
             catch (Exception ex)
@@ -97,49 +97,48 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
 
         private async Task CalculateViewshed(MapPoint location)
         {
-            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a 
+            // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed 
+            // is a problem with the execution of the geoprocessing task an error message will be displayed.
 
-            // Create new geoprocessing task using the url defined in the member variables section
+            // Create new geoprocessing task using the url defined in the member variables section.
             GeoprocessingTask myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
 
-            // Create a new feature collection table based upon point geometries using the current map view spatial reference
+            // Create a new feature collection table based upon point geometries using the current map view spatial reference.
             FeatureCollectionTable myInputFeatures = new FeatureCollectionTable(new List<Field>(), GeometryType.Point, MyMapView.SpatialReference);
 
-            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet
+            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet.
             Feature myInputFeature = myInputFeatures.CreateFeature();
 
-            // Assign a physical location to the new point feature based upon where the user clicked in the map view
+            // Assign a physical location to the new point feature based upon where the user clicked in the map view.
             myInputFeature.Geometry = location;
 
-            // Add the new feature with (x,y) location to the feature collection table
+            // Add the new feature with (x,y) location to the feature collection table.
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
-            // Create the parameters that are passed to the used geoprocessing task
+            // Create the parameters that are passed to the used geoprocessing task.
             GeoprocessingParameters myViewshedParameters =
                 new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
-
-                    // Request the output features to use the same SpatialReference as the map view
+                    // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference
                 };
 
-            // Add an input location to the geoprocessing parameters
+            // Add an input location to the geoprocessing parameters.
             myViewshedParameters.Inputs.Add("Input_Observation_Point", new GeoprocessingFeatures(myInputFeatures));
 
-            // Create the job that handles the communication between the application and the geoprocessing task
+            // Create the job that handles the communication between the application and the geoprocessing task.
             GeoprocessingJob myViewshedJob = myViewshedTask.CreateJob(myViewshedParameters);
 
             try
             {
-                // Execute analysis and wait for the results
+                // Execute analysis and wait for the results.
                 GeoprocessingResult myAnalysisResult = await myViewshedJob.GetResultAsync();
 
-                // Get the results from the outputs
+                // Get the results from the outputs.
                 GeoprocessingFeatures myViewshedResultFeatures = (GeoprocessingFeatures)myAnalysisResult.Outputs["Viewshed_Result"];
 
-                // Add all the results as a graphics to the map
+                // Add all the results as a graphics to the map.
                 IFeatureSet myViewshedAreas = myViewshedResultFeatures.Features;
                 foreach (Feature myFeature in myViewshedAreas)
                 {
@@ -148,7 +147,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
             }
             catch (Exception ex)
             {
-                // Display an error message if there is a problem
+                // Display an error message if there is a problem.
                 if (myViewshedJob.Status == JobStatus.Failed && myViewshedJob.Error != null)
                 {
                     await Application.Current.MainPage.DisplayAlert("Geoprocessing error", "Executing geoprocessing failed. " + myViewshedJob.Error.Message, "OK");
@@ -160,14 +159,14 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
             }
             finally
             {
-                // Indicate that the geoprocessing is not running
+                // Indicate that the geoprocessing is not running.
                 SetBusy(false);
             }
         }
 
         private void CreateOverlays()
         {
-            // This function will create the overlays that show the user clicked location and the results of the 
+            // This function will create the overlays that show the user clicked location and the results of the
             // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
 
             // Create renderer for input graphic. Set the size and color properties for the simple renderer
@@ -186,7 +185,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer 
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -208,7 +207,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
 
         private void SetBusy(bool isBusy = true)
         {
-            // This function toggles running of the 'progress' control feedback status to denote if 
+            // This function toggles running of the 'progress' control feedback status to denote if
             // the viewshed analysis is executing as a result of the user click on the map
 
             if (isBusy)
@@ -222,7 +221,6 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
                 // Remove the busy activity indication
                 MyActivityIndicator.IsRunning = false;
                 MyActivityIndicator.IsVisible = false;
-
             }
         }
     }

--- a/src/Forms/Shared/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
+++ b/src/Forms/Shared/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
@@ -24,44 +24,45 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
         tags: new[] { "SimpleFillSymbol", "SimpleLineSymbol", "SimpleMarkerSymbol" })]
     public partial class AddGraphicsWithSymbols : ContentPage
     {
-        // Create the graphics overlay
+        // Create the graphics overlay.
         private readonly GraphicsOverlay _overlay = new GraphicsOverlay();
 
         public AddGraphicsWithSymbols()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create the map
-            Map myMap = new Map(BasemapType.Oceans, 56.075844, -2.681572, 13);
+            // Create the map.
+            Map myMap = new Map(BasemapStyle.ArcGISOceans);
+            myMap.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 13);
 
-            // Add the map to the map view
+            // Add the map to the map view.
             MyMapView.Map = myMap;
 
-            // Add the graphics overlay to the map view
+            // Add the graphics overlay to the map view.
             MyMapView.GraphicsOverlays.Add(_overlay);
 
-            // Call functions to create the graphics
+            // Call functions to create the graphics.
             CreatePoints();
             CreatePolygon();
             CreatePolyline();
             CreateText();
 
-            // Update the extent to encompass all of the symbols
+            // Update the extent to encompass all of the symbols.
             SetExtent();
         }
 
         private void CreatePoints()
         {
-            // Create a red circle simple marker symbol
+            // Create a red circle simple marker symbol.
             SimpleMarkerSymbol redCircleSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, Colors.Red, 10);
 
-            // Create graphics and add them to graphics overlay
+            // Create graphics and add them to graphics overlay.
             Graphic graphic = new Graphic(new MapPoint(-2.72, 56.065, SpatialReferences.Wgs84), redCircleSymbol);
             _overlay.Graphics.Add(graphic);
 
@@ -77,13 +78,13 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
 
         private void CreatePolyline()
         {
-            // Create a purple simple line symbol
+            // Create a purple simple line symbol.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Colors.Purple, 4);
 
-            // Create a new point collection for polyline
+            // Create a new point collection for polyline.
             PointCollection points = new PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.715, 56.061),
                 new MapPoint(-2.6438, 56.079),
                 new MapPoint(-2.638, 56.079),
@@ -93,28 +94,28 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.715, 56.061)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polyline polyline = new Polyline(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polyline, lineSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreatePolygon()
         {
-            // Create a green simple line symbol
+            // Create a green simple line symbol.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Colors.Green, 1);
 
-            // Create a green mesh simple fill symbol
+            // Create a green mesh simple fill symbol.
             SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.DiagonalCross, Colors.Green, outlineSymbol);
 
-            // Create a new point collection for polygon
+            // Create a new point collection for polygon.
             PointCollection points = new PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.6425, 56.0784),
                 new MapPoint(-2.6430, 56.0763),
                 new MapPoint(-2.6410, 56.0759),
@@ -123,58 +124,58 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.6410, 56.0786)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polygon polygon = new Polygon(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polygon, fillSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreateText()
         {
-            // Create two text symbols
+            // Create two text symbols.
             TextSymbol bassRockTextSymbol = new TextSymbol("Black Rock", Colors.Blue, 10,
                 HorizontalAlignment.Left, VerticalAlignment.Bottom);
 
             TextSymbol craigleithTextSymbol = new TextSymbol("Craigleith", Colors.Blue, 10,
                 HorizontalAlignment.Right, VerticalAlignment.Top);
 
-            // Create two points
+            // Create two points.
             MapPoint bassPoint = new MapPoint(-2.64, 56.079, SpatialReferences.Wgs84);
             MapPoint craigleithPoint = new MapPoint(-2.72, 56.076, SpatialReferences.Wgs84);
 
-            // Create two graphics from the points and symbols
+            // Create two graphics from the points and symbols.
             Graphic bassRockGraphic = new Graphic(bassPoint, bassRockTextSymbol);
             Graphic craigleithGraphic = new Graphic(craigleithPoint, craigleithTextSymbol);
 
-            // Add graphics to the graphics overlay
+            // Add graphics to the graphics overlay.
             _overlay.Graphics.Add(bassRockGraphic);
             _overlay.Graphics.Add(craigleithGraphic);
         }
 
         private void SetExtent()
         {
-            // Get all of the graphics contained in the graphics overlay
+            // Get all of the graphics contained in the graphics overlay.
             GraphicCollection myGraphicCollection = _overlay.Graphics;
 
-            // Create a new envelope builder using the same spatial reference as the graphics
+            // Create a new envelope builder using the same spatial reference as the graphics.
             EnvelopeBuilder myEnvelopeBuilder = new EnvelopeBuilder(SpatialReferences.Wgs84);
 
-            // Loop through each graphic in the graphic collection
+            // Loop through each graphic in the graphic collection.
             foreach (Graphic oneGraphic in myGraphicCollection)
             {
-                // Union the extent of each graphic in the envelope builder
+                // Union the extent of each graphic in the envelope builder.
                 myEnvelopeBuilder.UnionOf(oneGraphic.Geometry.Extent);
             }
 
-            // Expand the envelope builder by 30%
+            // Expand the envelope builder by 30%.
             myEnvelopeBuilder.Expand(1.3);
 
             // Adjust the viewable area of the map to encompass all of the graphics in the
-            // graphics overlay plus an extra 30% margin for better viewing
+            // graphics overlay plus an extra 30% margin for better viewing.
             MyMapView.SetViewpointAsync(new Viewpoint(myEnvelopeBuilder.Extent));
         }
     }

--- a/src/Forms/Shared/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -35,7 +35,8 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/Forms/Shared/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -41,7 +41,8 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");

--- a/src/Forms/Shared/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -22,18 +22,19 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
     {
         public SetInitialMapLocation()
         {
-            InitializeComponent ();
+            InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 16);
+            // Create a map with 'Imagery with Labels' basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISImagery);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 16);
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
     }

--- a/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-    "category": "Map",
-    "description": "Display a basemap centered at an initial location and scale.",
-    "formal_name": "SetInitialMapLocation",
-    "ignore": false,
-    "images": [
-        "SetInitialMapLocation.jpg"
-    ],
-    "keywords": [
-        "LOD",
-        "basemap",
-        "center",
-        "envelope",
-        "extent",
-        "initial",
-        "lat",
-        "latitude",
-        "level of detail",
-        "location",
-        "long",
-        "longitude",
-        "scale",
-        "zoom level"
-    ],
-    "offline_data": [],
-    "redirect_from": [
-        "/net/latest/forms/sample-code/setinitialmaplocation.htm"
-    ],
-    "relevant_apis": [
-        "BasemapType",
-        "Map",
-        "MapView"
-    ],
-    "snippets": [
-        "SetInitialMapLocation.xaml",
-        "SetInitialMapLocation.xaml.cs"
-    ],
-    "title": "Set initial map location"
+  "category": "Map",
+  "description": "Display a basemap centered at an initial location and scale.",
+  "formal_name": "SetInitialMapLocation",
+  "ignore": false,
+  "images": [
+    "SetInitialMapLocation.jpg"
+  ],
+  "keywords": [
+    "LOD",
+    "basemap",
+    "center",
+    "envelope",
+    "extent",
+    "initial",
+    "lat",
+    "latitude",
+    "level of detail",
+    "location",
+    "long",
+    "longitude",
+    "scale",
+    "zoom level"
+  ],
+  "offline_data": [],
+  "redirect_from": [
+    "/net/latest/forms/sample-code/setinitialmaplocation.htm"
+  ],
+  "relevant_apis": [
+    "BasemapStyle",
+    "Map",
+    "MapView"
+  ],
+  "snippets": [
+    "SetInitialMapLocation.xaml",
+    "SetInitialMapLocation.xaml.cs"
+  ],
+  "title": "Set initial map location"
 }

--- a/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-  "category": "Map",
-  "description": "Display a basemap centered at an initial location and scale.",
-  "formal_name": "SetInitialMapLocation",
-  "ignore": false,
-  "images": [
-    "SetInitialMapLocation.jpg"
-  ],
-  "keywords": [
-    "LOD",
-    "basemap",
-    "center",
-    "envelope",
-    "extent",
-    "initial",
-    "lat",
-    "latitude",
-    "level of detail",
-    "location",
-    "long",
-    "longitude",
-    "scale",
-    "zoom level"
-  ],
-  "offline_data": [],
-  "redirect_from": [
-    "/net/latest/forms/sample-code/setinitialmaplocation.htm"
-  ],
-  "relevant_apis": [
-    "BasemapStyle",
-    "Map",
-    "MapView"
-  ],
-  "snippets": [
-    "SetInitialMapLocation.xaml",
-    "SetInitialMapLocation.xaml.cs"
-  ],
-  "title": "Set initial map location"
+    "category": "Map",
+    "description": "Display a basemap centered at an initial location and scale.",
+    "formal_name": "SetInitialMapLocation",
+    "ignore": false,
+    "images": [
+        "SetInitialMapLocation.jpg"
+    ],
+    "keywords": [
+        "LOD",
+        "basemap",
+        "center",
+        "envelope",
+        "extent",
+        "initial",
+        "lat",
+        "latitude",
+        "level of detail",
+        "location",
+        "long",
+        "longitude",
+        "scale",
+        "zoom level"
+    ],
+    "offline_data": [],
+    "redirect_from": [
+        "/net/latest/forms/sample-code/setinitialmaplocation.htm"
+    ],
+    "relevant_apis": [
+        "BasemapStyle",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "SetInitialMapLocation.xaml",
+        "SetInitialMapLocation.xaml.cs"
+    ],
+    "title": "Set initial map location"
 }

--- a/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -27,39 +27,40 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Hook up the DrawStatusChanged event
+            // Hook up the DrawStatusChanged event.
             myMapView.DrawStatusChanged += OnDrawStatusChanged;
 
-            // Create new Map with basemap
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            // Create new Map with basemap.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
-            // Create uri to the used feature service
+            // Create uri to the used feature service.
             Uri serviceUri = new Uri(
                 "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
-            // Initialize a new feature layer
+            // Initialize a new feature layer.
             ServiceFeatureTable myFeatureTable = new ServiceFeatureTable(serviceUri);
             FeatureLayer myFeatureLayer = new FeatureLayer(myFeatureTable);
 
-            // Add the feature layer to the Map
+            // Add the feature layer to the Map.
             myMap.OperationalLayers.Add(myFeatureLayer);
 
-            // Provide used Map to the MapView
+            // Provide used Map to the MapView.
             myMapView.Map = myMap;
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)
         {
-            // Make sure that the UI changes are done in the UI thread
+            // Make sure that the UI changes are done in the UI thread.
             Device.BeginInvokeOnMainThread(() =>
             {
-                // Show the activity indicator if the map is drawing
+                // Show the activity indicator if the map is drawing.
                 if (e.Status == DrawStatus.InProgress)
                 {
                     activityIndicator.IsVisible = true;

--- a/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -25,22 +25,23 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         {
             InitializeComponent();
 
-            // Initialize the sample
+            // Initialize the sample.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create new Map with basemap and initial location
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            // Create new Map with basemap and initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
-            // Enable magnifier
+            // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions
             {
                 IsMagnifierEnabled = true
             };
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
     }

--- a/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/Forms/Shared/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -28,7 +28,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
     {
         public FeatureLayerExtrusion()
         {
-            InitializeComponent ();
+            InitializeComponent();
 
             Initialize();
         }
@@ -37,78 +37,77 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
         {
             try
             {
-                // Define the Uri for the service feature table (US state polygons)
+                // Define the Uri for the service feature table (US state polygons).
                 Uri myServiceFeatureTable_Uri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
 
-                // Create a new service feature table from the Uri
+                // Create a new service feature table from the Uri.
                 ServiceFeatureTable myServiceFeatureTable = new ServiceFeatureTable(myServiceFeatureTable_Uri);
 
-                // Create a new feature layer from the service feature table
+                // Create a new feature layer from the service feature table.
                 FeatureLayer myFeatureLayer = new FeatureLayer(myServiceFeatureTable)
                 {
-
-                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work)
+                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work).
                     RenderingMode = FeatureRenderingMode.Dynamic
                 };
 
-                // Create a new simple line symbol for the feature layer
+                // Create a new simple line symbol for the feature layer.
                 SimpleLineSymbol mySimpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Colors.Black, 1);
 
-                // Create a new simple fill symbol for the feature layer 
+                // Create a new simple fill symbol for the feature layer.
                 SimpleFillSymbol mysimpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Solid, Colors.Blue, mySimpleLineSymbol);
 
-                // Create a new simple renderer for the feature layer
+                // Create a new simple renderer for the feature layer.
                 SimpleRenderer mySimpleRenderer = new SimpleRenderer(mysimpleFillSymbol);
 
-                // Get the scene properties from the simple renderer
+                // Get the scene properties from the simple renderer.
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties
+                // Set the extrusion mode for the scene properties.
                 myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
-                // Set the initial extrusion expression
+                // Set the initial extrusion expression.
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
 
-                // Set the feature layer's renderer to the define simple renderer
+                // Set the feature layer's renderer to the define simple renderer.
                 myFeatureLayer.Renderer = mySimpleRenderer;
 
-                // Create a new scene with the topographic backdrop 
-                Scene myScene = new Scene(BasemapType.Topographic);
+                // Create a new scene with the topographic backdrop.
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
-                // Set the scene view's scene to the newly create one
+                // Set the scene view's scene to the newly create one.
                 MySceneView.Scene = myScene;
 
-                // Add the feature layer to the scene's operational layer collection
+                // Add the feature layer to the scene's operational layer collection.
                 myScene.OperationalLayers.Add(myFeatureLayer);
 
-                // Create a new map point to define where to look on the scene view
+                // Create a new map point to define where to look on the scene view.
                 MapPoint myMapPoint = new MapPoint(-10974490, 4814376, 0, SpatialReferences.WebMercator);
 
-                // Create a new orbit location camera controller using the map point and defined distance
+                // Create a new orbit location camera controller using the map point and defined distance.
                 OrbitLocationCameraController myOrbitLocationCameraController = new OrbitLocationCameraController(myMapPoint, 20000000);
 
-                // Set the scene view's camera controller to the orbit location camera controller
+                // Set the scene view's camera controller to the orbit location camera controller.
                 MySceneView.CameraController = myOrbitLocationCameraController;
             }
             catch (Exception ex)
             {
-                // Something went wrong, display the error
-                await Application.Current.MainPage.DisplayAlert("Error",ex.ToString(), "OK");
+                // Something went wrong, display the error.
+                await Application.Current.MainPage.DisplayAlert("Error", ex.ToString(), "OK");
             }
         }
 
         private void ChangeExtrusionExpression()
         {
-            // Get the first layer from the scene view's operation layers, it should be a feature layer
+            // Get the first layer from the scene view's operation layers, it should be a feature layer.
             FeatureLayer myFeatureLayer = (FeatureLayer)MySceneView.Scene.OperationalLayers[0];
 
-            // Get the renderer from the feature layer
+            // Get the renderer from the feature layer.
             Renderer myRenderer = myFeatureLayer.Renderer;
 
-            // Get the scene properties from the feature layer's renderer
+            // Get the scene properties from the feature layer's renderer.
             RendererSceneProperties myRendererSceneProperties = myRenderer.SceneProperties;
 
-            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
+            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text.
             if (ToggleExtrusionDataButton.Text == "Show population density")
             {
                 // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
@@ -125,7 +124,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
 
         private void ToggleExtrusionData_Click(object sender, EventArgs e)
         {
-            // Call the function to change the feature layer's renderer scene properties extrusion expression
+            // Call the function to change the feature layer's renderer scene properties extrusion expression.
             ChangeExtrusionExpression();
         }
     }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
@@ -22,41 +22,42 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerGeoPackage
         description: "Display features from a local GeoPackage.",
         instructions: "Pan and zoom around the map. View the data loaded from the geopackage.",
         tags: new[] { "OGC", "feature table", "geopackage", "gpkg", "package", "standards" })]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     public partial class FeatureLayerGeoPackage
     {
         public FeatureLayerGeoPackage()
         {
             InitializeComponent();
-            
-            // Read data from the GeoPackage
+
+            // Read data from the GeoPackage.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a new map centered on Aurora Colorado
-            MyMapView.Map = new Map(BasemapType.LightGrayCanvasVector, 39.7294, -104.8319, 9);
-            
-            // Get the full path
+            // Create a new map centered on Aurora Colorado.
+            MyMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
+
+            // Get the full path.
             string geoPackagePath = GetGeoPackagePath();
 
             try
             {
-                // Open the GeoPackage
+                // Open the GeoPackage.
                 GeoPackage myGeoPackage = await GeoPackage.OpenAsync(geoPackagePath);
 
-                // Read the feature tables and get the first one
+                // Read the feature tables and get the first one.
                 FeatureTable geoPackageTable = myGeoPackage.GeoPackageFeatureTables.FirstOrDefault();
 
-                // Make sure a feature table was found in the package
-                if(geoPackageTable == null) { return; }
+                // Make sure a feature table was found in the package.
+                if (geoPackageTable == null) { return; }
 
-                // Create a layer to show the feature table
+                // Create a layer to show the feature table.
                 FeatureLayer newLayer = new FeatureLayer(geoPackageTable);
                 await newLayer.LoadAsync();
 
-                // Add the feature table as a layer to the map (with default symbology)
+                // Add the feature table as a layer to the map (with default symbology).
                 MyMapView.Map.OperationalLayers.Add(newLayer);
             }
             catch (Exception e)

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -35,7 +35,8 @@ namespace ArcGISRuntime.WPF.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            MyMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.70, 11);
+            MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -26,11 +26,11 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
     {
         // GraphicsOverlay to hold the polygon graphics.
         private GraphicsOverlay _polygonsOverlay;
-        
+
         // Polygon graphics to run spatial operations on.
         private Graphic _graphicOne;
         private Graphic _graphicTwo;
-        
+
         // Graphic to display the spatial operation result polygon.
         private Graphic _resultGraphic;
 
@@ -45,14 +45,15 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
         private void Initialize()
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
-            Map spatialOperationsMap = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 15);
+            Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;
 
             // Create and add two overlapping polygon graphics to operate on.
             CreatePolygonsOverlay();
-            
+
             // Fill the combo box with some spatial operations to run on the polygon graphics.
             SpatialOperationComboBox.Items.Add("Difference");
             SpatialOperationComboBox.Items.Add("Intersection");
@@ -65,17 +66,17 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
         {
             // If an operation hasn't been selected, return.
             if (SpatialOperationComboBox.SelectedItem == null) { return; }
-            
+
             // Remove any currently displayed result.
             _polygonsOverlay.Graphics.Remove(_resultGraphic);
-            
+
             // Polygon geometry from the input graphics.
             Geometry polygonOne = _graphicOne.Geometry;
             Geometry polygonTwo = _graphicTwo.Geometry;
-            
+
             // Result polygon for spatial operations.
             Geometry resultPolygon = null;
-            
+
             // Run the selected spatial operation on the polygon graphics and get the result geometry.
             string operation = (string)SpatialOperationComboBox.SelectedItem;
             switch (operation)
@@ -83,23 +84,26 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
                 case "Union":
                     resultPolygon = GeometryEngine.Union(polygonOne, polygonTwo);
                     break;
+
                 case "Difference":
                     resultPolygon = GeometryEngine.Difference(polygonOne, polygonTwo);
                     break;
+
                 case "Symmetric difference":
                     resultPolygon = GeometryEngine.SymmetricDifference(polygonOne, polygonTwo);
                     break;
+
                 case "Intersection":
                     resultPolygon = GeometryEngine.Intersection(polygonOne, polygonTwo);
                     break;
             }
-            
+
             // Create a black outline symbol to use for the result polygon.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Black, 1);
-            
+
             // Create a solid red fill symbol for the result polygon graphic.
             SimpleFillSymbol resultSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Solid, System.Drawing.Color.Red, outlineSymbol);
-            
+
             // Create the result polygon graphic and add it to the graphics overlay.
             _resultGraphic = new Graphic(resultPolygon, resultSymbol);
             _polygonsOverlay.Graphics.Add(_resultGraphic);
@@ -109,7 +113,7 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
         {
             // Remove any currently displayed result.
             _polygonsOverlay.Graphics.Remove(_resultGraphic);
-            
+
             // Clear the selected spatial operation.
             SpatialOperationComboBox.SelectedIndex = -1;
         }
@@ -128,12 +132,12 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
                 new MapPoint(-13300, 6710500),
                 new MapPoint(-13160, 6710100)
             };
-            
+
             // Create a polygon graphic with a blue fill.
             SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Vertical, System.Drawing.Color.Blue, outlineSymbol);
             Polygon polygonOne = new Polygon(polygonVertices);
             _graphicOne = new Graphic(polygonOne, fillSymbol);
-            
+
             // Create a point collection to define outer polygon ring vertices.
             PointCollection outerRingVerticesCollection = new PointCollection(SpatialReferences.WebMercator)
             {
@@ -142,7 +146,7 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
                 new MapPoint(-13160, 6709700),
                 new MapPoint(-14560, 6710730)
             };
-            
+
             // Create a point collection to define inner polygon ring vertices ("donut hole").
             PointCollection innerRingVerticesCollection = new PointCollection(SpatialReferences.WebMercator)
             {
@@ -151,7 +155,7 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
                 new MapPoint(-13160, 6709900),
                 new MapPoint(-12450, 6710660)
             };
-            
+
             // Create a list to contain the inner and outer ring point collections.
             List<PointCollection> polygonParts = new List<PointCollection>
             {
@@ -162,11 +166,11 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
             // Create a polygon graphic with a green fill.
             fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Horizontal, System.Drawing.Color.Green, outlineSymbol);
             _graphicTwo = new Graphic(new Polygon(polygonParts), fillSymbol);
-            
+
             // Create a graphics overlay in the map view to hold the polygons.
             _polygonsOverlay = new GraphicsOverlay();
             MyMapView.GraphicsOverlays.Add(_polygonsOverlay);
-            
+
             // Add the polygons to the graphics overlay.
             _polygonsOverlay.Graphics.Add(_graphicOne);
             _polygonsOverlay.Graphics.Add(_graphicTwo);

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -31,39 +31,40 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         tags: new[] { "geoprocessing", "heat map", "heatmap", "viewshed" })]
     public partial class AnalyzeViewshed
     {
-        // Url for the geoprocessing service
+        // Url for the geoprocessing service.
         private const string _viewshedUrl =
             "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/ESRI_Elevation_World/GPServer/Viewshed";
 
-        // Used to store state of the geoprocessing task
+        // Used to store state of the geoprocessing task.
         private bool _isExecutingGeoprocessing;
 
-        // The graphics overlay to show where the user clicked in the map
+        // The graphics overlay to show where the user clicked in the map.
         private GraphicsOverlay _inputOverlay;
 
-        // The graphics overlay to display the result of the viewshed analysis
+        // The graphics overlay to display the result of the viewshed analysis.
         private GraphicsOverlay _resultOverlay;
 
         public AnalyzeViewshed()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with topographic basemap and an initial location
-            Map myMap = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            // Create a map with topographic basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
-            // Hook into the tapped event
+            // Hook into the tapped event.
             MyMapView.GeoViewTapped += OnMapViewTapped;
 
-            // Create empty overlays for the user clicked location and the results of the viewshed analysis
+            // Create empty overlays for the user clicked location and the results of the viewshed analysis.
             CreateOverlays();
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
 
@@ -76,28 +77,28 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
                 return;
             }
 
-            // Indicate that the geoprocessing is running
+            // Indicate that the geoprocessing is running.
             SetBusy();
 
-            // Clear previous user click location and the viewshed geoprocessing task results
+            // Clear previous user click location and the viewshed geoprocessing task results.
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Get the tapped point
+            // Get the tapped point.
             MapPoint geometry = e.Location;
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay.
             Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Normalize the geometry if wrap-around is enabled
-            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            // Normalize the geometry if wrap-around is enabled.
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime.
             //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
             if (MyMapView.IsWrapAroundEnabled) { geometry = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geometry); }
 
             try
             {
-                // Execute the geoprocessing task using the user click location
+                // Execute the geoprocessing task using the user click location.
                 await CalculateViewshed(geometry);
             }
             catch (Exception ex)
@@ -110,46 +111,46 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         {
             // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed
+            // is a problem with the execution of the geoprocessing task an error message will be displayed.
 
-            // Create new geoprocessing task using the url defined in the member variables section
+            // Create new geoprocessing task using the url defined in the member variables section.
             GeoprocessingTask myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
 
-            // Create a new feature collection table based upon point geometries using the current map view spatial reference
+            // Create a new feature collection table based upon point geometries using the current map view spatial reference.
             FeatureCollectionTable myInputFeatures = new FeatureCollectionTable(new List<Field>(), GeometryType.Point, MyMapView.SpatialReference);
 
-            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet
+            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet.
             Feature myInputFeature = myInputFeatures.CreateFeature();
 
-            // Assign a physical location to the new point feature based upon where the user clicked in the map view
+            // Assign a physical location to the new point feature based upon where the user clicked in the map view.
             myInputFeature.Geometry = location;
 
-            // Add the new feature with (x,y) location to the feature collection table
+            // Add the new feature with (x,y) location to the feature collection table.
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
-            // Create the parameters that are passed to the used geoprocessing task
+            // Create the parameters that are passed to the used geoprocessing task.
             GeoprocessingParameters myViewshedParameters =
                 new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
-                    // Request the output features to use the same SpatialReference as the map view
+                    // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference
                 };
 
-            // Add an input location to the geoprocessing parameters
+            // Add an input location to the geoprocessing parameters.
             myViewshedParameters.Inputs.Add("Input_Observation_Point", new GeoprocessingFeatures(myInputFeatures));
 
-            // Create the job that handles the communication between the application and the geoprocessing task
+            // Create the job that handles the communication between the application and the geoprocessing task.
             GeoprocessingJob myViewshedJob = myViewshedTask.CreateJob(myViewshedParameters);
 
             try
             {
-                // Execute analysis and wait for the results
+                // Execute analysis and wait for the results.
                 GeoprocessingResult myAnalysisResult = await myViewshedJob.GetResultAsync();
 
-                // Get the results from the outputs
+                // Get the results from the outputs.
                 GeoprocessingFeatures myViewshedResultFeatures = (GeoprocessingFeatures)myAnalysisResult.Outputs["Viewshed_Result"];
 
-                // Add all the results as a graphics to the map
+                // Add all the results as a graphics to the map.
                 IFeatureSet myViewshedAreas = myViewshedResultFeatures.Features;
                 foreach (Feature myFeature in myViewshedAreas)
                 {
@@ -158,7 +159,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
             }
             catch (Exception ex)
             {
-                // Display an error message if there is a problem
+                // Display an error message if there is a problem.
                 if (myViewshedJob.Status == JobStatus.Failed && myViewshedJob.Error != null)
                     MessageBox.Show("Executing geoprocessing failed. " + myViewshedJob.Error.Message, "Geoprocessing error");
                 else
@@ -166,7 +167,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
             }
             finally
             {
-                // Indicate that the geoprocessing is not running
+                // Indicate that the geoprocessing is not running.
                 SetBusy(false);
             }
         }
@@ -174,9 +175,9 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         private void CreateOverlays()
         {
             // This function will create the overlays that show the user clicked location and the results of the
-            // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
+            // viewshed analysis. Note: the overlays will not be populated with any graphics at this point.
 
-            // Create renderer for input graphic. Set the size and color properties for the simple renderer
+            // Create renderer for input graphic. Set the size and color properties for the simple renderer.
             SimpleRenderer myInputRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleMarkerSymbol()
@@ -186,13 +187,13 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
                 }
             };
 
-            // Create overlay to where input graphic is shown
+            // Create overlay to where input graphic is shown.
             _inputOverlay = new GraphicsOverlay()
             {
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer.
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -201,13 +202,13 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
                 }
             };
 
-            // Create overlay to where viewshed analysis graphic is shown
+            // Create overlay to where viewshed analysis graphic is shown.
             _resultOverlay = new GraphicsOverlay()
             {
                 Renderer = myResultRenderer
             };
 
-            // Add the created overlays to the MapView
+            // Add the created overlays to the MapView.
             MyMapView.GraphicsOverlays.Add(_inputOverlay);
             MyMapView.GraphicsOverlays.Add(_resultOverlay);
         }
@@ -217,18 +218,18 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
             // This function toggles the visibility of the 'BusyOverlay' Grid control defined in xaml,
             // sets the 'progress' control feedback status and updates the _isExecutingGeoprocessing
             // boolean to denote if the viewshed analysis is executing as a result of the user click
-            // on the map
+            // on the map.
 
             if (isBusy)
             {
-                // Change UI to indicate that the geoprocessing is running
+                // Change UI to indicate that the geoprocessing is running.
                 _isExecutingGeoprocessing = true;
                 BusyOverlay.Visibility = Visibility.Visible;
                 Progress.IsIndeterminate = true;
             }
             else
             {
-                // Change UI to indicate that the geoprocessing is not running
+                // Change UI to indicate that the geoprocessing is not running.
                 _isExecutingGeoprocessing = false;
                 BusyOverlay.Visibility = Visibility.Collapsed;
                 Progress.IsIndeterminate = false;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsWithSymbols
         tags: new[] { "SimpleFillSymbol", "SimpleLineSymbol", "SimpleMarkerSymbol" })]
     public partial class AddGraphicsWithSymbols
     {
-        // Create the graphics overlay
+        // Create the graphics overlay.
         private readonly GraphicsOverlay _overlay = new GraphicsOverlay();
 
         public AddGraphicsWithSymbols()
@@ -35,31 +35,32 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsWithSymbols
 
         private void Initialize()
         {
-            // Create the map
-            Map myMap = new Map(BasemapType.Oceans, 56.075844, -2.681572, 14);
+            // Create the map.
+            Map myMap = new Map(BasemapStyle.ArcGISOceans);
+            myMap.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 14);
 
-            // Add the map to the map view
+            // Add the map to the map view.
             MyMapView.Map = myMap;
 
-            // Add the graphics overlay to the map view
+            // Add the graphics overlay to the map view.
             MyMapView.GraphicsOverlays.Add(_overlay);
 
-            // Call functions to create the graphics
+            // Call functions to create the graphics.
             CreatePoints();
             CreatePolygon();
             CreatePolyline();
             CreateText();
 
-            // Update the extent to encompass all of the symbols
+            // Update the extent to encompass all of the symbols.
             SetExtent();
         }
 
         private void CreatePoints()
         {
-            // Create a red circle simple marker symbol
+            // Create a red circle simple marker symbol.
             SimpleMarkerSymbol redCircleSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), 10);
 
-            // Create graphics and add them to graphics overlay
+            // Create graphics and add them to graphics overlay.
             Graphic graphic = new Graphic(new MapPoint(-2.72, 56.065, SpatialReferences.Wgs84), redCircleSymbol);
             _overlay.Graphics.Add(graphic);
 
@@ -75,13 +76,13 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsWithSymbols
 
         private void CreatePolyline()
         {
-            // Create a purple simple line symbol
+            // Create a purple simple line symbol.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Color.FromArgb(0xFF, 0x80, 0x00, 0x80), 4);
 
-            // Create a new point collection for polyline
+            // Create a new point collection for polyline.
             Esri.ArcGISRuntime.Geometry.PointCollection points = new Esri.ArcGISRuntime.Geometry.PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.715, 56.061),
                 new MapPoint(-2.6438, 56.079),
                 new MapPoint(-2.638, 56.079),
@@ -91,28 +92,28 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.715, 56.061)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polyline polyline = new Polyline(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polyline, lineSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreatePolygon()
         {
-            // Create a green simple line symbol
+            // Create a green simple line symbol.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Color.FromArgb(0xFF, 0x00, 0x50, 0x00), 1);
 
-            // Create a green mesh simple fill symbol
+            // Create a green mesh simple fill symbol.
             SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.DiagonalCross, Color.FromArgb(0xFF, 0x00, 0x50, 0x00), outlineSymbol);
 
-            // Create a new point collection for polygon
+            // Create a new point collection for polygon.
             Esri.ArcGISRuntime.Geometry.PointCollection points = new Esri.ArcGISRuntime.Geometry.PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.6425, 56.0784),
                 new MapPoint(-2.6430, 56.0763),
                 new MapPoint(-2.6410, 56.0759),
@@ -121,58 +122,58 @@ namespace ArcGISRuntime.WPF.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.6410, 56.0786)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polygon polygon = new Polygon(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polygon, fillSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreateText()
         {
-            // Create two text symbols
+            // Create two text symbols.
             TextSymbol bassRockTextSymbol = new TextSymbol("Black Rock", Color.Blue, 10,
                 Esri.ArcGISRuntime.Symbology.HorizontalAlignment.Left, Esri.ArcGISRuntime.Symbology.VerticalAlignment.Bottom);
 
             TextSymbol craigleithTextSymbol = new TextSymbol("Craigleith", Color.Blue, 10,
                 Esri.ArcGISRuntime.Symbology.HorizontalAlignment.Right, Esri.ArcGISRuntime.Symbology.VerticalAlignment.Top);
 
-            // Create two points
+            // Create two points.
             MapPoint bassPoint = new MapPoint(-2.64, 56.079, SpatialReferences.Wgs84);
             MapPoint craigleithPoint = new MapPoint(-2.72, 56.076, SpatialReferences.Wgs84);
 
-            // Create two graphics from the points and symbols
+            // Create two graphics from the points and symbols.
             Graphic bassRockGraphic = new Graphic(bassPoint, bassRockTextSymbol);
             Graphic craigleithGraphic = new Graphic(craigleithPoint, craigleithTextSymbol);
 
-            // Add graphics to the graphics overlay
+            // Add graphics to the graphics overlay.
             _overlay.Graphics.Add(bassRockGraphic);
             _overlay.Graphics.Add(craigleithGraphic);
         }
 
         private void SetExtent()
         {
-            // Get all of the graphics contained in the graphics overlay
+            // Get all of the graphics contained in the graphics overlay.
             GraphicCollection myGraphicCollection = _overlay.Graphics;
 
-            // Create a new envelope builder using the same spatial reference as the graphics
+            // Create a new envelope builder using the same spatial reference as the graphics.
             EnvelopeBuilder myEnvelopeBuilder = new EnvelopeBuilder(SpatialReferences.Wgs84);
 
-            // Loop through each graphic in the graphic collection
+            // Loop through each graphic in the graphic collection.
             foreach (Graphic oneGraphic in myGraphicCollection)
             {
-                // Union the extent of each graphic in the envelope builder
+                // Union the extent of each graphic in the envelope builder.
                 myEnvelopeBuilder.UnionOf(oneGraphic.Geometry.Extent);
             }
 
-            // Expand the envelope builder by 30%
+            // Expand the envelope builder by 30%.
             myEnvelopeBuilder.Expand(1.3);
 
             // Adjust the viewable area of the map to encompass all of the graphics in the
-            // graphics overlay plus an extra 30% margin for better viewing
+            // graphics overlay plus an extra 30% margin for better viewing.
             MyMapView.SetViewpointAsync(new Viewpoint(myEnvelopeBuilder.Extent));
         }
     }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -34,7 +34,8 @@ namespace ArcGISRuntime.WPF.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -48,7 +48,8 @@ namespace ArcGISRuntime.WPF.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");
@@ -99,7 +100,7 @@ namespace ArcGISRuntime.WPF.Samples.IdentifyRasterCell
 
         private async void IdentifyCell(Point position)
         {
-            // Check if a cell is already being identified
+            // Check if a cell is already being identified.
             if (_isIdentifying)
             {
                 _nextIdentifyAction = () => IdentifyCell(position);

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -23,9 +23,11 @@ namespace ArcGISRuntime.WPF.Samples.SetInitialMapLocation
         {
             InitializeComponent();
 
-            //initialize map with `imagery with labels` basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 15);
-            //assign the map to the map view
+            //initialize map with `imagery with labels` basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISImagery);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
+
+            //assign the map to the map view.
             MyMapView.Map = myMap;
         }
     }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-    "category": "Map",
-    "description": "Display a basemap centered at an initial location and scale.",
-    "formal_name": "SetInitialMapLocation",
-    "ignore": false,
-    "images": [
-        "SetInitialMapLocation.jpg"
-    ],
-    "keywords": [
-        "LOD",
-        "basemap",
-        "center",
-        "envelope",
-        "extent",
-        "initial",
-        "lat",
-        "latitude",
-        "level of detail",
-        "location",
-        "long",
-        "longitude",
-        "scale",
-        "zoom level"
-    ],
-    "offline_data": [],
-    "redirect_from": [
-        "/net/latest/wpf/sample-code/setinitialmaplocation.htm"
-    ],
-    "relevant_apis": [
-        "BasemapType",
-        "Map",
-        "MapView"
-    ],
-    "snippets": [
-        "SetInitialMapLocation.xaml",
-        "SetInitialMapLocation.xaml.cs"
-    ],
-    "title": "Set initial map location"
+  "category": "Map",
+  "description": "Display a basemap centered at an initial location and scale.",
+  "formal_name": "SetInitialMapLocation",
+  "ignore": false,
+  "images": [
+    "SetInitialMapLocation.jpg"
+  ],
+  "keywords": [
+    "LOD",
+    "basemap",
+    "center",
+    "envelope",
+    "extent",
+    "initial",
+    "lat",
+    "latitude",
+    "level of detail",
+    "location",
+    "long",
+    "longitude",
+    "scale",
+    "zoom level"
+  ],
+  "offline_data": [],
+  "redirect_from": [
+    "/net/latest/wpf/sample-code/setinitialmaplocation.htm"
+  ],
+  "relevant_apis": [
+    "BasemapStyle",
+    "Map",
+    "MapView"
+  ],
+  "snippets": [
+    "SetInitialMapLocation.xaml",
+    "SetInitialMapLocation.xaml.cs"
+  ],
+  "title": "Set initial map location"
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-  "category": "Map",
-  "description": "Display a basemap centered at an initial location and scale.",
-  "formal_name": "SetInitialMapLocation",
-  "ignore": false,
-  "images": [
-    "SetInitialMapLocation.jpg"
-  ],
-  "keywords": [
-    "LOD",
-    "basemap",
-    "center",
-    "envelope",
-    "extent",
-    "initial",
-    "lat",
-    "latitude",
-    "level of detail",
-    "location",
-    "long",
-    "longitude",
-    "scale",
-    "zoom level"
-  ],
-  "offline_data": [],
-  "redirect_from": [
-    "/net/latest/wpf/sample-code/setinitialmaplocation.htm"
-  ],
-  "relevant_apis": [
-    "BasemapStyle",
-    "Map",
-    "MapView"
-  ],
-  "snippets": [
-    "SetInitialMapLocation.xaml",
-    "SetInitialMapLocation.xaml.cs"
-  ],
-  "title": "Set initial map location"
+    "category": "Map",
+    "description": "Display a basemap centered at an initial location and scale.",
+    "formal_name": "SetInitialMapLocation",
+    "ignore": false,
+    "images": [
+        "SetInitialMapLocation.jpg"
+    ],
+    "keywords": [
+        "LOD",
+        "basemap",
+        "center",
+        "envelope",
+        "extent",
+        "initial",
+        "lat",
+        "latitude",
+        "level of detail",
+        "location",
+        "long",
+        "longitude",
+        "scale",
+        "zoom level"
+    ],
+    "offline_data": [],
+    "redirect_from": [
+        "/net/latest/wpf/sample-code/setinitialmaplocation.htm"
+    ],
+    "relevant_apis": [
+        "BasemapStyle",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "SetInitialMapLocation.xaml",
+        "SetInitialMapLocation.xaml.cs"
+    ],
+    "title": "Set initial map location"
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -27,39 +27,40 @@ namespace ArcGISRuntime.WPF.Samples.DisplayDrawingStatus
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Hook up the DrawStatusChanged event
+            // Hook up the DrawStatusChanged event.
             MyMapView.DrawStatusChanged += OnDrawStatusChanged;
 
-            // Create new Map with basemap
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            // Create new Map with basemap.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
-            // Create uri to the used feature service
+            // Create uri to the used feature service.
             Uri serviceUri = new Uri(
                 "https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
 
-            // Initialize a new feature layer
+            // Initialize a new feature layer.
             ServiceFeatureTable myFeatureTable = new ServiceFeatureTable(serviceUri);
             FeatureLayer myFeatureLayer = new FeatureLayer(myFeatureTable);
 
-            // Add the feature layer to the Map
+            // Add the feature layer to the Map.
             myMap.OperationalLayers.Add(myFeatureLayer);
 
-            // Provide used Map to the MapView
+            // Provide used Map to the MapView.
             MyMapView.Map = myMap;
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)
         {
-            // Update the load status information
+            // Update the load status information.
             Dispatcher.Invoke(delegate ()
             {
-                // Show the activity indicator if the map is drawing
+                // Show the activity indicator if the map is drawing.
                 if (e.Status == DrawStatus.InProgress)
                 {
                     ActivityIndicator.IsEnabled = true;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -30,7 +30,8 @@ namespace ArcGISRuntime.WPF.Samples.ShowMagnifier
         private void Initialize()
         {
             // Create new Map with basemap and initial location.
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
             // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions()

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -36,78 +36,77 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
         {
             try
             {
-                // Define the Uri for the service feature table (US state polygons)
+                // Define the Uri for the service feature table (US state polygons).
                 Uri serviceFeatureTableUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
 
-                // Create a new service feature table from the Uri
+                // Create a new service feature table from the Uri.
                 ServiceFeatureTable myServiceFeatureTable = new ServiceFeatureTable(serviceFeatureTableUri);
 
-                // Create a new feature layer from the service feature table
+                // Create a new feature layer from the service feature table.
                 FeatureLayer myFeatureLayer = new FeatureLayer(myServiceFeatureTable)
                 {
-
-                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work)
+                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work).
                     RenderingMode = FeatureRenderingMode.Dynamic
                 };
 
-                // Create a new simple line symbol for the feature layer
+                // Create a new simple line symbol for the feature layer.
                 SimpleLineSymbol mySimpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Black, 1);
 
-                // Create a new simple fill symbol for the feature layer 
+                // Create a new simple fill symbol for the feature layer.
                 SimpleFillSymbol mysimpleFillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Solid, System.Drawing.Color.Blue, mySimpleLineSymbol);
 
-                // Create a new simple renderer for the feature layer
+                // Create a new simple renderer for the feature layer.
                 SimpleRenderer mySimpleRenderer = new SimpleRenderer(mysimpleFillSymbol);
 
-                // Get the scene properties from the simple renderer
+                // Get the scene properties from the simple renderer.
                 RendererSceneProperties myRendererSceneProperties = mySimpleRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties
+                // Set the extrusion mode for the scene properties.
                 myRendererSceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
-                // Set the initial extrusion expression
+                // Set the initial extrusion expression.
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
 
-                // Set the feature layer's renderer to the define simple renderer
+                // Set the feature layer's renderer to the define simple renderer.
                 myFeatureLayer.Renderer = mySimpleRenderer;
 
-                // Create a new scene with the topographic backdrop 
-                Scene myScene = new Scene(BasemapType.Topographic);
+                // Create a new scene with the topographic backdrop.
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
-                // Set the scene view's scene to the newly create one
+                // Set the scene view's scene to the newly create one.
                 MySceneView.Scene = myScene;
 
-                // Add the feature layer to the scene's operational layer collection
+                // Add the feature layer to the scene's operational layer collection.
                 myScene.OperationalLayers.Add(myFeatureLayer);
 
-                // Create a new map point to define where to look on the scene view
+                // Create a new map point to define where to look on the scene view.
                 MapPoint myMapPoint = new MapPoint(-10974490, 4814376, 0, SpatialReferences.WebMercator);
 
-                // Create a new orbit location camera controller using the map point and defined distance
+                // Create a new orbit location camera controller using the map point and defined distance.
                 OrbitLocationCameraController myOrbitLocationCameraController = new OrbitLocationCameraController(myMapPoint, 20000000);
 
-                // Set the scene view's camera controller to the orbit location camera controller
+                // Set the scene view's camera controller to the orbit location camera controller.
                 MySceneView.CameraController = myOrbitLocationCameraController;
             }
             catch (Exception ex)
             {
-                // Something went wrong, display the error
+                // Something went wrong, display the error.
                 MessageBox.Show(ex.ToString());
             }
         }
 
         private void ChangeExtrusionExpression()
         {
-            // Get the first layer from the scene view's operation layers, it should be a feature layer
+            // Get the first layer from the scene view's operation layers, it should be a feature layer.
             FeatureLayer myFeatureLayer = (FeatureLayer)MySceneView.Scene.OperationalLayers[0];
 
-            // Get the renderer from the feature layer
+            // Get the renderer from the feature layer.
             Renderer myRenderer = myFeatureLayer.Renderer;
 
-            // Get the scene properties from the feature layer's renderer
+            // Get the scene properties from the feature layer's renderer.
             RendererSceneProperties myRendererSceneProperties = myRenderer.SceneProperties;
 
-            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
+            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text.
             if (ToggleDataButton.Content.ToString() == "Show population density")
             {
                 // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
@@ -115,7 +114,7 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 ToggleDataButton.Content = "Show total population";
             }
-            else if(ToggleDataButton.Content.ToString() == "Show total population")
+            else if (ToggleDataButton.Content.ToString() == "Show total population")
             {
                 myRendererSceneProperties.ExtrusionExpression = "[POP2007] / 10";
                 ToggleDataButton.Content = "Show population density";
@@ -124,7 +123,7 @@ namespace ArcGISRuntime.WPF.Samples.FeatureLayerExtrusion
 
         private void Button_ToggleExtrusionData_Click(object sender, RoutedEventArgs e)
         {
-            // Call the function to change the feature layer's renderer scene properties extrusion expression
+            // Call the function to change the feature layer's renderer scene properties extrusion expression.
             ChangeExtrusionExpression();
         }
     }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
@@ -22,41 +22,42 @@ namespace ArcGISRuntime.WinUI.Samples.FeatureLayerGeoPackage
         description: "Display features from a local GeoPackage.",
         instructions: "Pan and zoom around the map. View the data loaded from the geopackage.",
         tags: new[] { "OGC", "feature table", "geopackage", "gpkg", "package", "standards" })]
-	[ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
+    [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("68ec42517cdd439e81b036210483e8e7")]
     public partial class FeatureLayerGeoPackage
     {
         public FeatureLayerGeoPackage()
         {
             InitializeComponent();
 
-            // Read data from the GeoPackage
+            // Read data from the GeoPackage.
             Initialize();
         }
 
         private async void Initialize()
         {
-            // Create a new map centered on Aurora Colorado
-            MyMapView.Map = new Map(BasemapType.LightGrayCanvasVector, 39.7294, -104.8319, 9);
+            // Create a new map centered on Aurora Colorado.
+            MyMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
 
-            // Get the full path
+            // Get the full path.
             string geoPackagePath = GetGeoPackagePath();
 
             try
             {
-                // Open the GeoPackage
+                // Open the GeoPackage.
                 GeoPackage myGeoPackage = await GeoPackage.OpenAsync(geoPackagePath);
 
-                // Read the feature tables and get the first one
+                // Read the feature tables and get the first one.
                 FeatureTable geoPackageTable = myGeoPackage.GeoPackageFeatureTables.FirstOrDefault();
 
-                // Make sure a feature table was found in the package
+                // Make sure a feature table was found in the package.
                 if (geoPackageTable == null) { return; }
 
-                // Create a layer to show the feature table
+                // Create a layer to show the feature table.
                 FeatureLayer newLayer = new FeatureLayer(geoPackageTable);
                 await newLayer.LoadAsync();
 
-                // Add the feature table as a layer to the map (with default symbology)
+                // Add the feature table as a layer to the map (with default symbology).
                 MyMapView.Map.OperationalLayers.Add(newLayer);
             }
             catch (Exception e)

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -34,7 +34,8 @@ namespace ArcGISRuntime.WinUI.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            MyMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.73, 11);
+            MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.73, 11);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -45,7 +45,8 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
         private void Initialize()
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
-            Map spatialOperationsMap = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 15);
+            Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;
@@ -68,14 +69,14 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
 
             // Remove any currently displayed result.
             _polygonsOverlay.Graphics.Remove(_resultGraphic);
-            
+
             // Polygon geometry from the input graphics.
             Geometry polygonOne = _graphicOne.Geometry;
             Geometry polygonTwo = _graphicTwo.Geometry;
-            
+
             // Result polygon for spatial operations.
             Geometry resultPolygon = null;
-            
+
             // Run the selected spatial operation on the polygon graphics and get the result geometry.
             string operation = (string)SpatialOperationComboBox.SelectedItem;
             switch (operation)
@@ -83,40 +84,45 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
                 case "Union":
                     resultPolygon = GeometryEngine.Union(polygonOne, polygonTwo);
                     break;
+
                 case "Difference":
                     resultPolygon = GeometryEngine.Difference(polygonOne, polygonTwo);
                     break;
+
                 case "Symmetric difference":
                     resultPolygon = GeometryEngine.SymmetricDifference(polygonOne, polygonTwo);
                     break;
+
                 case "Intersection":
                     resultPolygon = GeometryEngine.Intersection(polygonOne, polygonTwo);
                     break;
             }
-            
+
             // Create a black outline symbol to use for the result polygon.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Black, 1);
-            
+
             // Create a solid red fill symbol for the result polygon graphic.
             SimpleFillSymbol resultSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Solid, System.Drawing.Color.Red, outlineSymbol);
-            
+
             // Create the result polygon graphic and add it to the graphics overlay.
             _resultGraphic = new Graphic(resultPolygon, resultSymbol);
             _polygonsOverlay.Graphics.Add(_resultGraphic);
         }
+
         private void ResetOperationButton_Click(object sender, RoutedEventArgs e)
         {
             // Remove any currently displayed result.
             _polygonsOverlay.Graphics.Remove(_resultGraphic);
-            
+
             // Clear the selected spatial operation.
             SpatialOperationComboBox.SelectedIndex = -1;
         }
+
         private void CreatePolygonsOverlay()
         {
             // Create a black outline symbol to use for the polygons.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, System.Drawing.Color.Black, 1);
-            
+
             // Create a point collection to define polygon vertices.
             PointCollection polygonVertices = new PointCollection(SpatialReferences.WebMercator)
             {
@@ -126,12 +132,12 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
                 new MapPoint(-13300, 6710500),
                 new MapPoint(-13160, 6710100)
             };
-            
+
             // Create a polygon graphic with a blue fill.
             SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Vertical, System.Drawing.Color.Blue, outlineSymbol);
             Polygon polygonOne = new Polygon(polygonVertices);
             _graphicOne = new Graphic(polygonOne, fillSymbol);
-            
+
             // Create a point collection to define outer polygon ring vertices.
             PointCollection outerRingVerticesCollection = new PointCollection(SpatialReferences.WebMercator)
             {
@@ -140,7 +146,7 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
                 new MapPoint(-13160, 6709700),
                 new MapPoint(-14560, 6710730)
             };
-            
+
             // Create a point collection to define inner polygon ring vertices ("donut hole").
             PointCollection innerRingVerticesCollection = new PointCollection(SpatialReferences.WebMercator)
             {
@@ -149,22 +155,22 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
                 new MapPoint(-13160, 6709900),
                 new MapPoint(-12450, 6710660)
             };
-            
+
             // Create a list to contain the inner and outer ring point collections.
             List<PointCollection> polygonParts = new List<PointCollection>
             {
                 outerRingVerticesCollection,
                 innerRingVerticesCollection
             };
-            
+
             // Create a polygon graphic with a green fill.
             fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Horizontal, System.Drawing.Color.Green, outlineSymbol);
             _graphicTwo = new Graphic(new Polygon(polygonParts), fillSymbol);
-            
+
             // Create a graphics overlay in the map view to hold the polygons.
             _polygonsOverlay = new GraphicsOverlay();
             MyMapView.GraphicsOverlays.Add(_polygonsOverlay);
-            
+
             // Add the polygons to the graphics overlay.
             _polygonsOverlay.Graphics.Add(_graphicOne);
             _polygonsOverlay.Graphics.Add(_graphicTwo);

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -32,39 +32,40 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
         tags: new[] { "geoprocessing", "heat map", "heatmap", "viewshed" })]
     public partial class AnalyzeViewshed
     {
-        // Url for the geoprocessing service
+        // Url for the geoprocessing service.
         private const string _viewshedUrl =
             "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/ESRI_Elevation_World/GPServer/Viewshed";
 
-        // Used to store state of the geoprocessing task
+        // Used to store state of the geoprocessing task.
         private bool _isExecutingGeoprocessing;
 
-        // The graphics overlay to show where the user clicked in the map
+        // The graphics overlay to show where the user clicked in the map.
         private GraphicsOverlay _inputOverlay;
 
-        // The graphics overlay to display the result of the viewshed analysis
+        // The graphics overlay to display the result of the viewshed analysis.
         private GraphicsOverlay _resultOverlay;
 
         public AnalyzeViewshed()
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with topographic basemap and an initial location
-            Map myMap = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            // Create a map with topographic basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
-            // Hook into the tapped event
+            // Hook into the tapped event.
             MyMapView.GeoViewTapped += OnMapViewTapped;
 
-            // Create empty overlays for the user clicked location and the results of the viewshed analysis
+            // Create empty overlays for the user clicked location and the results of the viewshed analysis.
             CreateOverlays();
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
 
@@ -77,28 +78,28 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
                 return;
             }
 
-            // Indicate that the geoprocessing is running
+            // Indicate that the geoprocessing is running.
             SetBusy();
 
-            // Clear previous user click location and the viewshed geoprocessing task results
+            // Clear previous user click location and the viewshed geoprocessing task results.
             _inputOverlay.Graphics.Clear();
             _resultOverlay.Graphics.Clear();
 
-            // Get the tapped point
+            // Get the tapped point.
             MapPoint geometry = e.Location;
 
-            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
+            // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay.
             Graphic myInputGraphic = new Graphic(geometry);
             _inputOverlay.Graphics.Add(myInputGraphic);
 
-            // Normalize the geometry if wrap-around is enabled
-            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime
+            // Normalize the geometry if wrap-around is enabled.
+            //    This is necessary because of how wrapped-around map coordinates are handled by Runtime.
             //    Without this step, the task may fail because wrapped-around coordinates are out of bounds.
             if (MyMapView.IsWrapAroundEnabled) { geometry = (MapPoint)GeometryEngine.NormalizeCentralMeridian(geometry); }
 
             try
             {
-                // Execute the geoprocessing task using the user click location
+                // Execute the geoprocessing task using the user click location.
                 await CalculateViewshed(geometry);
             }
             catch (Exception ex)
@@ -111,47 +112,46 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
         {
             // This function will define a new geoprocessing task that performs a custom viewshed analysis based upon a
             // user click on the map and then display the results back as a polygon fill graphics overlay. If there
-            // is a problem with the execution of the geoprocessing task an error message will be displayed
+            // is a problem with the execution of the geoprocessing task an error message will be displayed.
 
-            // Create new geoprocessing task using the url defined in the member variables section
+            // Create new geoprocessing task using the url defined in the member variables section.
             GeoprocessingTask myViewshedTask = await GeoprocessingTask.CreateAsync(new Uri(_viewshedUrl));
 
-            // Create a new feature collection table based upon point geometries using the current map view spatial reference
+            // Create a new feature collection table based upon point geometries using the current map view spatial reference.
             FeatureCollectionTable myInputFeatures = new FeatureCollectionTable(new List<Field>(), GeometryType.Point, MyMapView.SpatialReference);
 
-            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet
+            // Create a new feature from the feature collection table. It will not have a coordinate location (x,y) yet.
             Feature myInputFeature = myInputFeatures.CreateFeature();
 
-            // Assign a physical location to the new point feature based upon where the user clicked in the map view
+            // Assign a physical location to the new point feature based upon where the user clicked in the map view.
             myInputFeature.Geometry = location;
 
-            // Add the new feature with (x,y) location to the feature collection table
+            // Add the new feature with (x,y) location to the feature collection table.
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
-            // Create the parameters that are passed to the used geoprocessing task
+            // Create the parameters that are passed to the used geoprocessing task.
             GeoprocessingParameters myViewshedParameters =
                 new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
-
-                    // Request the output features to use the same SpatialReference as the map view
+                    // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference
                 };
 
-            // Add an input location to the geoprocessing parameters
+            // Add an input location to the geoprocessing parameters.
             myViewshedParameters.Inputs.Add("Input_Observation_Point", new GeoprocessingFeatures(myInputFeatures));
 
-            // Create the job that handles the communication between the application and the geoprocessing task
+            // Create the job that handles the communication between the application and the geoprocessing task.
             GeoprocessingJob myViewshedJob = myViewshedTask.CreateJob(myViewshedParameters);
 
             try
             {
-                // Execute analysis and wait for the results
+                // Execute analysis and wait for the results.
                 GeoprocessingResult myAnalysisResult = await myViewshedJob.GetResultAsync();
 
-                // Get the results from the outputs
+                // Get the results from the outputs.
                 GeoprocessingFeatures myViewshedResultFeatures = (GeoprocessingFeatures)myAnalysisResult.Outputs["Viewshed_Result"];
 
-                // Add all the results as a graphics to the map
+                // Add all the results as a graphics to the map.
                 IFeatureSet myViewshedAreas = myViewshedResultFeatures.Features;
                 foreach (Feature myFeature in myViewshedAreas)
                 {
@@ -160,7 +160,7 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
             }
             catch (Exception ex)
             {
-                // Display an error message if there is a problem
+                // Display an error message if there is a problem.
                 if (myViewshedJob.Status == JobStatus.Failed && myViewshedJob.Error != null)
                 {
                     var message = new MessageDialog2("Executing geoprocessing failed. " + myViewshedJob.Error.Message, "Geoprocessing error");
@@ -174,7 +174,7 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
             }
             finally
             {
-                // Indicate that the geoprocessing is not running
+                // Indicate that the geoprocessing is not running.
                 SetBusy(false);
             }
         }
@@ -182,9 +182,9 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
         private void CreateOverlays()
         {
             // This function will create the overlays that show the user clicked location and the results of the
-            // viewshed analysis. Note: the overlays will not be populated with any graphics at this point
+            // viewshed analysis. Note: the overlays will not be populated with any graphics at this point.
 
-            // Create renderer for input graphic. Set the size and color properties for the simple renderer
+            // Create renderer for input graphic. Set the size and color properties for the simple renderer.
             SimpleRenderer myInputRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleMarkerSymbol()
@@ -194,13 +194,13 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
                 }
             };
 
-            // Create overlay to where input graphic is shown
+            // Create overlay to where input graphic is shown.
             _inputOverlay = new GraphicsOverlay()
             {
                 Renderer = myInputRenderer
             };
 
-            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer
+            // Create fill renderer for output of the viewshed analysis. Set the color property of the simple renderer.
             SimpleRenderer myResultRenderer = new SimpleRenderer()
             {
                 Symbol = new SimpleFillSymbol()
@@ -209,13 +209,13 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
                 }
             };
 
-            // Create overlay to where viewshed analysis graphic is shown
+            // Create overlay to where viewshed analysis graphic is shown.
             _resultOverlay = new GraphicsOverlay()
             {
                 Renderer = myResultRenderer
             };
 
-            // Add the created overlays to the MapView
+            // Add the created overlays to the MapView.
             MyMapView.GraphicsOverlays.Add(_inputOverlay);
             MyMapView.GraphicsOverlays.Add(_resultOverlay);
         }
@@ -225,18 +225,18 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
             // This function toggles the visibility of the 'busyOverlay' Grid control defined in xaml,
             // sets the 'progress' control feedback status and updates the _isExecutingGeoprocessing
             // boolean to denote if the viewshed analysis is executing as a result of the user click
-            // on the map
+            // on the map.
 
             if (isBusy)
             {
-                // Change UI to indicate that the geoprocessing is running
+                // Change UI to indicate that the geoprocessing is running.
                 _isExecutingGeoprocessing = true;
                 busyOverlay.Visibility = Visibility.Visible;
                 progress.IsIndeterminate = true;
             }
             else
             {
-                // Change UI to indicate that the geoprocessing is not running
+                // Change UI to indicate that the geoprocessing is not running.
                 _isExecutingGeoprocessing = false;
                 busyOverlay.Visibility = Visibility.Collapsed;
                 progress.IsIndeterminate = false;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
@@ -23,7 +23,7 @@ namespace ArcGISRuntime.WinUI.Samples.AddGraphicsWithSymbols
         tags: new[] { "SimpleFillSymbol", "SimpleLineSymbol", "SimpleMarkerSymbol" })]
     public partial class AddGraphicsWithSymbols
     {
-        // Create the graphics overlay
+        // Create the graphics overlay.
         private readonly GraphicsOverlay _overlay = new GraphicsOverlay();
 
         public AddGraphicsWithSymbols()
@@ -35,31 +35,32 @@ namespace ArcGISRuntime.WinUI.Samples.AddGraphicsWithSymbols
 
         private void Initialize()
         {
-            // Create the map
-            Map myMap = new Map(BasemapType.Oceans, 56.075844, -2.681572, 13);
+            // Create the map.
+            Map myMap = new Map(BasemapStyle.ArcGISOceans);
+            myMap.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 13);
 
-            // Add the map to the map view
+            // Add the map to the map view.
             MyMapView.Map = myMap;
 
-            // Add the graphics overlay to the map view
+            // Add the graphics overlay to the map view.
             MyMapView.GraphicsOverlays.Add(_overlay);
 
-            // Call functions to create the graphics
+            // Call functions to create the graphics.
             CreatePoints();
             CreatePolygon();
             CreatePolyline();
             CreateText();
 
-            // Update the extent to encompass all of the symbols
+            // Update the extent to encompass all of the symbols.
             SetExtent();
         }
 
         private void CreatePoints()
         {
-            // Create a red circle simple marker symbol
+            // Create a red circle simple marker symbol.
             SimpleMarkerSymbol redCircleSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.Circle, Color.FromArgb(0xFF, 0xFF, 0x00, 0x00), 10);
 
-            // Create graphics and add them to graphics overlay
+            // Create graphics and add them to graphics overlay.
             Graphic graphic = new Graphic(new MapPoint(-2.72, 56.065, SpatialReferences.Wgs84), redCircleSymbol);
             _overlay.Graphics.Add(graphic);
 
@@ -75,13 +76,13 @@ namespace ArcGISRuntime.WinUI.Samples.AddGraphicsWithSymbols
 
         private void CreatePolyline()
         {
-            // Create a purple simple line symbol
+            // Create a purple simple line symbol.
             SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Color.FromArgb(0xFF, 0x80, 0x00, 0x80), 4);
 
-            // Create a new point collection for polyline
+            // Create a new point collection for polyline.
             PointCollection points = new PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.715, 56.061),
                 new MapPoint(-2.6438, 56.079),
                 new MapPoint(-2.638, 56.079),
@@ -91,28 +92,28 @@ namespace ArcGISRuntime.WinUI.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.715, 56.061)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polyline polyline = new Polyline(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polyline, lineSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreatePolygon()
         {
-            // Create a green simple line symbol
+            // Create a green simple line symbol.
             SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Dash, Color.FromArgb(0xFF, 0x00, 0x50, 0x00), 1);
 
-            // Create a green mesh simple fill symbol
+            // Create a green mesh simple fill symbol.
             SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.DiagonalCross, Color.FromArgb(0xFF, 0x00, 0x50, 0x00), outlineSymbol);
 
-            // Create a new point collection for polygon
+            // Create a new point collection for polygon.
             PointCollection points = new PointCollection(SpatialReferences.Wgs84)
             {
-                // Create and add points to the point collection
+                // Create and add points to the point collection.
                 new MapPoint(-2.6425, 56.0784),
                 new MapPoint(-2.6430, 56.0763),
                 new MapPoint(-2.6410, 56.0759),
@@ -121,58 +122,58 @@ namespace ArcGISRuntime.WinUI.Samples.AddGraphicsWithSymbols
                 new MapPoint(-2.6410, 56.0786)
             };
 
-            // Create the polyline from the point collection
+            // Create the polyline from the point collection.
             Polygon polygon = new Polygon(points);
 
-            // Create the graphic with polyline and symbol
+            // Create the graphic with polyline and symbol.
             Graphic graphic = new Graphic(polygon, fillSymbol);
 
-            // Add graphic to the graphics overlay
+            // Add graphic to the graphics overlay.
             _overlay.Graphics.Add(graphic);
         }
 
         private void CreateText()
         {
-            // Create two text symbols
+            // Create two text symbols.
             TextSymbol bassRockTextSymbol = new TextSymbol("Black Rock", Color.Blue, 10,
                 Esri.ArcGISRuntime.Symbology.HorizontalAlignment.Left, Esri.ArcGISRuntime.Symbology.VerticalAlignment.Bottom);
 
             TextSymbol craigleithTextSymbol = new TextSymbol("Craigleith", Color.Blue, 10,
                 Esri.ArcGISRuntime.Symbology.HorizontalAlignment.Right, Esri.ArcGISRuntime.Symbology.VerticalAlignment.Top);
 
-            // Create two points
+            // Create two points.
             MapPoint bassPoint = new MapPoint(-2.64, 56.079, SpatialReferences.Wgs84);
             MapPoint craigleithPoint = new MapPoint(-2.72, 56.076, SpatialReferences.Wgs84);
 
-            // Create two graphics from the points and symbols
+            // Create two graphics from the points and symbols.
             Graphic bassRockGraphic = new Graphic(bassPoint, bassRockTextSymbol);
             Graphic craigleithGraphic = new Graphic(craigleithPoint, craigleithTextSymbol);
 
-            // Add graphics to the graphics overlay
+            // Add graphics to the graphics overlay.
             _overlay.Graphics.Add(bassRockGraphic);
             _overlay.Graphics.Add(craigleithGraphic);
         }
 
         private void SetExtent()
         {
-            // Get all of the graphics contained in the graphics overlay
+            // Get all of the graphics contained in the graphics overlay.
             GraphicCollection myGraphicCollection = _overlay.Graphics;
 
-            // Create a new envelope builder using the same spatial reference as the graphics
+            // Create a new envelope builder using the same spatial reference as the graphics.
             EnvelopeBuilder myEnvelopeBuilder = new EnvelopeBuilder(SpatialReferences.Wgs84);
 
-            // Loop through each graphic in the graphic collection
+            // Loop through each graphic in the graphic collection.
             foreach (Graphic oneGraphic in myGraphicCollection)
             {
-                // Union the extent of each graphic in the envelope builder
+                // Union the extent of each graphic in the envelope builder.
                 myEnvelopeBuilder.UnionOf(oneGraphic.Geometry.Extent);
             }
 
-            // Expand the envelope builder by 30%
+            // Expand the envelope builder by 30%.
             myEnvelopeBuilder.Expand(1.3);
 
             // Adjust the viewable area of the map to encompass all of the graphics in the
-            // graphics overlay plus an extra 30% margin for better viewing
+            // graphics overlay plus an extra 30% margin for better viewing.
             MyMapView.SetViewpointAsync(new Viewpoint(myEnvelopeBuilder.Extent));
         }
     }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -43,7 +43,8 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -49,7 +49,8 @@ namespace ArcGISRuntime.WinUI.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -23,14 +23,15 @@ namespace ArcGISRuntime.WinUI.Samples.SetInitialMapLocation
         {
             InitializeComponent();
 
-            // Create the UI, setup the control references and execute initialization 
+            // Create the UI, setup the control references and execute initialization.
             Initialize();
         }
 
         private void Initialize()
         {
-            // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 16);
+            // Create a map with 'Imagery with Labels' basemap and an initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISImagery);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 16);
 
             // Assign the map to the MapView
             MyMapView.Map = myMap;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-    "category": "Map",
-    "description": "Display a basemap centered at an initial location and scale.",
-    "formal_name": "SetInitialMapLocation",
-    "ignore": false,
-    "images": [
-        "SetInitialMapLocation.jpg"
-    ],
-    "keywords": [
-        "LOD",
-        "basemap",
-        "center",
-        "envelope",
-        "extent",
-        "initial",
-        "lat",
-        "latitude",
-        "level of detail",
-        "location",
-        "long",
-        "longitude",
-        "scale",
-        "zoom level"
-    ],
-    "offline_data": [],
-    "redirect_from": [
-        "/net/latest/winui/sample-code/setinitialmaplocation.htm"
-    ],
-    "relevant_apis": [
-        "BasemapType",
-        "Map",
-        "MapView"
-    ],
-    "snippets": [
-        "SetInitialMapLocation.xaml",
-        "SetInitialMapLocation.xaml.cs"
-    ],
-    "title": "Set initial map location"
+  "category": "Map",
+  "description": "Display a basemap centered at an initial location and scale.",
+  "formal_name": "SetInitialMapLocation",
+  "ignore": false,
+  "images": [
+    "SetInitialMapLocation.jpg"
+  ],
+  "keywords": [
+    "LOD",
+    "basemap",
+    "center",
+    "envelope",
+    "extent",
+    "initial",
+    "lat",
+    "latitude",
+    "level of detail",
+    "location",
+    "long",
+    "longitude",
+    "scale",
+    "zoom level"
+  ],
+  "offline_data": [],
+  "redirect_from": [
+    "/net/latest/winui/sample-code/setinitialmaplocation.htm"
+  ],
+  "relevant_apis": [
+    "BasemapStyle",
+    "Map",
+    "MapView"
+  ],
+  "snippets": [
+    "SetInitialMapLocation.xaml",
+    "SetInitialMapLocation.xaml.cs"
+  ],
+  "title": "Set initial map location"
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -1,39 +1,39 @@
 {
-  "category": "Map",
-  "description": "Display a basemap centered at an initial location and scale.",
-  "formal_name": "SetInitialMapLocation",
-  "ignore": false,
-  "images": [
-    "SetInitialMapLocation.jpg"
-  ],
-  "keywords": [
-    "LOD",
-    "basemap",
-    "center",
-    "envelope",
-    "extent",
-    "initial",
-    "lat",
-    "latitude",
-    "level of detail",
-    "location",
-    "long",
-    "longitude",
-    "scale",
-    "zoom level"
-  ],
-  "offline_data": [],
-  "redirect_from": [
-    "/net/latest/winui/sample-code/setinitialmaplocation.htm"
-  ],
-  "relevant_apis": [
-    "BasemapStyle",
-    "Map",
-    "MapView"
-  ],
-  "snippets": [
-    "SetInitialMapLocation.xaml",
-    "SetInitialMapLocation.xaml.cs"
-  ],
-  "title": "Set initial map location"
+    "category": "Map",
+    "description": "Display a basemap centered at an initial location and scale.",
+    "formal_name": "SetInitialMapLocation",
+    "ignore": false,
+    "images": [
+        "SetInitialMapLocation.jpg"
+    ],
+    "keywords": [
+        "LOD",
+        "basemap",
+        "center",
+        "envelope",
+        "extent",
+        "initial",
+        "lat",
+        "latitude",
+        "level of detail",
+        "location",
+        "long",
+        "longitude",
+        "scale",
+        "zoom level"
+    ],
+    "offline_data": [],
+    "redirect_from": [
+        "/net/latest/winui/sample-code/setinitialmaplocation.htm"
+    ],
+    "relevant_apis": [
+        "BasemapStyle",
+        "Map",
+        "MapView"
+    ],
+    "snippets": [
+        "SetInitialMapLocation.xaml",
+        "SetInitialMapLocation.xaml.cs"
+    ],
+    "title": "Set initial map location"
 }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -37,7 +37,8 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayDrawingStatus
             MyMapView.DrawStatusChanged += OnDrawStatusChanged;
 
             // Create new Map with a topographic basemap.
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL pointing to a feature service.
             Uri serviceUri =

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Mapping;
@@ -29,16 +29,17 @@ namespace ArcGISRuntime.WinUI.Samples.ShowMagnifier
 
         private void Initialize()
         {
-            // Create new Map with basemap and initial location
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            // Create new Map with basemap and initial location.
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
-            // Enable magnifier
+            // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions
             {
                 IsMagnifierEnabled = true
             };
 
-            // Assign the map to the MapView
+            // Assign the map to the MapView.
             MyMapView.Map = myMap;
         }
     }

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific 
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
@@ -38,82 +38,80 @@ namespace ArcGISRuntime.WinUI.Samples.FeatureLayerExtrusion
         {
             try
             {
-                // Define the Uri for the service feature table (US state polygons)
+                // Define the Uri for the service feature table (US state polygons).
                 Uri serviceFeatureTableUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3");
 
-                // Create a new service feature table from the Uri
+                // Create a new service feature table from the Uri.
                 ServiceFeatureTable censusTable = new ServiceFeatureTable(serviceFeatureTableUri);
 
-                // Create a new feature layer from the service feature table
+                // Create a new feature layer from the service feature table.
                 FeatureLayer censusLayer = new FeatureLayer(censusTable)
                 {
-                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work)
+                    // Set the rendering mode of the feature layer to be dynamic (needed for extrusion to work).
                     RenderingMode = FeatureRenderingMode.Dynamic
                 };
 
-                // Create a new simple line symbol for the feature layer
+                // Create a new simple line symbol for the feature layer.
                 SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbolStyle.Solid, Color.Black, 1);
 
-                // Create a new simple fill symbol for the feature layer 
+                // Create a new simple fill symbol for the feature layer.
                 SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbolStyle.Solid, Color.Blue, lineSymbol);
 
-                // Create a new simple renderer for the feature layer
+                // Create a new simple renderer for the feature layer.
                 SimpleRenderer layerRenderer = new SimpleRenderer(fillSymbol);
 
-                // Get the scene properties from the simple renderer
+                // Get the scene properties from the simple renderer.
                 RendererSceneProperties sceneProperties = layerRenderer.SceneProperties;
 
-                // Set the extrusion mode for the scene properties
+                // Set the extrusion mode for the scene properties.
                 sceneProperties.ExtrusionMode = ExtrusionMode.AbsoluteHeight;
 
-                // Set the initial extrusion expression
+                // Set the initial extrusion expression.
                 sceneProperties.ExtrusionExpression = "[POP2007] / 10";
 
-                // Set the feature layer's renderer to the define simple renderer
+                // Set the feature layer's renderer to the define simple renderer.
                 censusLayer.Renderer = layerRenderer;
 
-                // Create a new scene with the topographic backdrop 
-                Scene myScene = new Scene(BasemapType.Topographic);
+                // Create a new scene with the topographic backdrop.
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
-                // Set the scene view's scene to the newly create one
+                // Set the scene view's scene to the newly create one.
                 MySceneView.Scene = myScene;
 
-                // Add the feature layer to the scene's operational layer collection
+                // Add the feature layer to the scene's operational layer collection.
                 myScene.OperationalLayers.Add(censusLayer);
 
-                // Create a new map point to define where to look on the scene view
+                // Create a new map point to define where to look on the scene view.
                 MapPoint myMapPoint = new MapPoint(-10974490, 4814376, 0, SpatialReferences.WebMercator);
 
-                // Set the scene view's camera controller to the orbit location camera controller
+                // Set the scene view's camera controller to the orbit location camera controller.
                 MySceneView.CameraController = new OrbitLocationCameraController(myMapPoint, 20000000);
             }
             catch (Exception ex)
             {
-                // Something went wrong, display the error
+                // Something went wrong, display the error.
                 await new MessageDialog2(ex.ToString(), "Error").ShowAsync();
             }
-
         }
 
         private void ChangeExtrusionExpression()
         {
-            // Get the first layer from the scene view's operation layers, it should be a feature layer
+            // Get the first layer from the scene view's operation layers, it should be a feature layer.
             FeatureLayer myFeatureLayer = (FeatureLayer)MySceneView.Scene.OperationalLayers[0];
 
-            // Get the renderer from the feature layer
+            // Get the renderer from the feature layer.
             Renderer myRenderer = myFeatureLayer.Renderer;
 
-            // Get the scene properties from the feature layer's renderer
+            // Get the scene properties from the feature layer's renderer.
             RendererSceneProperties myRendererSceneProperties = myRenderer.SceneProperties;
 
-            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text
+            // Toggle the feature layer's scene properties renderer extrusion expression and change the button text.
             if (ToggleButton.Content.ToString() == "Show population density")
             {
                 // An offset of 100000 is added to ensure that polygons for large areas (like Alaska)
                 // with low populations will be extruded above the curvature of the Earth.
                 myRendererSceneProperties.ExtrusionExpression = "[POP07_SQMI] * 5000 + 100000";
                 ToggleButton.Content = "Show total population";
-
             }
             else if (ToggleButton.Content.ToString() == "Show total population")
             {
@@ -124,7 +122,7 @@ namespace ArcGISRuntime.WinUI.Samples.FeatureLayerExtrusion
 
         private void Button_ToggleExtrusionData_Click(object sender, RoutedEventArgs e)
         {
-            // Call the function to change the feature layer's renderer scene properties extrusion expression
+            // Call the function to change the feature layer's renderer scene properties extrusion expression.
             ChangeExtrusionExpression();
         }
     }


### PR DESCRIPTION
# Description

Replaces every instance of BasemapType with BasemapStyle since BasemapType is outdated. 

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] Xamarin.Forms Android
- [x] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP


## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab