### PR TITLE
UWP Bug fix: resolved issue with class file source code for Map reference scale and mobile map search & route

### DIFF
--- a/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
@@ -471,9 +471,15 @@
     <Compile Include="Samples\Scene\GetElevationAtPoint\GetElevationAtPoint.xaml.cs">
       <DependentUpon>GetElevationAtPoint.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Samples\Map\MapReferenceScale\DoubleToScaleStringConverter.cs" />
-    <Compile Include="Samples\Map\MobileMapSearchAndRoute\ItemToImageSourceConverter.cs" />
-    <Compile Include="Samples\Map\MobileMapSearchAndRoute\NullOrEmptyToVisibilityConverter.cs" />
+    <Compile Include="Samples\Map\MapReferenceScale\DoubleToScaleStringConverter.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
+    <Compile Include="Samples\Map\MobileMapSearchAndRoute\ItemToImageSourceConverter.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
+    <Compile Include="Samples\Map\MobileMapSearchAndRoute\NullOrEmptyToVisibilityConverter.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
     <Compile Include="Samples\Layers\RasterColormapRenderer\RasterColormapRenderer.xaml.cs">
       <DependentUpon>RasterColormapRenderer.xaml</DependentUpon>
     </Compile>
@@ -1805,8 +1811,12 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Converters\NullToVisibilityConverter.cs" />
-    <Compile Include="Converters\SampleToBitmapConverter.cs" />
+    <Compile Include="Converters\NullToVisibilityConverter.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
+    <Compile Include="Converters\SampleToBitmapConverter.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/MapReferenceScale/MapReferenceScale.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/MapReferenceScale/MapReferenceScale.xaml.cs
@@ -29,7 +29,6 @@ namespace ArcGISRuntime.UWP.Samples.MapReferenceScale
         description: "Set the map's reference scale and which feature layers should honor the reference scale.",
         instructions: "Use the control at the top to set the map's reference scale (1:500,000 1:250,000 1:100,000 1:50,000). Use the menu checkboxes in the layer menu to set which feature layers should honor the reference scale.",
         tags: new[] { "map", "reference scale", "scene" })]
-    [ArcGISRuntime.Samples.Shared.Attributes.ClassFile("Converters/DoubleToScaleStringConverter")]
     public partial class MapReferenceScale
     {
         // List of reference scale options.

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/MobileMapSearchAndRoute/MobileMapSearchAndRoute.xaml.cs
@@ -34,7 +34,6 @@ namespace ArcGISRuntime.UWP.Samples.MobileMapSearchAndRoute
         instructions: "A list of maps from a mobile map package will be displayed. If the map contains transportation networks, the list item will have a navigation icon. Click on a map in the list to open it. If a locator task is available, click on the map to reverse geocode the location's address. If transportation networks are available, a route will be calculated between geocode locations.",
         tags: new[] { "disconnected", "field mobility", "geocode", "network", "network analysis", "offline", "routing", "search", "transportation" })]
     [ArcGISRuntime.Samples.Shared.Attributes.OfflineData("260eb6535c824209964cf281766ebe43")]
-    [ArcGISRuntime.Samples.Shared.Attributes.ClassFile("Converters\\ItemToImageSourceConverter.cs", "Converters\\NullToVisibilityConverter.cs")]
     public partial class MobileMapSearchAndRoute
     {
         // Hold references to map resources for easy access.


### PR DESCRIPTION
# Description

UWP has a bug where two of the samples wont open. The viewer is trying to load source code files that don't exist. This PR makes the code files get copied to the output directory and removes the bad attributes in the sample source code.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] UWP

## Checklist

- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
