### PR TITLE
Fix bug with Forms.Android samples deploying to Android 12 devices

### DIFF
--- a/src/Forms/Android/MainActivity.cs
+++ b/src/Forms/Android/MainActivity.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace ArcGISRuntime.Droid
 {
-    [Activity(Label = "ArcGIS Runtime SDK for .NET", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [Activity(Label = "ArcGIS Runtime SDK for .NET", Icon = "@drawable/icon", MainLauncher = true, Exported = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : Xamarin.Forms.Platform.Android.FormsApplicationActivity
     {
         internal static MainActivity Instance { get; private set; }

--- a/src/Forms/Shared/Helpers/ArcGISLoginPrompt.cs
+++ b/src/Forms/Shared/Helpers/ArcGISLoginPrompt.cs
@@ -162,7 +162,7 @@ namespace Forms.Helpers
 
 #if __ANDROID__
 
-    [Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+    [Activity(NoHistory = true, Exported = true, LaunchMode = LaunchMode.SingleTop)]
     [IntentFilter(new[] { Intent.ActionView },
        Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
        DataScheme = "forms-samples-app", DataHost = "auth")]


### PR DESCRIPTION
# Description

For Android 12, Activities with intent filters need `Exported` to be set to true.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Xamarin.Forms Android

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
