### PR TITLE
WPF: Fixed bug where license tab could open css file

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/SettingsWindow.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/SettingsWindow.xaml.cs
@@ -73,7 +73,7 @@ namespace ArcGISRuntime
             System.Windows.Forms.HtmlElement src = LicenseBrowser.Document?.GetElementFromPoint(e.ClientMousePosition);
 
             // Check if the element is a hyperlink.
-            if (src?.OuterHtml.Contains("http") == true)
+            if (src?.OuterHtml.Contains("http") == true && src.Children.Count == 0)
             {
                 // Parse the url from the hyperlink html.
                 string url = src.OuterHtml.Split('\"')[1];


### PR DESCRIPTION
# Description

It was possible to open the formatting CSS file in the license tab of the settings window. This fixes that by checking the the html element has children.

## Type of change

- [X] Bug fix