### PR TITLE
Fix invalid package reference in WinUI

### DIFF
--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/ArcGISRuntime.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/ArcGISRuntime.WinUI.Viewer.csproj
@@ -66,7 +66,6 @@
     <PackageReference Include="Esri.ArcGISRuntime.Hydrography" Version="100.14.0" />
     <PackageReference Include="Esri.ArcGISRuntime.WinUI" Version="100.14.0" />
     <PackageReference Include="Esri.ArcGISRuntime.LocalServices" Version="100.14.0" />
-    <PackageReference Include="Microsoft.UI.Xaml" Version="2.7.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />


### PR DESCRIPTION
# Description

This package reference was added in error in the first place. It causes a build error with the latest version of Visual Studio.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WinUI

## Checklist

- [x] Runs and compiles on all active platforms
