### PR TITLE
WinUI/WPF Screenshot Tool Data Persistence Fix

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ScreenshotTab.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ScreenshotTab.xaml.cs
@@ -21,6 +21,7 @@ namespace ArcGISRuntime
             HeightEntryBox.Text = ScreenshotManager.ScreenshotSettings.Height.HasValue ? ScreenshotManager.ScreenshotSettings.Height.ToString() : null;
 
             ScreenshotEnabledCheckBox.Checked += SaveData_Event;
+            ScreenshotEnabledCheckBox.Unchecked += SaveData_Event;
             SourcePathText.TextChanged += SaveData_Event;
             WidthEntryBox.TextChanged += SaveData_Event;
             HeightEntryBox.TextChanged += SaveData_Event;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/ScreenshotTab.xaml
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/ScreenshotTab.xaml
@@ -5,7 +5,6 @@
     <StackPanel Orientation="Vertical">
         <CheckBox x:Name="ScreenshotEnabledCheckBox"
                   Margin="3"
-                  Checked="SaveData_Event"
                   Content="Screenshot tool enabled" />
         <StackPanel Orientation="Horizontal">
             <TextBlock Margin="5"
@@ -13,8 +12,7 @@
                        Text="Source path:" />
             <TextBox x:Name="SourcePathText"
                      Width="450"
-                     Margin="5"
-                     TextChanged="SaveData_Event" />
+                     Margin="5" />
         </StackPanel>
         <StackPanel Orientation="Horizontal">
             <TextBlock Margin="5"
@@ -23,16 +21,14 @@
             <TextBox x:Name="WidthEntryBox"
                      Width="40"
                      Margin="5"
-                     HorizontalAlignment="Left"
-                     TextChanged="SaveData_Event" />
+                     HorizontalAlignment="Left" />
             <TextBlock Margin="5"
                        VerticalAlignment="Center"
                        Text="Height" />
             <TextBox x:Name="HeightEntryBox"
                      Width="40"
                      Margin="5"
-                     HorizontalAlignment="Left"
-                     TextChanged="SaveData_Event" />
+                     HorizontalAlignment="Left" />
         </StackPanel>
         <StackPanel Orientation="Horizontal">
             <TextBlock Margin="5"
@@ -41,8 +37,7 @@
             <TextBox x:Name="ScaleFactorEntryBox"
                      Width="40"
                      Margin="5"
-                     HorizontalAlignment="Left"
-                     TextChanged="SaveData_Event" />
+                     HorizontalAlignment="Left" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/ScreenshotTab.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/ScreenshotTab.xaml.cs
@@ -38,6 +38,7 @@ namespace ArcGISRuntime
             ScaleFactorEntryBox.Text = ScreenshotManager.ScreenshotSettings.ScaleFactor.HasValue ? ScreenshotManager.ScreenshotSettings.ScaleFactor.ToString() : null;
 
             ScreenshotEnabledCheckBox.Checked += SaveData_Event;
+            ScreenshotEnabledCheckBox.Unchecked += SaveData_Event;
             SourcePathText.TextChanged += SaveData_Event;
             WidthEntryBox.TextChanged += SaveData_Event;
             HeightEntryBox.TextChanged += SaveData_Event;


### PR DESCRIPTION
# Description

Fixed issues with Screenshot Settings. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP

- [ ] UWP
- [ ] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
