### PR TITLE
Remove warnings on legacy platforms

### DIFF
--- a/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
+++ b/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
@@ -48,7 +48,6 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
-    <NoWarn>CS0618; CS0672</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
+++ b/src/Android/Xamarin.Android/ArcGISRuntime.Xamarin.Samples.Android.csproj
@@ -48,6 +48,7 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+    <NoWarn>CS0618; CS0672</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
+++ b/src/Android/Xamarin.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto" package="ArcGISRuntimeSDK_Xamarin_Android.ArcGISRuntimeSDK_Xamarin_Android" android:requestLegacyExternalStorage="true">
-	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
@@ -66,7 +66,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             // Create a scene with elevation.
             Surface sceneSurface = new Surface();
             sceneSurface.ElevationSources.Add(new ArcGISTiledElevationSource(_worldElevationService));
-            Scene myScene = new Scene(Basemap.CreateTopographic())
+            Scene myScene = new Scene(BasemapStyle.ArcGISTopographic)
             {
                 BaseSurface = sceneSurface
             };

--- a/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
@@ -87,7 +87,7 @@ namespace ArcGISRuntime.Samples.LineOfSightGeoElement
         private async void Initialize()
         {
             // Create scene
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 InitialViewpoint = new Viewpoint(_observerPoint, 1600)
             };

--- a/src/Android/Xamarin.Android/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cs
+++ b/src/Android/Xamarin.Android/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cs
@@ -52,8 +52,8 @@ namespace ArcGISRuntime.Samples.ViewshedGeoElement
         private MapPoint _tankEndPoint;
 
         // Units for geodetic calculation (used in animating tank)
-        private readonly LinearUnit _metersUnit = (LinearUnit)Unit.FromUnitId(9001);
-        private readonly AngularUnit _degreesUnit = (AngularUnit)Unit.FromUnitId(9102);
+        private readonly LinearUnit _metersUnit = (LinearUnit)Unit.FromWkid(9001);
+        private readonly AngularUnit _degreesUnit = (AngularUnit)Unit.FromWkid(9102);
 
         protected override async void OnCreate(Bundle bundle)
         {

--- a/src/Android/Xamarin.Android/Samples/AugmentedReality/CollectDataAR/MSLAdjustedARLocationDataSource.cs
+++ b/src/Android/Xamarin.Android/Samples/AugmentedReality/CollectDataAR/MSLAdjustedARLocationDataSource.cs
@@ -40,7 +40,7 @@ namespace ArcGISRuntimeXamarin.Samples.CollectDataAR
 
                 if (_currentMode == AltitudeAdjustmentMode.NmeaParsedMsl)
                 {
-                    GetLocationManager().AddNmeaListener(_listener);
+                    GetLocationManager().AddNmeaListener(_listener, null);
                 }
                 else
                 {

--- a/src/Android/Xamarin.Android/Samples/AugmentedReality/NavigateAR/MSLAdjustedARLocationDataSource.cs
+++ b/src/Android/Xamarin.Android/Samples/AugmentedReality/NavigateAR/MSLAdjustedARLocationDataSource.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntimeXamarin.Samples.NavigateAR
 
                 if (_currentMode == AltitudeAdjustmentMode.NmeaParsedMsl)
                 {
-                    GetLocationManager().AddNmeaListener(_listener);
+                    GetLocationManager().AddNmeaListener(_listener, null);
                 }
                 else
                 {

--- a/src/Android/Xamarin.Android/Samples/AugmentedReality/NavigateAR/RouteViewerAR.cs
+++ b/src/Android/Xamarin.Android/Samples/AugmentedReality/NavigateAR/RouteViewerAR.cs
@@ -228,7 +228,7 @@ namespace ArcGISRuntimeXamarin.Samples.NavigateAR
         private void StartTurnByTurn()
         {
             // Create the route tracker.
-            _routeTracker = new RouteTracker(PassedRouteResult, 0);
+            _routeTracker = new RouteTracker(PassedRouteResult, 0, true);
 
             // Create the speech synthesizer.
             _textToSpeech = new TextToSpeech(this, null, "com.google.android.tts");

--- a/src/Android/Xamarin.Android/Samples/AugmentedReality/ViewHiddenInfrastructureAR/MSLAdjustedARLocationDataSource.cs
+++ b/src/Android/Xamarin.Android/Samples/AugmentedReality/ViewHiddenInfrastructureAR/MSLAdjustedARLocationDataSource.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntimeXamarin.Samples.ViewHiddenInfrastructureAR
 
                 if (_currentMode == AltitudeAdjustmentMode.NmeaParsedMsl)
                 {
-                    GetLocationManager().AddNmeaListener(_listener);
+                    GetLocationManager().AddNmeaListener(_listener, null);
                 }
                 else
                 {

--- a/src/Android/Xamarin.Android/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.cs
@@ -61,12 +61,12 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureLinkedAnnotation
                 Geodatabase geodatabase = await Geodatabase.OpenAsync(geodatabasePath);
 
                 // Create feature layers from tables in the geodatabase.
-                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("Loudoun_Address_Points_1"));
-                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("ParcelLines_1"));
+                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("Loudoun_Address_Points_1"));
+                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("ParcelLines_1"));
 
                 // Create annotation layers from tables in the geodatabase.
-                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
-                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("ParcelLinesAnno_1"));
+                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
+                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("ParcelLinesAnno_1"));
 
                 // Create a map with the layers.
                 _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
@@ -45,7 +45,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado
-            _myMapView.Map = new Map(BasemapType.LightGrayCanvas, 39.7294, -104.8319, 9);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
 
             // Get the full path
             string geoPackagePath = GetGeoPackagePath();

--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
@@ -57,7 +57,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeodatabase
                 Geodatabase mobileGeodatabase = await Geodatabase.OpenAsync(mobileGeodatabaseFilePath);
 
                 // Get the 'Trailheads' geodatabase feature table from the mobile geodatabase.
-                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GeodatabaseFeatureTable("Trailheads");
+                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GetGeodatabaseFeatureTable("Trailheads");
 
                 // Asynchronously load the 'Trailheads' geodatabase feature table.
                 await trailheadsGeodatabaseFeatureTable.LoadAsync();

--- a/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
@@ -541,7 +541,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 SyncGeodatabaseJob job = syncTask.SyncGeodatabase(taskParameters, _localGeodatabase);
 
                 // Handle the JobChanged event for the job
-                job.JobChanged += (s, arg) =>
+                job.StatusChanged += (s, arg) =>
                 {
                     RunOnUiThread(() =>
                     {

--- a/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
@@ -253,7 +253,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                     GenerateGeodatabaseJob generateGdbJob = gdbTask.GenerateGeodatabase(gdbParams, localGeodatabasePath);
 
                     // Handle the job changed event and check the status of the job; store the geodatabase when it's ready
-                    generateGdbJob.JobChanged += (s, e) =>
+                    generateGdbJob.StatusChanged += (s, e) =>
                     {
                         // Call a function to update the progress bar
                         RunOnUiThread(() => UpdateProgressBar(generateGdbJob.Progress));

--- a/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
@@ -45,7 +45,8 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            _myMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.73, 11);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/Android/Xamarin.Android/Samples/Geometry/BufferList/BufferList.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/BufferList/BufferList.cs
@@ -137,7 +137,7 @@ namespace ArcGISRuntime.Samples.BufferList
         private void Initialize()
         {
             // Create a spatial reference that's suitable for creating planar buffers in north central Texas (State Plane).
-            SpatialReference statePlaneNorthCentralTexas = new SpatialReference(32038);
+            SpatialReference statePlaneNorthCentralTexas = SpatialReference.Create(32038);
 
             // Define a polygon that represents the valid area of use for the spatial reference.
             // This information is available at https://developers.arcgis.com/net/latest/wpf/guide/pdf/projected_coordinate_systems_rt100_3_0.pdf

--- a/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
@@ -62,7 +62,8 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         private void Initialize()
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
-            Map myMap = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 14);
+            Map myMap = new Map(BasemapStyle.ArcGISLightGray);
+            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Add the map to the map view.
             _myMapView.Map = myMap;

--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -63,7 +63,8 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         private void Initialize()
         {
             // Create a map with topographic basemap and an initial location
-            Map myMap = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
             // Hook into the MapView tapped event
             _myMapView.GeoViewTapped += MyMapView_GeoViewTapped;

--- a/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
+++ b/src/Android/Xamarin.Android/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
@@ -48,7 +48,8 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
         private void Initialize()
         {
             // Create the map
-            Map myMap = new Map(BasemapType.Oceans, 56.075844, -2.681572, 13);
+            Map myMap = new Map(BasemapStyle.ArcGISOceans);
+            myMap.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 14);
 
             // Add the map to the map view
             _myMapView.Map = myMap;

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
@@ -46,7 +46,8 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayKml/DisplayKml.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayKml/DisplayKml.cs
@@ -49,7 +49,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKml
         private void Initialize()
         {
             // Set up the basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
         }
 
         private void CreateLayout()

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
@@ -44,7 +44,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKmlNetworkLinks
         private void Initialize()
         {
             // Set up the basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create the dataset.
             KmlDataset dataset = new KmlDataset(new Uri("https://www.arcgis.com/sharing/rest/content/items/600748d4464442288f6db8a4ba27dc95/data"));

--- a/src/Android/Xamarin.Android/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.cs
@@ -52,7 +52,8 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");

--- a/src/Android/Xamarin.Android/Samples/Layers/ListKmlContents/ListKmlContents.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/ListKmlContents/ListKmlContents.cs
@@ -56,7 +56,7 @@ namespace ArcGISRuntimeXamarin.Samples.ListKmlContents
         private async void Initialize()
         {
             // Add a basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
             _mySceneView.Scene.BaseSurface.ElevationSources.Add(new ArcGISTiledElevationSource(new Uri("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")));
 
             // Get the URL to the data.

--- a/src/Android/Xamarin.Android/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
+++ b/src/Android/Xamarin.Android/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
@@ -119,7 +119,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
                 // Start the data source.
                 await _locationDataSource.StartAsync();
 
-                if (_locationDataSource.IsStarted)
+                if (_locationDataSource.Status == LocationDataSourceStatus.Started)
                 {
                     // Set the location display data source and enable location display.
                     _myMapView.LocationDisplay.DataSource = _locationDataSource;

--- a/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.cs
@@ -96,7 +96,7 @@ namespace ArcGISRuntime.Samples.GenerateOfflineMap
             _alertDialog = builder.Create();
             _alertDialog.SetButton("Cancel", (s, e) =>
             {
-                _generateOfflineMapJob.Cancel();
+                _generateOfflineMapJob.CancelAsync();
             });
         }
 

--- a/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.cs
@@ -102,7 +102,7 @@ namespace ArcGISRuntimeXamarin.Samples.GenerateOfflineMapWithOverrides
             builder.SetCancelable(true);
             builder.SetMessage("Generating offline map ...");
             _alertDialog = builder.Create();
-            _alertDialog.SetButton("Cancel", (s, e) => { _generateOfflineMapJob.Cancel(); });
+            _alertDialog.SetButton("Cancel", (s, e) => { _generateOfflineMapJob.CancelAsync(); });
         }
 
         private async void Initialize()

--- a/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMapWithOverrides/ParameterOverrideFragment.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/GenerateOfflineMapWithOverrides/ParameterOverrideFragment.cs
@@ -13,7 +13,9 @@ using System.Linq;
 
 namespace ArcGISRuntime.Samples.GenerateOfflineMapWithOverrides
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class ParameterOverrideFragment : DialogFragment
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         // Hold references to the overrides, map, and area of interest.
         private GenerateOfflineMapParameterOverrides _overrides;

--- a/src/Android/Xamarin.Android/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.cs
@@ -304,7 +304,7 @@ namespace ArcGISRuntimeXamarin.Samples.OfflineBasemapByReference
             builder.SetCancelable(true);
             builder.SetMessage("Generating offline map ...");
             _alertDialog = builder.Create();
-            _alertDialog.SetButton("Cancel", (s, e) => { _generateOfflineMapJob?.Cancel(); });
+            _alertDialog.SetButton("Cancel", (s, e) => { _generateOfflineMapJob?.CancelAsync(); });
         }
 
         #endregion Generate offline map

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
@@ -41,7 +41,8 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
         private void Initialize()
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 16);
+            Map myMap = new Map(BasemapStyle.ArcGISImagery);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
 
             // Provide used Map to the MapView
             _myMapView.Map = myMap;

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -27,7 +27,7 @@
         "/net/latest/android/sample-code/setinitialmaplocation.htm"
     ],
     "relevant_apis": [
-        "BasemapType",
+        "BasemapStyle",
         "Map",
         "MapView"
     ],

--- a/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -53,7 +53,8 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
             _myMapView.DrawStatusChanged += OnDrawStatusChanged;
 
             // Create new Map with basemap
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // Create uri to the used feature service
             Uri serviceUri = new Uri(

--- a/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -41,7 +41,8 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         private void Initialize()
         {
             // Create new Map with basemap and initial location
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
             // Enable the ability to interact with the map view (including enabling the magnifier) 
             _myMapView.InteractionOptions = new Esri.ArcGISRuntime.UI.MapViewInteractionOptions

--- a/src/Android/Xamarin.Android/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.cs
+++ b/src/Android/Xamarin.Android/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.cs
@@ -90,7 +90,7 @@ namespace ArcGISRuntimeXamarin.Samples.GetElevationAtPoint
             Camera camera = new Camera(_observerPoint, 20000.0, 10.0, 70.0, 0.0);
 
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 // Set the initial viewpoint.
                 InitialViewpoint = new Viewpoint(_observerPoint, 1000000, camera)

--- a/src/Android/Xamarin.Android/Samples/Scene/TerrainExaggeration/TerrainExaggeration.cs
+++ b/src/Android/Xamarin.Android/Samples/Scene/TerrainExaggeration/TerrainExaggeration.cs
@@ -47,7 +47,7 @@ namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
         private void Initialize()
         {
             // Configure the scene with National Geographic basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateTopographic());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISTopographic);
 
             // Add the base surface for elevation data.
             Surface elevationSurface = new Surface();

--- a/src/Android/Xamarin.Android/Samples/SceneView/ChooseCameraController/ChooseCameraController.cs
+++ b/src/Android/Xamarin.Android/Samples/SceneView/ChooseCameraController/ChooseCameraController.cs
@@ -65,7 +65,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChooseCameraController
         private async void Initialize()
         {
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels());
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create a surface for elevation data.
             Surface surface = new Surface();

--- a/src/Android/Xamarin.Android/Samples/SceneView/GeoViewSync/GeoViewSync.cs
+++ b/src/Android/Xamarin.Android/Samples/SceneView/GeoViewSync/GeoViewSync.cs
@@ -47,7 +47,7 @@ namespace ArcGISRuntime.Samples.GeoViewSync
         {
             // Initialize the MapView and SceneView with a basemap
             _myMapView.Map = new Map(BasemapStyle.ArcGISImagery);
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
             //     animation on one view from competing with user interaction on the other

--- a/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
                 myFeatureLayer.Renderer = mySimpleRenderer;
 
                 // Create a new scene with the topographic backdrop 
-                Scene myScene = new Scene(BasemapType.Topographic);
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
                 // Set the scene view's scene to the newly create one
                 _mySceneView.Scene = myScene;

--- a/src/Android/Xamarin.Android/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.cs
+++ b/src/Android/Xamarin.Android/Samples/Symbology/SymbolsFromMobileStyle/SymbolsFromMobileStyle.cs
@@ -394,7 +394,7 @@ namespace ArcGISRuntime.Samples.SymbolsFromMobileStyle
             }
 
             // Show a preview of the current symbol (created previously or the default face).
-            UpdateSymbol();
+            _ = UpdateSymbol();
 
             // Return the new view for display.
             return dialogView;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
@@ -117,9 +117,6 @@
     <SDKReference Include="Microsoft.VCLibs, version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="Microsoft.VCLibs, version=14.0">
-      <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
-    </SDKReference>
   </ItemGroup>
   <ItemGroup>
     <!-- Screenshots -->

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.xaml.cs
@@ -52,7 +52,7 @@ namespace ArcGISRuntime.UWP.Samples.DistanceMeasurement
             // Create a scene with elevation.
             Surface sceneSurface = new Surface();
             sceneSurface.ElevationSources.Add(new ArcGISTiledElevationSource(_worldElevationService));
-            Scene myScene = new Scene(Basemap.CreateTopographic())
+            Scene myScene = new Scene(BasemapStyle.ArcGISTopographic)
             {
                 BaseSurface = sceneSurface
             };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.xaml.cs
@@ -71,7 +71,7 @@ namespace ArcGISRuntime.UWP.Samples.LineOfSightGeoElement
         private async void Initialize()
         {
             // Create scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 InitialViewpoint = new Viewpoint(_observerPoint, 1600)
             };

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Analysis/ViewshedGeoElement/ViewshedGeoElement.xaml.cs
@@ -42,8 +42,8 @@ namespace ArcGISRuntime.UWP.Samples.ViewshedGeoElement
         private MapPoint _tankEndPoint;
 
         // Units for geodetic calculation (used in animating tank)
-        private readonly LinearUnit _metersUnit = (LinearUnit)Unit.FromUnitId(9001);
-        private readonly AngularUnit _degreesUnit = (AngularUnit)Unit.FromUnitId(9102);
+        private readonly LinearUnit _metersUnit = (LinearUnit)Unit.FromWkid(9001);
+        private readonly AngularUnit _degreesUnit = (AngularUnit)Unit.FromWkid(9102);
 
         public ViewshedGeoElement()
         {

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.xaml.cs
@@ -48,12 +48,12 @@ namespace ArcGISRuntime.UWP.Samples.EditFeatureLinkedAnnotation
                 Geodatabase geodatabase = await Geodatabase.OpenAsync(geodatabasePath);
 
                 // Create feature layers from tables in the geodatabase.
-                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("Loudoun_Address_Points_1"));
-                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("ParcelLines_1"));
+                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("Loudoun_Address_Points_1"));
+                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("ParcelLines_1"));
 
                 // Create annotation layers from tables in the geodatabase.
-                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
-                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("ParcelLinesAnno_1"));
+                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
+                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("ParcelLinesAnno_1"));
 
                 // Create a map with the layers.
                 MyMapView.Map = new Map(BasemapStyle.ArcGISLightGray);

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.xaml.cs
@@ -36,7 +36,8 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado
-            MyMapView.Map = new Map(BasemapType.LightGrayCanvasVector, 39.7294, -104.8319, 9);
+            MyMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
 
             // Get the full path
             string geoPackagePath = GetGeoPackagePath();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerGeodatabase
                 Geodatabase mobileGeodatabase = await Geodatabase.OpenAsync(mobileGeodatabaseFilePath);
 
                 // Get the 'Trailheads' geodatabase feature table from the mobile geodatabase.
-                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GeodatabaseFeatureTable("Trailheads");
+                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GetGeodatabaseFeatureTable("Trailheads");
 
                 // Asynchronously load the 'Trailheads' geodatabase feature table.
                 await trailheadsGeodatabaseFeatureTable.LoadAsync();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.xaml.cs
@@ -99,7 +99,7 @@ namespace ArcGISRuntime.UWP.Samples.GeodatabaseTransactions
                     GenerateGeodatabaseJob generateGdbJob = gdbTask.GenerateGeodatabase(gdbParams, localGeodatabasePath);
 
                     // Handle the job changed event and check the status of the job; store the geodatabase when it's ready
-                    generateGdbJob.JobChanged += async (s, e) =>
+                    generateGdbJob.StatusChanged += async (s, e) =>
                     {
                         // See if the job succeeded
                         if (generateGdbJob.Status == JobStatus.Succeeded)
@@ -357,7 +357,7 @@ namespace ArcGISRuntime.UWP.Samples.GeodatabaseTransactions
                 SyncGeodatabaseJob job = syncTask.SyncGeodatabase(taskParameters, _localGeodatabase);
 
                 // Handle the JobChanged event for the job
-                job.JobChanged += async (s, arg) =>
+                job.StatusChanged += async (s, arg) =>
                 {
                     // Report changes in the job status
                     if (job.Status == JobStatus.Succeeded)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -34,7 +34,8 @@ namespace ArcGISRuntime.UWP.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            MyMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.73, 11);
+            MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/BufferList/BufferList.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/BufferList/BufferList.xaml.cs
@@ -45,7 +45,7 @@ namespace ArcGISRuntime.UWP.Samples.BufferList
         private void Initialize()
         {
             // Create a spatial reference that's suitable for creating planar buffers in north central Texas (State Plane).
-            SpatialReference statePlaneNorthCentralTexas = new SpatialReference(32038);
+            SpatialReference statePlaneNorthCentralTexas = SpatialReference.Create(32038);
 
             // Define a polygon that represents the valid area of use for the spatial reference.
             // This information is available at https://developers.arcgis.com/net/latest/wpf/guide/pdf/projected_coordinate_systems_rt100_3_0.pdf

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -45,7 +45,8 @@ namespace ArcGISRuntime.UWP.Samples.SpatialOperations
         private void Initialize()
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
-            Map spatialOperationsMap = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 15);
+            Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -71,7 +71,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeHotspots
         {
             // Cancel current geoprocessing job
             if (_hotspotJob.Status == JobStatus.Started)
-                _hotspotJob.Cancel();
+                _hotspotJob.CancelAsync();
 
             // Hide the BusyOverlay indication
             ShowBusyOverlay(false);

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -56,7 +56,8 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
         private void Initialize()
         {
             // Create a map with topographic basemap and an initial location
-            Map myMap = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
             // Hook into the tapped event
             MyMapView.GeoViewTapped += OnMapViewTapped;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.xaml.cs
@@ -36,7 +36,8 @@ namespace ArcGISRuntime.UWP.Samples.AddGraphicsWithSymbols
         private void Initialize()
         {
             // Create the map
-            Map myMap = new Map(BasemapType.Oceans, 56.075844, -2.681572, 13);
+            Map myMap = new Map(BasemapStyle.ArcGISOceans);
+            myMap.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 14);
 
             // Add the map to the map view
             MyMapView.Map = myMap;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -43,7 +43,8 @@ namespace ArcGISRuntime.UWP.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayKml/DisplayKml.xaml.cs
@@ -37,7 +37,7 @@ namespace ArcGISRuntime.UWP.Samples.DisplayKml
         private void Initialize()
         {
             // Set up the basemap.
-            MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Update the UI.
             LayerPicker.IsEnabled = true;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.UWP.Samples.DisplayKmlNetworkLinks
         private void Initialize()
         {
             // Set up the basemap.
-            MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create the dataset.
             KmlDataset dataset = new KmlDataset(new Uri("https://www.arcgis.com/sharing/rest/content/items/600748d4464442288f6db8a4ba27dc95/data"));

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.xaml.cs
@@ -49,7 +49,8 @@ namespace ArcGISRuntime.UWP.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/ListKmlContents/ListKmlContents.xaml.cs
@@ -41,7 +41,7 @@ namespace ArcGISRuntime.UWP.Samples.ListKmlContents
         private async void Initialize()
         {
             // Add a basemap.
-            MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
             MySceneView.Scene.BaseSurface.ElevationSources.Add(new ArcGISTiledElevationSource(new Uri("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")));
 
             // Get the URL to the data.

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -99,7 +99,7 @@ namespace ArcGISRuntime.UWP.Samples.ShowLocationHistory
                 // Start the data source.
                 await _locationDataSource.StartAsync();
 
-                if (_locationDataSource.IsStarted)
+                if (_locationDataSource.Status == LocationDataSourceStatus.Started)
                 {
                     // Set the location display data source and enable location display.
                     MyMapView.LocationDisplay.DataSource = _locationDataSource;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/GenerateOfflineMap/GenerateOfflineMap.xaml.cs
@@ -223,7 +223,7 @@ namespace ArcGISRuntime.UWP.Samples.GenerateOfflineMap
         private void CancelJobButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // The user canceled the job.
-            _generateOfflineMapJob.Cancel();
+            _generateOfflineMapJob.CancelAsync();
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/GenerateOfflineMapWithOverrides/GenerateOfflineMapWithOverrides.xaml.cs
@@ -373,7 +373,7 @@ namespace ArcGISRuntime.UWP.Samples.GenerateOfflineMapWithOverrides
         private void CancelJobButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // The user canceled the job.
-            _generateOfflineMapJob.Cancel();
+            _generateOfflineMapJob.CancelAsync();
         }
     }
 }

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/OfflineBasemapByReference/OfflineBasemapByReference.xaml.cs
@@ -264,7 +264,7 @@ namespace ArcGISRuntime.UWP.Samples.OfflineBasemapByReference
         private void CancelJobButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // The user canceled the job.
-            _generateOfflineMapJob.Cancel();
+            _generateOfflineMapJob.CancelAsync();
         }
 
         #endregion Generate offline map

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -30,7 +30,8 @@ namespace ArcGISRuntime.UWP.Samples.SetInitialMapLocation
         private void Initialize()
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location
-            Map myMap = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 16);
+            Map myMap = new Map(BasemapStyle.ArcGISImagery);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
 
             // Assign the map to the MapView
             MyMapView.Map = myMap;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -27,7 +27,7 @@
         "/net/latest/uwp/sample-code/setinitialmaplocation.htm"
     ],
     "relevant_apis": [
-        "BasemapType",
+        "BasemapStyle",
         "Map",
         "MapView"
     ],

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -37,7 +37,8 @@ namespace ArcGISRuntime.UWP.Samples.DisplayDrawingStatus
             MyMapView.DrawStatusChanged += OnDrawStatusChanged;
 
             // Create new Map with a topographic basemap.
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL pointing to a feature service.
             Uri serviceUri =

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -30,7 +30,8 @@ namespace ArcGISRuntime.UWP.Samples.ShowMagnifier
         private void Initialize()
         {
             // Create new Map with basemap and initial location
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
             // Enable magnifier
             MyMapView.InteractionOptions = new MapViewInteractionOptions

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.xaml.cs
@@ -60,7 +60,7 @@ namespace ArcGISRuntime.UWP.Samples.GetElevationAtPoint
             Camera camera = new Camera(_observerPoint, 20000.0, 10.0, 70.0, 0.0);
 
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 // Set the initial viewpoint.
                 InitialViewpoint = new Viewpoint(_observerPoint, 1000000, camera)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Scene/TerrainExaggeration/TerrainExaggeration.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.UWP.Samples.TerrainExaggeration
         private void Initialize()
         {
             // Configure the scene with National Geographic basemap.
-            MySceneView.Scene = new Scene(Basemap.CreateTopographic());
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISTopographic);
 
             // Add the base surface for elevation data.
             Surface elevationSurface = new Surface();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/SceneView/ChooseCameraController/ChooseCameraController.xaml.cs
@@ -52,7 +52,7 @@ namespace ArcGISRuntime.UWP.Samples.ChooseCameraController
         private async void Initialize()
         {
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels());
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create a surface for elevation data.
             Surface surface = new Surface();

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/SceneView/GeoViewSync/GeoViewSync.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/SceneView/GeoViewSync/GeoViewSync.xaml.cs
@@ -34,7 +34,7 @@ namespace ArcGISRuntime.UWP.Samples.GeoViewSync
         {
             // Initialize the MapView and SceneView with a basemap
             MyMapView.Map = new Map(BasemapStyle.ArcGISImagery);
-            MySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
             //     animation on one view from competing with user interaction on the other

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.UWP.Samples.FindPlace
             SearchViewButton.IsEnabled = true;
         }
 
-        private async void LocationDisplay_LocationChanged(object sender, Esri.ArcGISRuntime.Location.Location e)
+        private void LocationDisplay_LocationChanged(object sender, Esri.ArcGISRuntime.Location.Location e)
         {
             // Return if position is null; event is raised with null location after
             if (e.Position == null) { return; }
@@ -88,7 +88,7 @@ namespace ArcGISRuntime.UWP.Samples.FindPlace
             ((LocationDisplay)sender).LocationChanged -= LocationDisplay_LocationChanged;
 
             // Zoom to the location.
-            MyMapView.SetViewpointCenterAsync(e.Position, 100000);
+            _ = MyMapView.SetViewpointCenterAsync(e.Position, 100000);
         }
 
         /// <summary>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Security/CertificateAuthenticationWithPki/CertificateAuthenticationWithPKI.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Security/CertificateAuthenticationWithPki/CertificateAuthenticationWithPKI.xaml.cs
@@ -76,10 +76,7 @@ namespace ArcGISRuntime.UWP.Samples.CertificateAuthenticationWithPKI
                     X509Certificate2 cert = (X509Certificate2) listview.SelectedItem;
 
                     // Create a new CertificateCredential using the chosen certificate.
-                    credential = new Esri.ArcGISRuntime.Security.CertificateCredential(cert)
-                    {
-                        ServiceUri = new Uri(_serverUrl)
-                    };
+                    credential = new CertificateCredential(new Uri(_serverUrl), cert);
                 }
             }
             catch (Exception ex)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.xaml.cs
@@ -73,7 +73,7 @@ namespace ArcGISRuntime.UWP.Samples.FeatureLayerExtrusion
                 censusLayer.Renderer = layerRenderer;
 
                 // Create a new scene with the topographic backdrop 
-                Scene myScene = new Scene(BasemapType.Topographic);
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
                 // Set the scene view's scene to the newly create one
                 MySceneView.Scene = myScene;

--- a/src/iOS/Xamarin.iOS/Helpers/ApplicationTheme.cs
+++ b/src/iOS/Xamarin.iOS/Helpers/ApplicationTheme.cs
@@ -30,8 +30,8 @@ namespace ArcGISRuntime
             // Check if the device is running iOS 13 or higher. iOS 13 is required to use these UIColor values at runtime in code.
             if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
             {
-                BackgroundColor = UIColor.SystemBackgroundColor;
-                ForegroundColor = UIColor.LabelColor;
+                BackgroundColor = UIColor.SystemBackground;
+                ForegroundColor = UIColor.Label;
             }
             else
             {

--- a/src/iOS/Xamarin.iOS/Main.cs
+++ b/src/iOS/Xamarin.iOS/Main.cs
@@ -18,7 +18,7 @@ namespace ArcGISRuntime
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }

--- a/src/iOS/Xamarin.iOS/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Analysis/DistanceMeasurement/DistanceMeasurement.cs
@@ -51,7 +51,7 @@ namespace ArcGISRuntime.Samples.DistanceMeasurement
             // Create a scene with elevation.
             Surface sceneSurface = new Surface();
             sceneSurface.ElevationSources.Add(new ArcGISTiledElevationSource(_worldElevationService));
-            Scene myScene = new Scene(Basemap.CreateTopographic())
+            Scene myScene = new Scene(BasemapStyle.ArcGISTopographic)
             {
                 BaseSurface = sceneSurface
             };

--- a/src/iOS/Xamarin.iOS/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Analysis/LineOfSightGeoElement/LineOfSightGeoElement.cs
@@ -79,7 +79,7 @@ namespace ArcGISRuntime.Samples.LineOfSightGeoElement
         private async void Initialize()
         {
             // Create scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 // Set initial viewpoint.
                 InitialViewpoint = new Viewpoint(_observerPoint, 1600)

--- a/src/iOS/Xamarin.iOS/Samples/AugmentedReality/NavigateAR/RouteViewerAR.cs
+++ b/src/iOS/Xamarin.iOS/Samples/AugmentedReality/NavigateAR/RouteViewerAR.cs
@@ -199,7 +199,7 @@ namespace ArcGISRuntimeXamarin.Samples.NavigateAR
             _navigateButton.Enabled = false;
 
             // Configure the route tracker.
-            _routeTracker = new RouteTracker(_routeResult, 0);
+            _routeTracker = new RouteTracker(_routeResult, 0, true);
             _routeTracker.NewVoiceGuidance += TrackingDataSource_VoiceGuidanceChanged;
             _routeTracker.TrackingStatusChanged += TrackingDataSource_StatusChanged;
         }

--- a/src/iOS/Xamarin.iOS/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/EditFeatureLinkedAnnotation/EditFeatureLinkedAnnotation.cs
@@ -54,12 +54,12 @@ namespace ArcGISRuntimeXamarin.Samples.EditFeatureLinkedAnnotation
                 Geodatabase geodatabase = await Geodatabase.OpenAsync(geodatabasePath);
 
                 // Create feature layers from tables in the geodatabase.
-                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("Loudoun_Address_Points_1"));
-                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GeodatabaseFeatureTable("ParcelLines_1"));
+                FeatureLayer addressFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("Loudoun_Address_Points_1"));
+                FeatureLayer parcelFeatureLayer = new FeatureLayer(geodatabase.GetGeodatabaseFeatureTable("ParcelLines_1"));
 
                 // Create annotation layers from tables in the geodatabase.
-                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
-                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GeodatabaseAnnotationTable("ParcelLinesAnno_1"));
+                AnnotationLayer addressAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("Loudoun_Address_PointsAnno_1"));
+                AnnotationLayer parcelAnnotationLayer = new AnnotationLayer(geodatabase.GetGeodatabaseAnnotationTable("ParcelLinesAnno_1"));
 
                 // Create a map with the layers.
                 _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeoPackage/FeatureLayerGeoPackage.cs
@@ -39,7 +39,8 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            _myMapView.Map = new Map(BasemapType.LightGrayCanvasVector, 39.7294, -104.8319, 9);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.8319, 9);
 
             // Get the full path.
             string geoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerGeodatabase/FeatureLayerGeodatabase.cs
@@ -49,7 +49,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerGeodatabase
                 Geodatabase mobileGeodatabase = await Geodatabase.OpenAsync(mobileGeodatabaseFilePath);
 
                 // Get the 'Trailheads' geodatabase feature table from the mobile geodatabase.
-                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GeodatabaseFeatureTable("Trailheads");
+                GeodatabaseFeatureTable trailheadsGeodatabaseFeatureTable = mobileGeodatabase.GetGeodatabaseFeatureTable("Trailheads");
 
                 // Asynchronously load the 'Trailheads' geodatabase feature table.
                 await trailheadsGeodatabaseFeatureTable.LoadAsync();

--- a/src/iOS/Xamarin.iOS/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/GenerateGeodatabase/GenerateGeodatabase.cs
@@ -364,7 +364,7 @@ namespace ArcGISRuntime.Samples.GenerateGeodatabase
             // Unsubscribe from events, per best practice.
             if (_generateGdbJob != null)
             {
-                _generateGdbJob.Cancel();
+                _generateGdbJob.CancelAsync();
                 _generateGdbJob.ProgressChanged -= GenerateGdbJob_ProgressChanged;
             }
 

--- a/src/iOS/Xamarin.iOS/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/GeodatabaseTransactions/GeodatabaseTransactions.cs
@@ -118,7 +118,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                     GenerateGeodatabaseJob generateGdbJob = gdbTask.GenerateGeodatabase(gdbParams, localGeodatabasePath);
 
                     // Handle the job changed event and check the status of the job; store the geodatabase when it's ready.
-                    void GenerateGdbJob_JobChanged(object jobSender, EventArgs e)
+                    void GenerateGdbJob_JobStatusChanged(object jobSender, JobStatus e)
                     {
                         // Call a function to update the progress bar.
                         InvokeOnMainThread(() => UpdateProgressBar(generateGdbJob.Progress));
@@ -128,7 +128,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                             // See if the job succeeded.
                             case JobStatus.Succeeded:
                                 // Unsubscribe from event.
-                                generateGdbJob.JobChanged -= GenerateGdbJob_JobChanged;
+                                generateGdbJob.StatusChanged -= GenerateGdbJob_JobStatusChanged;
 
                                 InvokeOnMainThread(() =>
                                 {
@@ -139,7 +139,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                                 break;
                             case JobStatus.Failed:
                                 // Unsubscribe from event.
-                                generateGdbJob.JobChanged -= GenerateGdbJob_JobChanged;
+                                generateGdbJob.StatusChanged -= GenerateGdbJob_JobStatusChanged;
 
                                 InvokeOnMainThread(() =>
                                 {
@@ -152,7 +152,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                     }
 
                     // Subscribe to job change event.
-                    generateGdbJob.JobChanged += GenerateGdbJob_JobChanged;
+                    generateGdbJob.StatusChanged += GenerateGdbJob_JobStatusChanged;
 
                     // Start the generate geodatabase job.
                     _localGeodatabase = await generateGdbJob.GetResultAsync();
@@ -378,7 +378,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 // Create a synchronize geodatabase job, pass in the parameters and the geodatabase.
                 SyncGeodatabaseJob job = syncTask.SyncGeodatabase(taskParameters, _localGeodatabase);
 
-                void Job_JobChanged(object sendingJob, EventArgs args)
+                void Job_JobStatusChanged(object sendingJob, JobStatus args)
                 {
                     InvokeOnMainThread(() =>
                     {
@@ -390,14 +390,14 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                             // Report changes in the job status.
                             case JobStatus.Succeeded:
                                 // Unsubscribe
-                                ((SyncGeodatabaseJob) sendingJob).JobChanged -= Job_JobChanged;
+                                ((SyncGeodatabaseJob) sendingJob).StatusChanged -= Job_JobStatusChanged;
                                 // Report success.
                                 _statusLabel.Text = "Synchronization is complete!";
                                 _progressBar.Hidden = true;
                                 break;
                             case JobStatus.Failed:
                                 // Unsubscribe
-                                ((SyncGeodatabaseJob) sendingJob).JobChanged -= Job_JobChanged;
+                                ((SyncGeodatabaseJob) sendingJob).StatusChanged -= Job_JobStatusChanged;
                                 // Report failure.
                                 _statusLabel.Text = job.Error.Message;
                                 _progressBar.Hidden = true;
@@ -410,7 +410,7 @@ namespace ArcGISRuntime.Samples.GeodatabaseTransactions
                 }
 
                 // Handle the JobChanged event for the job.
-                job.JobChanged += Job_JobChanged;
+                job.StatusChanged += Job_JobStatusChanged;
 
                 // Await the completion of the job.
                 await job.GetResultAsync();

--- a/src/iOS/Xamarin.iOS/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
@@ -53,7 +53,8 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         private async void Initialize()
         {
             // Create a new map centered on Aurora Colorado.
-            _myMapView.Map = new Map(BasemapType.Streets, 39.7294, -104.8319, 11);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISStreets);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
 
             // Get the full path to the GeoPackage on the device.
             string geoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/iOS/Xamarin.iOS/Samples/Geometry/BufferList/BufferList.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geometry/BufferList/BufferList.cs
@@ -51,7 +51,7 @@ namespace ArcGISRuntime.Samples.BufferList
         private void Initialize()
         {
             // Create a spatial reference that's suitable for creating planar buffers in north central Texas (State Plane).
-            SpatialReference statePlaneNorthCentralTexas = new SpatialReference(32038);
+            SpatialReference statePlaneNorthCentralTexas = SpatialReference.Create(32038);
 
             // Define a polygon that represents the valid area of use for the spatial reference.
             // This information is available at https://developers.arcgis.com/net/latest/wpf/guide/pdf/projected_coordinate_systems_rt100_3_0.pdf

--- a/src/iOS/Xamarin.iOS/Samples/Geometry/SpatialOperations/SpatialOperations.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geometry/SpatialOperations/SpatialOperations.cs
@@ -52,7 +52,8 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         private void Initialize()
         {
             // Create and show a map with a gray canvas basemap and an initial location centered on London, UK.
-            _myMapView.Map = new Map(BasemapType.LightGrayCanvas, 51.5017, -0.12714, 14);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
 
             // Create and add two overlapping polygon graphics to operate on.
             CreatePolygonsOverlay();

--- a/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -53,7 +53,8 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         private void Initialize()
         {
             // Create and show a map with topographic basemap and an initial location.
-            _myMapView.Map = new Map(BasemapType.Topographic, 45.3790902612337, 6.84905317262762, 13);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISTopographic);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
 
             // Create empty overlays for the user clicked location and the results of the viewshed analysis.
             CreateOverlays();

--- a/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
+++ b/src/iOS/Xamarin.iOS/Samples/GraphicsOverlay/AddGraphicsWithSymbols/AddGraphicsWithSymbols.cs
@@ -41,7 +41,8 @@ namespace ArcGISRuntime.Samples.AddGraphicsWithSymbols
         private void Initialize()
         {
             // Add the map to the map view.
-            _myMapView.Map = new Map(BasemapType.Oceans, 56.075844, -2.681572, 13);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISOceans);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(56.075844, -2.681572, 14);
 
             // Add the graphics overlay to the map view.
             _myMapView.GraphicsOverlays.Add(_overlay);

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
@@ -41,7 +41,8 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
             Uri riverFeatureLayerUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/RiversAnnotation/FeatureServer/0");
 
             // Create a map.
-            Map map = new Map(BasemapType.LightGrayCanvasVector, 55.882436, -2.725610, 13);
+            Map map = new Map(BasemapStyle.ArcGISLightGray);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplayKml/DisplayKml.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplayKml/DisplayKml.cs
@@ -44,7 +44,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKml
         private void Initialize()
         {
             // Set up the basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
         }
 
         private async void DataChoiceButtonOnValueChanged(object sender, EventArgs e)

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplayKmlNetworkLinks/DisplayKmlNetworkLinks.cs
@@ -41,7 +41,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayKmlNetworkLinks
         private void Initialize()
         {
             // Set up the basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create the dataset.
             _dataset = new KmlDataset(new Uri("https://www.arcgis.com/sharing/rest/content/items/600748d4464442288f6db8a4ba27dc95/data"));

--- a/src/iOS/Xamarin.iOS/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/IdentifyRasterCell/IdentifyRasterCell.cs
@@ -46,7 +46,8 @@ namespace ArcGISRuntimeXamarin.Samples.IdentifyRasterCell
         private async void Initialize()
         {
             // Define a new map with Wgs84 Spatial Reference.
-            var map = new Map(BasemapType.Oceans, latitude: -34.1, longitude: 18.6, levelOfDetail: 9);
+            var map = new Map(BasemapStyle.ArcGISOceans);
+            map.InitialViewpoint = new Viewpoint(-34.1, 18.6, 9);
 
             // Get the file name for the raster.
             string filepath = DataManager.GetDataFolder("b5f977c78ec74b3a8857ca86d1d9b318", "SA_EVI_8Day_03May20.tif");

--- a/src/iOS/Xamarin.iOS/Samples/Layers/ListKmlContents/ListKmlContents.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/ListKmlContents/ListKmlContents.cs
@@ -48,7 +48,7 @@ namespace ArcGISRuntimeXamarin.Samples.ListKmlContents
         private async void Initialize()
         {
             // Add a basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
             _mySceneView.Scene.BaseSurface.ElevationSources.Add(new ArcGISTiledElevationSource(new Uri("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer")));
 
             // Get the URL to the data.

--- a/src/iOS/Xamarin.iOS/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Location/ShowLocationHistory/ShowLocationHistory.cs
@@ -104,7 +104,7 @@ namespace ArcGISRuntimeXamarin.Samples.ShowLocationHistory
                 // Start the data source.
                 await _locationDataSource.StartAsync();
 
-                if (_locationDataSource.IsStarted)
+                if (_locationDataSource.Status == LocationDataSourceStatus.Started)
                 {
                     // Set the location display data source and enable location display.
                     _myMapView.LocationDisplay.DataSource = _locationDataSource;

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
@@ -34,7 +34,8 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
         private void Initialize()
         {
             // Show a map with 'Imagery with Labels' basemap and an initial location.
-            _myMapView.Map = new Map(BasemapType.ImageryWithLabels, -33.867886, -63.985, 16);
+            _myMapView.Map = new Map(BasemapStyle.ArcGISImagery);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
         }
 
         public override void ViewDidLoad()

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/readme.md
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/readme.md
@@ -19,7 +19,7 @@ When the map loads, note the specific location and scale of the initial map view
 
 ## Relevant API
 
-* BasemapType
+* BasemapStyle
 * Map
 * MapView
 

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/readme.metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/readme.metadata.json
@@ -27,7 +27,7 @@
         "/net/latest/ios/sample-code/setinitialmaplocation.htm"
     ],
     "relevant_apis": [
-        "BasemapType",
+        "BasemapStyle",
         "Map",
         "MapView"
     ],

--- a/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -39,7 +39,8 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
         private async void Initialize()
         {
             // Create new Map with basemap.
-            Map myMap = new Map(BasemapType.Topographic, 34.056, -117.196, 4);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL to the feature service.
             Uri serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");

--- a/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -35,7 +35,8 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         private void Initialize()
         {
             // Create new Map with basemap and initial location.
-            Map myMap = new Map(BasemapType.Topographic, 34.056295, -117.195800, 10);
+            Map myMap = new Map(BasemapStyle.ArcGISTopographic);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
 
             // Enable magnifier.
             _myMapView.InteractionOptions = new MapViewInteractionOptions

--- a/src/iOS/Xamarin.iOS/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Scene/GetElevationAtPoint/GetElevationAtPoint.cs
@@ -62,7 +62,7 @@ namespace ArcGISRuntimeXamarin.Samples.GetElevationAtPoint
             Camera camera = new Camera(_observerPoint, 20000.0, 10.0, 70.0, 0.0);
 
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels())
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery)
             {
                 // Set the initial viewpoint.
                 InitialViewpoint = new Viewpoint(_observerPoint, 1000000, camera)

--- a/src/iOS/Xamarin.iOS/Samples/Scene/TerrainExaggeration/TerrainExaggeration.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Scene/TerrainExaggeration/TerrainExaggeration.cs
@@ -43,7 +43,7 @@ namespace ArcGISRuntimeXamarin.Samples.TerrainExaggeration
         private void Initialize()
         {
             // Configure the scene with National Geographic basemap.
-            _mySceneView.Scene = new Scene(Basemap.CreateTopographic());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISTopographic);
 
             // Add the base surface for elevation data.
             _elevationSurface = new Surface();

--- a/src/iOS/Xamarin.iOS/Samples/SceneView/ChooseCameraController/ChooseCameraController.cs
+++ b/src/iOS/Xamarin.iOS/Samples/SceneView/ChooseCameraController/ChooseCameraController.cs
@@ -59,7 +59,7 @@ namespace ArcGISRuntimeXamarin.Samples.ChooseCameraController
         private async void Initialize()
         {
             // Create a scene.
-            Scene myScene = new Scene(Basemap.CreateImageryWithLabels());
+            Scene myScene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Create a surface for elevation data.
             Surface surface = new Surface();

--- a/src/iOS/Xamarin.iOS/Samples/SceneView/GeoViewSync/GeoViewSync.cs
+++ b/src/iOS/Xamarin.iOS/Samples/SceneView/GeoViewSync/GeoViewSync.cs
@@ -39,7 +39,7 @@ namespace ArcGISRuntime.Samples.GeoViewSync
         {
             // Initialize the MapView and SceneView with basemaps.
             _myMapView.Map = new Map(BasemapStyle.ArcGISImagery);
-            _mySceneView.Scene = new Scene(Basemap.CreateImageryWithLabels());
+            _mySceneView.Scene = new Scene(BasemapStyle.ArcGISImagery);
 
             // Disable 'flick' gesture - this is the most straightforward way to prevent the 'flick'
             //     animation on one view from competing with user interaction on the other.

--- a/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.cs
@@ -535,7 +535,7 @@ namespace ArcGISRuntimeXamarin.Samples.IntegratedWindowsAuth
                 string.IsNullOrEmpty(password) ||
                 string.IsNullOrEmpty(domain))
             {
-                new UIAlertView("Login", "Please enter a username, password, and domain", null, "OK", null).Show();
+                new UIAlertView("Login", "Please enter a username, password, and domain", (IUIAlertViewDelegate)null, "OK", null).Show();
                 return;
             }
 

--- a/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Security/IntegratedWindowsAuth/IntegratedWindowsAuth.cs
@@ -382,11 +382,7 @@ namespace ArcGISRuntimeXamarin.Samples.IntegratedWindowsAuth
                 var netCred = new System.Net.NetworkCredential(e.Username, e.Password, e.Domain);
 
                 // Create a new ArcGIS network credential to hold the network credential and service URI.
-                var arcgisCred = new ArcGISNetworkCredential
-                {
-                    Credentials = netCred,
-                    ServiceUri = requestInfo.ServiceUri
-                };
+                var arcgisCred = new ArcGISNetworkCredential(requestInfo.ServiceUri, netCred);
 
                 // Set the task completion source result with the ArcGIS network credential.
                 // AuthenticationManager is waiting for this result and will add it to its Credentials collection.

--- a/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Symbology/FeatureLayerExtrusion/FeatureLayerExtrusion.cs
@@ -77,7 +77,7 @@ namespace ArcGISRuntime.Samples.FeatureLayerExtrusion
                 censusFeatureLayer.Renderer = renderer;
 
                 // Create a new scene with a topographic basemap.
-                Scene myScene = new Scene(BasemapType.Topographic);
+                Scene myScene = new Scene(BasemapStyle.ArcGISTopographic);
 
                 // Set the scene view's scene to the newly create one.
                 _mySceneView.Scene = myScene;


### PR DESCRIPTION
# Description

This PR removes many warnings on legacy samples platforms, mostly related to Runtime deprecations.
Main changes:
- Removing use of `Basemap.Create`
- Removing use of `BasemapType`
- Removing use of `JobChanged`
- Credential constructor updates

There are various other fixes to Runtime related warnings and platform specific issues.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] UWP
- [ ] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [ ] All variable and method names are good and make sense
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab
