### PR TITLE
Bug fix: Format coordinates

### DIFF
--- a/src/Forms/Shared/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
+++ b/src/Forms/Shared/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentPage x:Class="ArcGISRuntime.Samples.FormatCoordinates.FormatCoordinates"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
-             x:Class="ArcGISRuntime.Samples.FormatCoordinates.FormatCoordinates">
+             xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -16,15 +16,50 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
-        <Label Grid.Row="0" Grid.Column="0" HorizontalTextAlignment="End">Decimal Degrees</Label>
-        <Entry Grid.Row="0" Grid.Column="1" Placeholder="Decimal Degrees" x:Name="DecimalDegreesTextField" />
-        <Label Grid.Row="1" Grid.Column="0" HorizontalTextAlignment="End">Degrees, Minutes, Seconds</Label>
-        <Entry Grid.Row="1" Grid.Column="1" Placeholder="Degrees, Minutes, Seconds" x:Name="DmsTextField" />
-        <Label Grid.Row="2" Grid.Column="0" HorizontalTextAlignment="End">UTM</Label>
-        <Entry Grid.Row="2" Grid.Column="1" Placeholder="UTM" x:Name="UtmTextField" />
-        <Label Grid.Row="3" Grid.Column="0" HorizontalTextAlignment="End">USNG</Label>
-        <Entry Grid.Row="3" Grid.Column="1" Placeholder="USNG" x:Name="UsngTextField" />
-        <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Clicked="RecalculateFields" Text="Recalculate" />
-        <esriUI:MapView Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" x:Name="MyMapView" />
+        <Label Grid.Row="0"
+               Grid.Column="0"
+               HorizontalTextAlignment="End">
+            Decimal Degrees
+        </Label>
+        <Entry x:Name="DecimalDegreesTextField"
+               Grid.Row="0"
+               Grid.Column="1"
+               Placeholder="Decimal Degrees" />
+        <Label Grid.Row="1"
+               Grid.Column="0"
+               HorizontalTextAlignment="End">
+            Degrees, Minutes, Seconds
+        </Label>
+        <Entry x:Name="DmsTextField"
+               Grid.Row="1"
+               Grid.Column="1"
+               Placeholder="Degrees, Minutes, Seconds" />
+        <Label Grid.Row="2"
+               Grid.Column="0"
+               HorizontalTextAlignment="End">
+            UTM
+        </Label>
+        <Entry x:Name="UtmTextField"
+               Grid.Row="2"
+               Grid.Column="1"
+               Placeholder="UTM" />
+        <Label Grid.Row="3"
+               Grid.Column="0"
+               HorizontalTextAlignment="End">
+            USNG
+        </Label>
+        <Entry x:Name="UsngTextField"
+               Grid.Row="3"
+               Grid.Column="1"
+               Placeholder="USNG" />
+        <Button Grid.Row="4"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Clicked="RecalculateFields"
+                Text="Recalculate" />
+        <esriUI:MapView x:Name="MyMapView"
+                        Grid.Row="5"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2" />
     </Grid>
 </ContentPage>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
@@ -26,39 +26,51 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBlock
-                    Text="Tap on the map to see the coordinates in each format. Update any value and select 'Recalculate' to see the updated coordinates."
-                    Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
-                    Margin="0,0,0,0"
-                    TextWrapping="Wrap" FontWeight="SemiBold" />
-                <TextBlock Text="Decimal Degrees"
-                           Grid.Row="1" Grid.Column="0"
-                           HorizontalAlignment="Right" />
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="2"
+                           Margin="0,0,0,0"
+                           FontWeight="SemiBold"
+                           Text="Tap on the map to see the coordinates in each format. Update any value and select 'Recalculate' to see the updated coordinates."
+                           TextWrapping="Wrap" />
+                <TextBlock Grid.Row="1"
+                           Grid.Column="0"
+                           HorizontalAlignment="Right"
+                           Text="Decimal Degrees" />
                 <TextBox x:Name="DecimalDegreesTextField"
-                         Grid.Row="1" Grid.Column="1"
+                         Grid.Row="1"
+                         Grid.Column="1"
                          Tag="Decimal Degrees" />
-                <TextBlock Text="Degrees, Minutes, Seconds"
-                           Grid.Row="2" Grid.Column="0"
-                           HorizontalAlignment="Right" />
+                <TextBlock Grid.Row="2"
+                           Grid.Column="0"
+                           HorizontalAlignment="Right"
+                           Text="Degrees, Minutes, Seconds" />
                 <TextBox x:Name="DmsTextField"
-                         Grid.Row="2" Grid.Column="1"
+                         Grid.Row="2"
+                         Grid.Column="1"
                          Tag="Degrees, Minutes, Seconds" />
-                <TextBlock Text="UTM"
-                           Grid.Row="3" Grid.Column="0"
-                           HorizontalAlignment="Right" />
+                <TextBlock Grid.Row="3"
+                           Grid.Column="0"
+                           HorizontalAlignment="Right"
+                           Text="UTM" />
                 <TextBox x:Name="UtmTextField"
-                         Grid.Row="3" Grid.Column="1"
+                         Grid.Row="3"
+                         Grid.Column="1"
                          Tag="UTM" />
-                <TextBlock Text="USNG"
-                           Grid.Row="4" Grid.Column="0"
-                           HorizontalAlignment="Right" />
+                <TextBlock Grid.Row="4"
+                           Grid.Column="0"
+                           HorizontalAlignment="Right"
+                           Text="USNG" />
                 <TextBox x:Name="UsngTextField"
-                         Grid.Row="4" Grid.Column="1"
+                         Grid.Row="4"
+                         Grid.Column="1"
                          Tag="USNG" />
-                <Button Content="Recalculate"
-                        Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                <Button Grid.Row="5"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
                         Margin="0,5,0,0"
-                        Click="RecalculateFields" />
+                        Click="RecalculateFields"
+                        Content="Recalculate" />
             </Grid>
         </Border>
     </Grid>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Windows;
 using System.Windows.Controls;
@@ -26,20 +27,21 @@ namespace ArcGISRuntime.WPF.Samples.FormatCoordinates
         tags: new[] { "USNG", "UTM", "convert", "coordinate", "decimal degrees", "degree minutes seconds", "format", "latitude", "longitude" })]
     public partial class FormatCoordinates
     {
-        // Hold a reference to the most recently selected text
+        // Hold a reference to the most recently selected text.
         private TextBox _selectedTextBox;
+
+        private List<TextBox> _textBoxes;
 
         public FormatCoordinates()
         {
             InitializeComponent();
-
             Initialize();
         }
 
         private void Initialize()
         {
-            // Initialize the selection
-            _selectedTextBox = DecimalDegreesTextField;
+            // Create a list of the textboxes.
+            _textBoxes = new List<TextBox> { UtmTextField, DmsTextField, DecimalDegreesTextField, UsngTextField };
 
             // Create the map
             MyMapView.Map = new Map(BasemapStyle.ArcGISNavigation);
@@ -53,77 +55,25 @@ namespace ArcGISRuntime.WPF.Samples.FormatCoordinates
             // Update the UI with the initial point
             UpdateUIFromMapPoint(startingPoint);
 
-            // Subscribe to text change events
-            UtmTextField.TextChanged += InputTextChanged;
-            DmsTextField.TextChanged += InputTextChanged;
-            DecimalDegreesTextField.TextChanged += InputTextChanged;
-            UsngTextField.TextChanged += InputTextChanged;
-
             // Subscribe to map tap events to enable tapping on map to update coordinates
-            MyMapView.GeoViewTapped += (sender, args) => { UpdateUIFromMapPoint(args.Location); };
+            MyMapView.GeoViewTapped += (s, e) => { UpdateUIFromMapPoint(e.Location); };
         }
 
         private void InputTextChanged(object sender, TextChangedEventArgs e)
         {
-            // Keep track of the last edited field
+            // Keep track of the last edited field.
             _selectedTextBox = (TextBox)sender;
-        }
-
-        private void UpdateUIFromMapPoint(MapPoint selectedPoint)
-        {
-            try
-            {
-                // Check if the selected point can be formatted into coordinates.
-                CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 0);
-            }
-            catch (Exception e)
-            {
-                // Check if the excpetion is because the coordinates are out of range.
-                if (e.Message == "Invalid argument: coordinates are out of range")
-                {
-                    // Set all of the text fields to contain the error message.
-                    DecimalDegreesTextField.Text = "Coordinates are out of range";
-                    DmsTextField.Text = "Coordinates are out of range";
-                    UtmTextField.Text = "Coordinates are out of range";
-                    UsngTextField.Text = "Coordinates are out of range";
-
-                    // Clear the selectionss symbol.
-                    MyMapView.GraphicsOverlays[0].Graphics.Clear();
-                }
-                return;
-            }
-
-            // Update the decimal degrees text
-            DecimalDegreesTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 4);
-
-            // Update the degrees, minutes, seconds text
-            DmsTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DegreesMinutesSeconds, 1);
-
-            // Update the UTM text
-            UtmTextField.Text = CoordinateFormatter.ToUtm(selectedPoint, UtmConversionMode.NorthSouthIndicators, true);
-
-            // Update the USNG text
-            UsngTextField.Text = CoordinateFormatter.ToUsng(selectedPoint, 4, true);
-
-            // Clear existing graphics overlays
-            MyMapView.GraphicsOverlays[0].Graphics.Clear();
-
-            // Create a symbol to symbolize the point
-            SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, Color.Yellow, 20);
-
-            // Create the graphic
-            Graphic symbolGraphic = new Graphic(selectedPoint, symbol);
-
-            // Add the graphic to the graphics overlay
-            MyMapView.GraphicsOverlays[0].Graphics.Add(symbolGraphic);
         }
 
         private void RecalculateFields(object sender, RoutedEventArgs e)
         {
-            // Hold the entered point
+            // Only update the point if the user has changed text.
+            if (_selectedTextBox == null) return;
+
+            // Hold the entered point.
             MapPoint enteredPoint = null;
 
-            // Update the point based on which text sent the event
+            // Update the point based on which text sent the event.
             try
             {
                 switch (_selectedTextBox.Tag.ToString())
@@ -147,13 +97,54 @@ namespace ArcGISRuntime.WPF.Samples.FormatCoordinates
             }
             catch (Exception ex)
             {
-                // The coordinate is malformed, warn and return
+                // The coordinate is malformed, warn and return.
                 MessageBox.Show(ex.Message, "Invalid format");
                 return;
             }
 
-            // Update the UI from the MapPoint
+            // Update the UI from the MapPoint.
             UpdateUIFromMapPoint(enteredPoint);
+        }
+
+        private void UpdateUIFromMapPoint(MapPoint selectedPoint)
+        {
+            try
+            {
+                // Check if the selected point can be formatted into coordinates.
+                CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 0);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error");
+                return;
+            }
+
+            // "Deselect" any text box.
+            _selectedTextBox = null;
+
+            // Disable event handlers while updating text in text boxes.
+            _textBoxes.ForEach(box => box.TextChanged -= InputTextChanged);
+
+            // Update textbox values.
+            DecimalDegreesTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 4);
+            DmsTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DegreesMinutesSeconds, 1);
+            UtmTextField.Text = CoordinateFormatter.ToUtm(selectedPoint, UtmConversionMode.NorthSouthIndicators, true);
+            UsngTextField.Text = CoordinateFormatter.ToUsng(selectedPoint, 4, true);
+
+            // Enable event handlers for all of the text boxes.
+            _textBoxes.ForEach(box => box.TextChanged += InputTextChanged);
+
+            // Clear existing graphics.
+            MyMapView.GraphicsOverlays[0].Graphics.Clear();
+
+            // Create a symbol to symbolize the point.
+            SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, Color.Yellow, 20);
+
+            // Create the graphic.
+            Graphic symbolGraphic = new Graphic(selectedPoint, symbol);
+
+            // Add the graphic to the graphics overlay.
+            MyMapView.GraphicsOverlays[0].Graphics.Add(symbolGraphic);
         }
     }
 }

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -27,7 +27,7 @@ namespace ArcGISRuntime.WPF.Samples.FormatCoordinates
         tags: new[] { "USNG", "UTM", "convert", "coordinate", "decimal degrees", "degree minutes seconds", "format", "latitude", "longitude" })]
     public partial class FormatCoordinates
     {
-        // Hold a reference to the most recently selected text.
+        // Hold a reference to the most recently updated field.
         private TextBox _selectedTextBox;
 
         private List<TextBox> _textBoxes;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml
@@ -1,8 +1,7 @@
-﻿<UserControl
-    x:Class="ArcGISRuntime.WinUI.Samples.FormatCoordinates.FormatCoordinates"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:esriUI="using:Esri.ArcGISRuntime.UI.Controls">
+﻿<UserControl x:Class="ArcGISRuntime.WinUI.Samples.FormatCoordinates.FormatCoordinates"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:esriUI="using:Esri.ArcGISRuntime.UI.Controls">
     <UserControl.Resources>
         <Style TargetType="TextBlock">
             <Setter Property="VerticalAlignment" Value="Center" />
@@ -32,37 +31,49 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <TextBlock
-                    Text="Tap on the map to see the coordinates in each format. Update any value and tap 'Recalculate' to see the updated coordinates."
-                    Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
-                    Margin="0,0,0,5" MaxWidth="400"
-                    HorizontalAlignment="Stretch"
-                    TextWrapping="Wrap" />
-                <TextBlock Text="Decimal Degrees:"
-                           Grid.Row="1" Grid.Column="0" />
+                <TextBlock Grid.Row="0"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="2"
+                           MaxWidth="400"
+                           Margin="0,0,0,5"
+                           HorizontalAlignment="Stretch"
+                           Text="Tap on the map to see the coordinates in each format. Update any value and tap 'Recalculate' to see the updated coordinates."
+                           TextWrapping="Wrap" />
+                <TextBlock Grid.Row="1"
+                           Grid.Column="0"
+                           Text="Decimal Degrees:" />
                 <TextBox x:Name="DecimalDegreesTextField"
-                         Grid.Row="1" Grid.Column="1"
+                         Grid.Row="1"
+                         Grid.Column="1"
                          Tag="Decimal Degrees" />
-                <TextBlock Text="DMS:"
-                           Grid.Row="2" Grid.Column="0" />
+                <TextBlock Grid.Row="2"
+                           Grid.Column="0"
+                           Text="DMS:" />
                 <TextBox x:Name="DmsTextField"
-                         Grid.Row="2" Grid.Column="1"
+                         Grid.Row="2"
+                         Grid.Column="1"
                          Tag="Degrees, Minutes, Seconds" />
-                <TextBlock Text="UTM:"
-                           Grid.Row="3" Grid.Column="0" />
+                <TextBlock Grid.Row="3"
+                           Grid.Column="0"
+                           Text="UTM:" />
                 <TextBox x:Name="UtmTextField"
-                         Grid.Row="3" Grid.Column="1"
+                         Grid.Row="3"
+                         Grid.Column="1"
                          Tag="UTM" />
-                <TextBlock Text="USNG:"
-                           Grid.Row="4" Grid.Column="0" />
+                <TextBlock Grid.Row="4"
+                           Grid.Column="0"
+                           Text="USNG:" />
                 <TextBox x:Name="UsngTextField"
-                         Grid.Row="4" Grid.Column="1"
+                         Grid.Row="4"
+                         Grid.Column="1"
                          Tag="USNG" />
-                <Button Content="Recalculate"
-                        Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
-                        HorizontalAlignment="Stretch"
+                <Button Grid.Row="5"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
                         Margin="0,5,0,0"
-                        Click="RecalculateFields" />
+                        HorizontalAlignment="Stretch"
+                        Click="RecalculateFields"
+                        Content="Recalculate" />
             </Grid>
         </Border>
     </Grid>

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -11,12 +11,11 @@ using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.UI;
-using System;
-using System.Drawing;
-using Windows.UI.Popups;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 
 namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
 {
@@ -28,7 +27,7 @@ namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
         tags: new[] { "USNG", "UTM", "convert", "coordinate", "decimal degrees", "degree minutes seconds", "format", "latitude", "longitude" })]
     public partial class FormatCoordinates
     {
-        // Hold a reference to the most recently selected text.
+        // Hold a reference to the most recently updated field.
         private TextBox _selectedTextBox;
 
         private List<TextBox> _textBoxes;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/FormatCoordinates/FormatCoordinates.xaml.cs
@@ -16,6 +16,7 @@ using System.Drawing;
 using Windows.UI.Popups;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System.Collections.Generic;
 
 namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
 {
@@ -27,20 +28,21 @@ namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
         tags: new[] { "USNG", "UTM", "convert", "coordinate", "decimal degrees", "degree minutes seconds", "format", "latitude", "longitude" })]
     public partial class FormatCoordinates
     {
-        // Hold a reference to the text that was selected last
-        private TextBox _selectedTextField;
+        // Hold a reference to the most recently selected text.
+        private TextBox _selectedTextBox;
+
+        private List<TextBox> _textBoxes;
 
         public FormatCoordinates()
         {
             InitializeComponent();
-
             Initialize();
         }
 
         private void Initialize()
         {
-            // Set the initial selected text
-            _selectedTextField = DecimalDegreesTextField;
+            // Create a list of the textboxes.
+            _textBoxes = new List<TextBox> { UtmTextField, DmsTextField, DecimalDegreesTextField, UsngTextField };
 
             // Create the map
             MyMapView.Map = new Map(BasemapStyle.ArcGISNavigation);
@@ -54,20 +56,55 @@ namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
             // Update the UI with the initial point
             UpdateUIFromMapPoint(startingPoint);
 
-            // Subscribe to text change events
-            UtmTextField.TextChanged += InputTextChanged;
-            DmsTextField.TextChanged += InputTextChanged;
-            DecimalDegreesTextField.TextChanged += InputTextChanged;
-            UsngTextField.TextChanged += InputTextChanged;
-
             // Subscribe to map tap events to enable tapping on map to update coordinates
-            MyMapView.GeoViewTapped += (sender, args) => { UpdateUIFromMapPoint(args.Location); };
+            MyMapView.GeoViewTapped += (s, e) => { UpdateUIFromMapPoint(e.Location); };
         }
 
         private void InputTextChanged(object sender, TextChangedEventArgs e)
         {
-            // Keep track of the last edited field
-            _selectedTextField = (TextBox)sender;
+            // Keep track of the last edited field.
+            _selectedTextBox = (TextBox)sender;
+        }
+
+        private void RecalculateFields(object sender, RoutedEventArgs e)
+        {
+            // Only update the point if the user has changed text.
+            if (_selectedTextBox == null) return;
+
+            // Hold the entered point.
+            MapPoint enteredPoint = null;
+
+            // Update the point based on which text sent the event.
+            try
+            {
+                switch (_selectedTextBox.Tag.ToString())
+                {
+                    case "Decimal Degrees":
+                    case "Degrees, Minutes, Seconds":
+                        enteredPoint =
+                            CoordinateFormatter.FromLatitudeLongitude(_selectedTextBox.Text, MyMapView.SpatialReference);
+                        break;
+
+                    case "UTM":
+                        enteredPoint =
+                            CoordinateFormatter.FromUtm(_selectedTextBox.Text, MyMapView.SpatialReference, UtmConversionMode.NorthSouthIndicators);
+                        break;
+
+                    case "USNG":
+                        enteredPoint =
+                            CoordinateFormatter.FromUsng(_selectedTextBox.Text, MyMapView.SpatialReference);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                // The coordinate is malformed, warn and return
+                _ = new MessageDialog2(ex.Message, "Invalid format").ShowAsync();
+                return;
+            }
+
+            // Update the UI from the MapPoint.
+            UpdateUIFromMapPoint(enteredPoint);
         }
 
         private void UpdateUIFromMapPoint(MapPoint selectedPoint)
@@ -77,86 +114,38 @@ namespace ArcGISRuntime.WinUI.Samples.FormatCoordinates
                 // Check if the selected point can be formatted into coordinates.
                 CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 0);
             }
-            catch (Exception e)
-            {
-                // Check if the excpetion is because the coordinates are out of range.
-                if (e.Message == "Invalid argument: coordinates are out of range")
-                {
-                    // Set all of the text fields to contain the error message.
-                    DecimalDegreesTextField.Text = "Coordinates are out of range";
-                    DmsTextField.Text = "Coordinates are out of range";
-                    UtmTextField.Text = "Coordinates are out of range";
-                    UsngTextField.Text = "Coordinates are out of range";
-
-                    // Clear the selectionss symbol.
-                    MyMapView.GraphicsOverlays[0].Graphics.Clear();
-                }
-                return;
-            }
-
-            // Update the decimal degrees text
-            DecimalDegreesTextField.Text =
-                CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 4);
-
-            // Update the degrees, minutes, seconds text
-            DmsTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint,
-                LatitudeLongitudeFormat.DegreesMinutesSeconds, 1);
-
-            // Update the UTM text
-            UtmTextField.Text = CoordinateFormatter.ToUtm(selectedPoint, UtmConversionMode.NorthSouthIndicators, true);
-
-            // Update the USNG text
-            UsngTextField.Text = CoordinateFormatter.ToUsng(selectedPoint, 4, true);
-
-            // Clear existing graphics overlays
-            MyMapView.GraphicsOverlays[0].Graphics.Clear();
-
-            // Create a symbol to symbolize the point
-            SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, Color.Yellow, 20);
-
-            // Create the graphic
-            Graphic symbolGraphic = new Graphic(selectedPoint, symbol);
-
-            // Add the graphic to the graphics overlay
-            MyMapView.GraphicsOverlays[0].Graphics.Add(symbolGraphic);
-        }
-
-        private async void RecalculateFields(object sender, RoutedEventArgs e)
-        {
-            // Hold the entered point
-            MapPoint enteredPoint = null;
-
-            // Update the point based on which text sent the event
-            try
-            {
-                switch (_selectedTextField.Tag.ToString())
-                {
-                    case "Decimal Degrees":
-                    case "Degrees, Minutes, Seconds":
-                        enteredPoint =
-                            CoordinateFormatter.FromLatitudeLongitude(_selectedTextField.Text, MyMapView.SpatialReference);
-                        break;
-
-                    case "UTM":
-                        enteredPoint =
-                            CoordinateFormatter.FromUtm(_selectedTextField.Text, MyMapView.SpatialReference, UtmConversionMode.NorthSouthIndicators);
-                        break;
-
-                    case "USNG":
-                        enteredPoint =
-                            CoordinateFormatter.FromUsng(_selectedTextField.Text, MyMapView.SpatialReference);
-                        break;
-                }
-            }
             catch (Exception ex)
             {
-                // The coordinate is malformed, warn and return
-                await new MessageDialog2(ex.Message, "Invalid format").ShowAsync();
+                _ = new MessageDialog2(ex.Message, "Error").ShowAsync();
                 return;
             }
 
-            // Update the UI from the MapPoint
-            UpdateUIFromMapPoint(enteredPoint);
+            // "Deselect" any text box.
+            _selectedTextBox = null;
+
+            // Disable event handlers while updating text in text boxes.
+            _textBoxes.ForEach(box => box.TextChanged -= InputTextChanged);
+
+            // Update textbox values.
+            DecimalDegreesTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DecimalDegrees, 4);
+            DmsTextField.Text = CoordinateFormatter.ToLatitudeLongitude(selectedPoint, LatitudeLongitudeFormat.DegreesMinutesSeconds, 1);
+            UtmTextField.Text = CoordinateFormatter.ToUtm(selectedPoint, UtmConversionMode.NorthSouthIndicators, true);
+            UsngTextField.Text = CoordinateFormatter.ToUsng(selectedPoint, 4, true);
+
+            // Enable event handlers for all of the text boxes.
+            _textBoxes.ForEach(box => box.TextChanged += InputTextChanged);
+
+            // Clear existing graphics.
+            MyMapView.GraphicsOverlays[0].Graphics.Clear();
+
+            // Create a symbol to symbolize the point.
+            SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbolStyle.X, Color.Yellow, 20);
+
+            // Create the graphic.
+            Graphic symbolGraphic = new Graphic(selectedPoint, symbol);
+
+            // Add the graphic to the graphics overlay.
+            MyMapView.GraphicsOverlays[0].Graphics.Add(symbolGraphic);
         }
     }
 }


### PR DESCRIPTION
# Description

This fixes a bug where formatted coordinates could be repeatedly recalculated and rounded. The behavior of the sample is more clear now.

## Type of change

- [ ] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [ ] Xamarin.Forms UWP

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [ ] All variable and method names are good and make sense
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab
