### PR TITLE
Fix viewpoint parameters in some samples.

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
+++ b/src/Android/Xamarin.Android/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             _myMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
+++ b/src/Android/Xamarin.Android/Samples/Geometry/SpatialOperations/SpatialOperations.cs
@@ -63,7 +63,7 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
             Map myMap = new Map(BasemapStyle.ArcGISLightGray);
-            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Add the map to the map view.
             _myMapView.Map = myMap;

--- a/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/Android/Xamarin.Android/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -64,7 +64,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         {
             // Create a map with topographic basemap and an initial location
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Hook into the MapView tapped event
             _myMapView.GeoViewTapped += MyMapView_GeoViewTapped;

--- a/src/Android/Xamarin.Android/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
@@ -47,7 +47,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location
             Map myMap = new Map(BasemapStyle.ArcGISImagery);
-            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
 
             // Provide used Map to the MapView
             _myMapView.Map = myMap;

--- a/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -11,6 +11,7 @@ using Android.App;
 using Android.OS;
 using Android.Widget;
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
@@ -54,7 +55,6 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 
             // Create new Map with basemap
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // Create uri to the used feature service
             Uri serviceUri = new Uri(
@@ -69,6 +69,9 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 
             // Provide used Map to the MapView
             _myMapView.Map = myMap;
+
+             // Zoom to the United States.
+            _myMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)

--- a/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/Android/Xamarin.Android/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable the ability to interact with the map view (including enabling the magnifier) 
             _myMapView.InteractionOptions = new Esri.ArcGISRuntime.UI.MapViewInteractionOptions

--- a/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/Forms/Shared/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -37,7 +37,7 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/Forms/Shared/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/Forms/Shared/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -47,7 +47,7 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
             Map myMap = new Map(BasemapStyle.ArcGISLightGray);
-            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            myMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Add the map to the map view.
             MyMapView.Map = myMap;

--- a/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/Forms/Shared/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -51,7 +51,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         {
             // Create a map with topographic basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Hook into the MapView tapped event.
             MyMapView.GeoViewTapped += MyMapView_GeoViewTapped;

--- a/src/Forms/Shared/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -36,7 +36,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/Forms/Shared/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -32,7 +32,7 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISImagery);
-            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 16);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
 
             // Assign the map to the MapView.
             MyMapView.Map = myMap;

--- a/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using System;
@@ -38,7 +39,6 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 
             // Create new Map with basemap.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // Create uri to the used feature service.
             Uri serviceUri = new Uri(
@@ -53,6 +53,9 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 
             // Provide used Map to the MapView.
             myMapView.Map = myMap;
+
+            // Zoom to the United States.
+            myMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)

--- a/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/Forms/Shared/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -33,7 +33,7 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.UWP.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.UWP.Samples.SpatialOperations
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
             Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
-            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGISRuntime.UWP.Samples.AnalyzeViewshed
         {
             // Create a map with topographic basemap and an initial location
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Hook into the tapped event
             MyMapView.GeoViewTapped += OnMapViewTapped;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -44,7 +44,7 @@ namespace ArcGISRuntime.UWP.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.UWP.Samples.SetInitialMapLocation
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location
             Map myMap = new Map(BasemapStyle.ArcGISImagery);
-            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
 
             // Assign the map to the MapView
             MyMapView.Map = myMap;

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using System;
@@ -38,7 +39,6 @@ namespace ArcGISRuntime.UWP.Samples.DisplayDrawingStatus
 
             // Create new Map with a topographic basemap.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL pointing to a feature service.
             Uri serviceUri =
@@ -53,6 +53,9 @@ namespace ArcGISRuntime.UWP.Samples.DisplayDrawingStatus
 
             // Display the map in the view.
             MyMapView.Map = myMap;
+
+            // Zoom to the United States.
+            MyMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.UWP.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable magnifier
             MyMapView.InteractionOptions = new MapViewInteractionOptions

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -37,7 +37,7 @@ namespace ArcGISRuntime.WPF.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = GetGeoPackagePath();

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.WPF.Samples.SpatialOperations
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
             Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
-            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -56,7 +56,7 @@ namespace ArcGISRuntime.WPF.Samples.AnalyzeViewshed
         {
             // Create a map with topographic basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Hook into the tapped event.
             MyMapView.GeoViewTapped += OnMapViewTapped;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.WPF.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -25,7 +25,7 @@ namespace ArcGISRuntime.WPF.Samples.SetInitialMapLocation
 
             //initialize map with `imagery with labels` basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISImagery);
-            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
 
             //assign the map to the map view.
             MyMapView.Map = myMap;

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -8,6 +8,7 @@
 // language governing permissions and limitations under the License.
 
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using System;
@@ -38,7 +39,6 @@ namespace ArcGISRuntime.WPF.Samples.DisplayDrawingStatus
 
             // Create new Map with basemap.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // Create uri to the used feature service.
             Uri serviceUri = new Uri(
@@ -53,6 +53,9 @@ namespace ArcGISRuntime.WPF.Samples.DisplayDrawingStatus
 
             // Provide used Map to the MapView.
             MyMapView.Map = myMap;
+
+            // Zoom to the United States.
+            MyMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WPF.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions()

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Data/ReadGeoPackage/ReadGeoPackage.xaml.cs
@@ -36,7 +36,7 @@ namespace ArcGISRuntime.WinUI.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             MyMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.73, 11);
+            MyMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.73, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string myGeoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geometry/SpatialOperations/SpatialOperations.xaml.cs
@@ -46,7 +46,7 @@ namespace ArcGISRuntime.WinUI.Samples.SpatialOperations
         {
             // Create the map with a gray canvas basemap and an initial location centered on London, UK.
             Map spatialOperationsMap = new Map(BasemapStyle.ArcGISLightGray);
-            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            spatialOperationsMap.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Add the map to the map view.
             MyMapView.Map = spatialOperationsMap;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -57,7 +57,7 @@ namespace ArcGISRuntime.WinUI.Samples.AnalyzeViewshed
         {
             // Create a map with topographic basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            myMap.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Hook into the tapped event.
             MyMapView.GeoViewTapped += OnMapViewTapped;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/DisplayAnnotation/DisplayAnnotation.xaml.cs
@@ -44,7 +44,7 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WinUI.Samples.SetInitialMapLocation
         {
             // Create a map with 'Imagery with Labels' basemap and an initial location.
             Map myMap = new Map(BasemapStyle.ArcGISImagery);
-            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 16);
+            myMap.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
 
             // Assign the map to the MapView
             MyMapView.Map = myMap;

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.xaml.cs
@@ -12,6 +12,7 @@ using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using System;
 using Microsoft.UI.Xaml;
+using Esri.ArcGISRuntime.Geometry;
 
 namespace ArcGISRuntime.WinUI.Samples.DisplayDrawingStatus
 {
@@ -38,7 +39,6 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayDrawingStatus
 
             // Create new Map with a topographic basemap.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL pointing to a feature service.
             Uri serviceUri =
@@ -53,6 +53,9 @@ namespace ArcGISRuntime.WinUI.Samples.DisplayDrawingStatus
 
             // Display the map in the view.
             MyMapView.Map = myMap;
+
+            // Zoom to the United States.
+            MyMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
         }
 
         private void OnDrawStatusChanged(object sender, DrawStatusChangedEventArgs e)

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/MapView/ShowMagnifier/ShowMagnifier.xaml.cs
@@ -31,7 +31,7 @@ namespace ArcGISRuntime.WinUI.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable magnifier.
             MyMapView.InteractionOptions = new MapViewInteractionOptions

--- a/src/iOS/Xamarin.iOS/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ReadGeoPackage/ReadGeoPackage.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntime.Samples.ReadGeoPackage
         {
             // Create a new map centered on Aurora Colorado.
             _myMapView.Map = new Map(BasemapStyle.ArcGISStreets);
-            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 11);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(39.7294, -104.70, 175000);
 
             // Get the full path to the GeoPackage on the device.
             string geoPackagePath = DataManager.GetDataFolder("68ec42517cdd439e81b036210483e8e7", "AuroraCO.gpkg");

--- a/src/iOS/Xamarin.iOS/Samples/Geometry/SpatialOperations/SpatialOperations.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geometry/SpatialOperations/SpatialOperations.cs
@@ -53,7 +53,7 @@ namespace ArcGISRuntimeXamarin.Samples.SpatialOperations
         {
             // Create and show a map with a gray canvas basemap and an initial location centered on London, UK.
             _myMapView.Map = new Map(BasemapStyle.ArcGISLightGray);
-            _myMapView.Map.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 15);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(51.5017, -0.12714, 20000);
 
             // Create and add two overlapping polygon graphics to operate on.
             CreatePolygonsOverlay();

--- a/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.cs
@@ -54,7 +54,7 @@ namespace ArcGISRuntime.Samples.AnalyzeViewshed
         {
             // Create and show a map with topographic basemap and an initial location.
             _myMapView.Map = new Map(BasemapStyle.ArcGISTopographic);
-            _myMapView.Map.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 13);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(45.3790902612337, 6.84905317262762, 70000);
 
             // Create empty overlays for the user clicked location and the results of the viewshed analysis.
             CreateOverlays();

--- a/src/iOS/Xamarin.iOS/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/DisplayAnnotation/DisplayAnnotation.cs
@@ -42,7 +42,7 @@ namespace ArcGISRuntimeXamarin.Samples.DisplayAnnotation
 
             // Create a map.
             Map map = new Map(BasemapStyle.ArcGISLightGray);
-            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 13);
+            map.InitialViewpoint = new Viewpoint(55.882436, -2.725610, 50000);
 
             // Create a feature layer from a feature service.
             FeatureLayer riverFeatureLayer = new FeatureLayer(new ServiceFeatureTable(riverFeatureServiceUri));

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapLocation/SetInitialMapLocation.cs
@@ -35,7 +35,7 @@ namespace ArcGISRuntime.Samples.SetInitialMapLocation
         {
             // Show a map with 'Imagery with Labels' basemap and an initial location.
             _myMapView.Map = new Map(BasemapStyle.ArcGISImagery);
-            _myMapView.Map.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 15);
+            _myMapView.Map.InitialViewpoint = new Viewpoint(-33.867886, -63.985, 25000);
         }
 
         public override void ViewDidLoad()

--- a/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/DisplayDrawingStatus/DisplayDrawingStatus.cs
@@ -9,6 +9,7 @@
 
 using System;
 using Esri.ArcGISRuntime.Data;
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.UI;
 using Esri.ArcGISRuntime.UI.Controls;
@@ -40,7 +41,6 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
         {
             // Create new Map with basemap.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056, -117.196, 4);
 
             // URL to the feature service.
             Uri serviceUri = new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0");
@@ -57,6 +57,9 @@ namespace ArcGISRuntime.Samples.DisplayDrawingStatus
 
             // Provide used Map to the MapView.
             _myMapView.Map = myMap;
+
+             // Zoom to the United States.
+            _myMapView.SetViewpointCenterAsync(new MapPoint(-10800000, 4500000, SpatialReferences.WebMercator), 3e7);
 
             // Animate the activity spinner.
             _activityIndicator.StartAnimating();

--- a/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
+++ b/src/iOS/Xamarin.iOS/Samples/MapView/ShowMagnifier/ShowMagnifier.cs
@@ -36,7 +36,7 @@ namespace ArcGISRuntime.Samples.ShowMagnifier
         {
             // Create new Map with basemap and initial location.
             Map myMap = new Map(BasemapStyle.ArcGISTopographic);
-            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 10);
+            myMap.InitialViewpoint = new Viewpoint(34.056295, -117.195800, 50000);
 
             // Enable magnifier.
             _myMapView.InteractionOptions = new MapViewInteractionOptions


### PR DESCRIPTION
# Description

Some samples relied on an outdated and incorrect behavior from the 3 parameter viewpoint constructor. This PR updates the viewpoints in these samples on all platforms.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [ ] Xamarin.Forms UWP

- [ ] UWP
- [ ] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
