### PR TITLE
WPF: Fix main window minimizing when settings window closes

### DIFF
--- a/src/WPF/ArcGISRuntime.WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/MainWindow.xaml.cs
@@ -481,6 +481,9 @@ namespace ArcGISRuntime.Samples.Desktop
         {
             SetScreenshotButttonVisibility();
             SetContainerDimensions();
+
+            // Reactivate the parent window so that it does not minimize on close.
+            Activate();
         }
 
         private void SetScreenshotButttonVisibility()


### PR DESCRIPTION
# Description

Fix main window minimizing when settings window closes on WPF.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [x] WPF Framework

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
