### PR TITLE
Switch from MarkedNet to Markdig

### DIFF
--- a/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
+++ b/src/Forms/Android/ArcGISRuntime.Xamarin.Forms.Android.csproj
@@ -117,8 +117,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="PCLCrypto">
       <Version>2.0.147</Version>

--- a/src/Forms/Shared/Resources/SettingsPage/licenses.md
+++ b/src/Forms/Shared/Resources/SettingsPage/licenses.md
@@ -12,11 +12,39 @@ This app uses github-markdown-css under the MIT license.
 
 ----
 
-## MarkedNET
+## Markdig
 
-This app uses MarkedNET under the MIT license. It is used to render the content on the sample description page.
+This app uses Markdig under the BSD 2-Clause "Simplified" license. It is used to render the content on the sample description page.
 
-[Project on GitHub](https://github.com/T-Alex/MarkedNet) | [Project on NuGet](https://www.nuget.org/packages/MarkedNet/) | [License](https://github.com/T-Alex/MarkedNet/blob/master/LICENSE.md)
+[Project on GitHub](https://github.com/xoofx/markdig) | [Project on NuGet](https://www.nuget.org/packages/Markdig/) | [License](https://github.com/xoofx/markdig/blob/master/license.txt)
+
+BSD license reproduced in full:
+
+----
+
+Copyright (c) 2018-2019, Alexandre Mutel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----
 

--- a/src/Forms/Shared/SamplePage.xaml.cs
+++ b/src/Forms/Shared/SamplePage.xaml.cs
@@ -24,7 +24,6 @@ namespace ArcGISRuntime
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class SamplePage
     {
-        private readonly MarkedNet.Marked _markdownRenderer = new MarkedNet.Marked();
         private ContentPage _sample;
 
         public SamplePage()
@@ -78,7 +77,7 @@ namespace ArcGISRuntime
                 string cssPath = $"{baseUrl}/github-markdown.css";
 
                 string readmeContent = System.IO.File.ReadAllText(readmePath);
-                readmeContent = _markdownRenderer.Parse(readmeContent);
+                readmeContent = Markdig.Markdown.ToHtml(readmeContent);
 
                 // Fix paths for images.
                 readmeContent = readmeContent.Replace("src='", "src=\"").Replace(".jpg'", ".jpg\"").Replace("src=\"", $"src=\"{basePath}/");

--- a/src/Forms/Shared/SettingsPage.xaml.cs
+++ b/src/Forms/Shared/SettingsPage.xaml.cs
@@ -26,7 +26,6 @@ namespace ArcGISRuntime
     {
         private CancellationTokenSource _cancellationTokenSource;
         private List<SampleInfo> OfflineDataSamples;
-        private readonly MarkedNet.Marked _markdownRenderer = new MarkedNet.Marked();
 
         public SettingsPage()
         {
@@ -85,14 +84,14 @@ namespace ArcGISRuntime
 #if __IOS__
                 viewportHTML +
 #endif
-                $"</head><body class=\"markdown-body\">{_markdownRenderer.Parse(licenseString)}</body>";
+                $"</head><body class=\"markdown-body\">{Markdig.Markdown.ToHtml(licenseString)}</body>";
             LicensePage.Source = new HtmlWebViewSource() { Html = licenseHTML };
 
             string aboutHTML = htmlStart +
 #if __IOS__
                 viewportHTML +
 #endif
-                $"</head><body class=\"markdown-body\">{_markdownRenderer.Parse(aboutString)}{versionNumber}</body>";
+                $"</head><body class=\"markdown-body\">{Markdig.Markdown.ToHtml(aboutString)}{versionNumber}</body>";
             AboutPage.Source = new HtmlWebViewSource() { Html = aboutHTML };
 
             // Add an event handler for hyperlinks in the web views.

--- a/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
+++ b/src/Forms/UWP/ArcGISRuntime.Xamarin.Forms.UWP.csproj
@@ -175,8 +175,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>

--- a/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
+++ b/src/Forms/iOS/ArcGISRuntime.Xamarin.Forms.iOS.csproj
@@ -220,8 +220,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="PInvoke.BCrypt">
       <Version>0.7.124</Version>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/ArcGISRuntime.UWP.Viewer.csproj
@@ -1869,8 +1869,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.UWP">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Resources/licenses.md
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Resources/licenses.md
@@ -12,11 +12,39 @@ This app uses github-markdown-css under the MIT license.
 
 ----
 
-## MarkedNET
+## Markdig
 
-This app uses MarkedNET under the MIT license. It is used to render the content on the sample description page.
+This app uses Markdig under the BSD 2-Clause "Simplified" license. It is used to render the content on the sample description page.
 
-[Project on GitHub](https://github.com/T-Alex/MarkedNet) | [Project on NuGet](https://www.nuget.org/packages/MarkedNet/) | [License](https://github.com/T-Alex/MarkedNet/blob/master/LICENSE.md)
+[Project on GitHub](https://github.com/xoofx/markdig) | [Project on NuGet](https://www.nuget.org/packages/Markdig/) | [License](https://github.com/xoofx/markdig/blob/master/license.txt)
+
+BSD license reproduced in full:
+
+----
+
+Copyright (c) 2018-2019, Alexandre Mutel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----
 

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/SettingsPage.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/SettingsPage.xaml.cs
@@ -30,7 +30,6 @@ namespace ArcGISRuntime
         private static string _runtimeVersion = "";
         private CancellationTokenSource _cancellationTokenSource;
         private List<SampleInfo> OfflineDataSamples;
-        private readonly MarkedNet.Marked _markdownRenderer = new MarkedNet.Marked();
 
         public SettingsWindow()
         {
@@ -63,11 +62,11 @@ namespace ArcGISRuntime
             }
 
             string aboutPath = "Resources\\about.md";
-            string aboutHTML = "<!doctype html><head><link rel=\"stylesheet\" href=\"ms-appx-web:///" + cssPath + "\" /></head><body class=\"markdown-body\">" + _markdownRenderer.Parse(File.ReadAllText(aboutPath)) + _runtimeVersion + "</body>";
+            string aboutHTML = "<!doctype html><head><link rel=\"stylesheet\" href=\"ms-appx-web:///" + cssPath + "\" /></head><body class=\"markdown-body\">" + Markdig.Markdown.ToHtml(File.ReadAllText(aboutPath)) + _runtimeVersion + "</body>";
             AboutBlock.NavigateToString(aboutHTML);
 
             string licensePath = "Resources\\licenses.md";
-            string licenseHTML = "<!doctype html><head><link rel=\"stylesheet\" href=\"ms-appx-web:///" + cssPath + "\" /></head><body class=\"markdown-body\">" + _markdownRenderer.Parse(File.ReadAllText(licensePath)) + "</body>";
+            string licenseHTML = "<!doctype html><head><link rel=\"stylesheet\" href=\"ms-appx-web:///" + cssPath + "\" /></head><body class=\"markdown-body\">" + Markdig.Markdown.ToHtml(File.ReadAllText(licensePath)) + "</body>";
             LicensesBlock.NavigateToString(licenseHTML);
 
             // Set up offline data.

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.Net.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.Net.csproj
@@ -113,9 +113,7 @@
     <PackageReference Include="Esri.ArcGISRuntime.WPF">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
-    </PackageReference>
+    <PackageReference Include="Markdig" Version="0.30.2" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.5.3" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.5.3" />
     <PackageReference Include="System.Speech" Version="6.0.0" />

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.NetFramework.csproj
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/ArcGISRuntime.WPF.Viewer.NetFramework.csproj
@@ -275,8 +275,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.WPF">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>4.5.1</Version>

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Description.xaml.cs
@@ -15,8 +15,6 @@ namespace ArcGISRuntime.WPF.Viewer
 {
     public partial class Description
     {
-        private readonly MarkedNet.Marked _markdownRenderer = new MarkedNet.Marked();
-
         public Description()
         {
             InitializeComponent();
@@ -31,7 +29,7 @@ namespace ArcGISRuntime.WPF.Viewer
             string readmePath = Path.Combine(folderPath, "Readme.md");
             string readmeContent = File.ReadAllText(readmePath);
             string overrideCssPath = Path.Combine(App.ResourcePath, "Resources", "hide-header.css");
-            readmeContent = _markdownRenderer.Parse(readmeContent);
+            readmeContent = Markdig.Markdown.ToHtml(readmeContent);
 
             string htmlString = "<!doctype html><head><base href=\"" + readmePath + "\"><link rel=\"stylesheet\" href=\"" + cssPath + "\" /><link rel=\"stylesheet\" href=\"" + overrideCssPath + "\" /></head><body class=\"markdown-body\">" + readmeContent + "</body>";
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Resources/licenses.md
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Resources/licenses.md
@@ -2,37 +2,39 @@
 
 The ArcGIS Runtime SDK for .NET sample viewer (WPF version) was built using several free and open source software libraries and resources.
 
-## MarkedNET
+## Markdig
 
-This app uses MarkedNET under the MIT license. It is used to render the content on the sample description page.
+This app uses Markdig under the BSD 2-Clause "Simplified" license. It is used to render the content on the sample description page.
 
-[Project on GitHub](https://github.com/T-Alex/MarkedNet) | [Project on NuGet](https://www.nuget.org/packages/MarkedNet/) | [License](https://github.com/T-Alex/MarkedNet/blob/master/LICENSE.md)
+[Project on GitHub](https://github.com/xoofx/markdig) | [Project on NuGet](https://www.nuget.org/packages/Markdig/) | [License](https://github.com/xoofx/markdig/blob/master/license.txt)
 
-MIT license reproduced in full:
+BSD license reproduced in full:
 
 ------
 
-The MIT License (MIT)
+Copyright (c) 2018-2019, Alexandre Mutel
+All rights reserved.
 
-Copyright (c) 2015 Alex Titarenko, Christopher Jeffrey
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/SettingsWindow.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/SettingsWindow.xaml.cs
@@ -28,7 +28,6 @@ namespace ArcGISRuntime
     public partial class SettingsWindow : Window
     {
         private static string _runtimeVersion = "";
-        private readonly MarkedNet.Marked _markdownRenderer = new MarkedNet.Marked();
         private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         private List<SampleInfo> OfflineDataSamples;
@@ -50,7 +49,7 @@ namespace ArcGISRuntime
             string markdownPath = Path.Combine(App.ResourcePath, "Resources", "licenses.md");
             string cssPath = Path.Combine(App.ResourcePath, "Resources", "github-markdown.css");
             string licenseContent = File.ReadAllText(markdownPath);
-            licenseContent = _markdownRenderer.Parse(licenseContent);
+            licenseContent = Markdig.Markdown.ToHtml(licenseContent);
             string htmlString = "<!doctype html><head><link rel=\"stylesheet\" href=\"" + cssPath + "\" /></head><body class=\"markdown-body\">" + licenseContent + "</body>";
 
             // Set the html in web browser.

--- a/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
+++ b/src/iOS/Xamarin.iOS/ArcGISRuntime.Xamarin.Samples.iOS.csproj
@@ -734,8 +734,8 @@
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">
       <Version>100.15.0</Version>
     </PackageReference>
-    <PackageReference Include="MarkedNet">
-      <Version>2.1.4</Version>
+    <PackageReference Include="Markdig">
+      <Version>0.30.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.Build">
       <Version>1.0.21</Version>

--- a/src/iOS/Xamarin.iOS/Helpers/HTMLHelpers.cs
+++ b/src/iOS/Xamarin.iOS/Helpers/HTMLHelpers.cs
@@ -1,9 +1,5 @@
 ﻿using Foundation;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using UIKit;
 
 namespace ArcGISRuntime
@@ -25,7 +21,7 @@ namespace ArcGISRuntime
             string markdownFile = darkMode ? _darkMarkdownFile : _lightMarkdownFile;
 
             string markdownCSSPath = Path.Combine(NSBundle.MainBundle.BundlePath, $"SyntaxHighlighting/{markdownFile}");
-            string parsedMarkdown = new MarkedNet.Marked().Parse(rawMarkdown);
+            string parsedMarkdown = Markdig.Markdown.ToHtml(rawMarkdown);
 
             string markdowntHTML = "<!doctype html>" +
                 "<head>" +

--- a/src/iOS/Xamarin.iOS/Resources/licenses.md
+++ b/src/iOS/Xamarin.iOS/Resources/licenses.md
@@ -2,39 +2,41 @@
 
 The ArcGIS Runtime SDK for .NET sample viewer (iOS version) was built using several free and open source software libraries and resources.
 
-## MarkedNET
+## Markdig
 
-This app uses MarkedNET under the MIT license. It is used to render the content on the sample description page.
+This app uses Markdig under the BSD 2-Clause "Simplified" license. It is used to render the content on the sample description page.
 
-[Project on GitHub](https://github.com/T-Alex/MarkedNet) | [Project on NuGet](https://www.nuget.org/packages/MarkedNet/) | [License](https://github.com/T-Alex/MarkedNet/blob/master/LICENSE.md)
+[Project on GitHub](https://github.com/xoofx/markdig) | [Project on NuGet](https://www.nuget.org/packages/Markdig/) | [License](https://github.com/xoofx/markdig/blob/master/license.txt)
 
-MIT license reproduced in full:
+BSD license reproduced in full:
 
 ------
 
-The MIT License (MIT)
+Copyright (c) 2018-2019, Alexandre Mutel
+All rights reserved.
 
-Copyright (c) 2015 Alex Titarenko, Christopher Jeffrey
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-----
+------
 
 ## Highlight.JS
 

--- a/src/iOS/Xamarin.iOS/ViewControllers/SampleInfoViewController.cs
+++ b/src/iOS/Xamarin.iOS/ViewControllers/SampleInfoViewController.cs
@@ -72,7 +72,7 @@ namespace ArcGISRuntime
 
                 string readmePath = Path.Combine(NSBundle.MainBundle.BundlePath, "Samples", _info.Category, _info.FormalName, "readme.md");
                 string readmeCSSPath = Path.Combine(NSBundle.MainBundle.BundlePath, $"SyntaxHighlighting/{markdownFile}");
-                string readmeContent = new MarkedNet.Marked().Parse(File.ReadAllText(readmePath));
+                string readmeContent = Markdig.Markdown.ToHtml(File.ReadAllText(readmePath));
 
                 string readmeHTML = "<!doctype html><head><base href=\"" +
                     readmePath +


### PR DESCRIPTION
# Description

MarkedNet requires net451, which is no longer supported with 100.15.0.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [x] Xamarin.Forms Android
- [x] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP
- [x] UWP
- [x] Xamarin.iOS

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
