### PR TITLE
WMS service catalog: exclude group layers from `WmsLayer` constructor

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
+++ b/src/Android/Xamarin.Android/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
@@ -134,6 +134,9 @@ namespace ArcGISRuntime.Samples.WmsServiceCatalog
 
             // Get a list of selected LayerInfos
             List<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info).ToList();
+			
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
 
             // Return if list is empty
             if (!selectedLayers.Any())

--- a/src/Forms/Shared/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/Forms/Shared/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -86,6 +86,9 @@ namespace ArcGISRuntime.Samples.WmsServiceCatalog
             // Get a list of selected LayerInfos.
             List<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info).ToList();
 
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
+
             // Return if no layers selected.
             if (!selectedLayers.Any())
             {

--- a/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/UWP/ArcGISRuntime.UWP.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -83,6 +83,9 @@ namespace ArcGISRuntime.UWP.Samples.WmsServiceCatalog
 
             // Get a list of selected LayerInfos.
             List<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info).ToList();
+			
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
 
             // Return if no layers selected.
             if (!selectedLayers.Any())

--- a/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/WPF/ArcGISRuntime.WPF.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -87,6 +87,9 @@ namespace ArcGISRuntime.WPF.Samples.WmsServiceCatalog
 
             // Get a list of selected LayerInfos.
             List<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info).ToList();
+			
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
 
             // Return if no layers are selected.
             if (!selectedLayers.Any())

--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.xaml.cs
@@ -83,6 +83,9 @@ namespace ArcGISRuntime.WinUI.Samples.WmsServiceCatalog
 
             // Get a list of selected LayerInfos.
             List<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info).ToList();
+			
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
 
             // Return if no layers selected.
             if (!selectedLayers.Any())

--- a/src/iOS/Xamarin.iOS/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/WmsServiceCatalog/WmsServiceCatalog.cs
@@ -93,6 +93,9 @@ namespace ArcGISRuntime.Samples.WmsServiceCatalog
 
             // Get a list of selected LayerInfos.
             IEnumerable<WmsLayerInfo> selectedLayers = displayList.Where(vm => vm.IsEnabled).Select(vm => vm.Info);
+			
+            // Only WMS layer infos without sub layers can be used to construct a WMS layer. Group layers that have sub layers must be excluded.
+            selectedLayers = selectedLayers.Where(info => info.LayerInfos.Count == 0).ToList();
 
             // Create a new WmsLayer from the selected layers.
             WmsLayer myLayer = new WmsLayer(selectedLayers);


### PR DESCRIPTION
# Description

`WmsLayer` is not compatible with any WMS group layers that have sublayers. This PR adds a line to remove any group layers from the list of `WmsLayerInfo`s.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WPF .NET 6
- [x] WPF Framework
- [x] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [x] Xamarin.Forms UWP
- [x] UWP
- [ ] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [x] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
