### PR TITLE
Fix .projitems bug in Xamarin.Forms

### DIFF
--- a/src/Forms/Shared/Forms.projitems
+++ b/src/Forms/Shared/Forms.projitems
@@ -18,10 +18,6 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-  <!-- Unique samples -->
-  <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Samples\NetworkAnalysis\NavigateRouteRerouting\GpxProvider.cs" />
-  </ItemGroup>
   <!-- Sample Manager Code -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ApiKeyPrompt.xaml.cs">


### PR DESCRIPTION
# Description

Removed outdated code reference from Forms .projitems.

## Type of change

- [x] Bug fix
