### PR TITLE
MAUI - Fixed bug where detail pages were visible before mapview loaded

### DIFF
--- a/src/MAUI/Maui.Samples/SamplePage.xaml
+++ b/src/MAUI/Maui.Samples/SamplePage.xaml
@@ -17,10 +17,10 @@
                      Text="Source" />
     </ContentPage.ToolbarItems>
     <Grid>
-        <Border x:Name="SampleDetailPage" >
+        <Border x:Name="SampleDetailPage">
             <WebView x:Name="DescriptionView" />
         </Border>
-        <Border x:Name="SourceCodePage" >
+        <Border x:Name="SourceCodePage">
             <StackLayout>
                 <StackLayout Orientation="Horizontal">
                     <Button Margin="5"
@@ -34,6 +34,9 @@
                 <WebView x:Name="SourceCodeView" VerticalOptions="FillAndExpand" />
             </StackLayout>
         </Border>
-        <Border x:Name="SampleContentPage" Padding="0" />
+        <Border x:Name="SampleContentPage"
+                Padding="0"
+                BackgroundColor="{AppThemeBinding Light=#dfdfdf,
+                                                  Dark=#303030}" />
     </Grid>
 </ContentPage>


### PR DESCRIPTION
# Description

This was broken when adding the description page and source code viewing. Adding a background to the sample container resolves the issue.