### PR TITLE
WinUI: Fix ArcGIS token challenge sample

### DIFF
--- a/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
+++ b/src/WinUI/ArcGISRuntime.WinUI.Viewer/Samples/Security/TokenSecuredChallenge/TokenSecuredChallenge.xaml.cs
@@ -84,7 +84,7 @@ namespace ArcGISRuntime.WinUI.Samples.TokenSecuredChallenge
         private async Task<Credential> Challenge(CredentialRequestInfo info)
         {
             // Get user credentials (on the UI thread).
-            if (this.Dispatcher == null)
+            if (this.DispatcherQueue == null)
             {
                 // No current dispatcher, code is already running on the UI thread.
                 return await GetUserCredentialsFromUI(info);


### PR DESCRIPTION
# Description

The TokenSecuredChallenger method checks for 'Dispatcher', a call that was deprecated in WinUI Preview 4. This fix changes to the newer 'DispatcherQueue'. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WinUI

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab
