### PR TITLE
Add missing null-check to LocationDisplay.Location

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.FindPlace
                         status = await Microsoft.Maui.ApplicationModel.Permissions.CheckStatusAsync<Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse>();
 
                         // Request location permission if not granted.
-                        if(status != Microsoft.Maui.ApplicationModel.PermissionStatus.Granted)
+                        if (status != Microsoft.Maui.ApplicationModel.PermissionStatus.Granted)
                         {
                             status = await Microsoft.Maui.ApplicationModel.Permissions.RequestAsync<Microsoft.Maui.ApplicationModel.Permissions.LocationWhenInUse>();
                         }
@@ -126,8 +126,8 @@ namespace ArcGIS.Samples.FindPlace
             }
             else
             {
-                // Get the current device location.
-                return MyMapView.LocationDisplay.Location.Position;
+                // Get the current device location (if available).
+                return MyMapView.LocationDisplay.Location?.Position;
             }
         }
 

--- a/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -120,8 +120,8 @@ namespace ArcGIS.WPF.Samples.FindPlace
             }
             else
             {
-                // Get the current device location.
-                return MyMapView.LocationDisplay.Location.Position;
+                // Get the current device location (if available).
+                return MyMapView.LocationDisplay.Location?.Position;
             }
         }
 

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -122,7 +122,7 @@ namespace ArcGIS.WinUI.Samples.FindPlace
             }
             else
             {
-                // Get the current device location
+                // Get the current device location (if available).
                 return MyMapView.LocationDisplay.Location?.Position;
             }
         }


### PR DESCRIPTION
# Description
The Location property may be null if location data source is still initializing or if the app doesn't have location permission.

Without this null-check, samples app can throw a NullReferenceException when switching samples or when location permission is denied. And, generally, it's a good idea to train our users to null-check this.

## Type of change
- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:
- [x] UWP

## Checklist

- [x] Runs and compiles on all active platforms
- [ ] ~Legacy platforms still compile and run (if applicable)~
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [ ] ~All variable and method names are good and make sense~
- [x] There is no leftover commented code
- [ ] ~Screenshots are correct size and display in description tab~
