### PR TITLE
MAUI MacCatalyst: Added workaround for search visibility

### DIFF
--- a/src/MAUI/Maui.Samples/CategoryListPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryListPage.xaml
@@ -2,7 +2,7 @@
 <ContentPage x:Class="ArcGIS.CategoryListPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:resources="clr-namespace:ArcGIS.Resources">
+             >
     <ContentPage.ToolbarItems>
         <ToolbarItem Clicked="SettingsClicked"
                      IconImageSource="{AppThemeBinding Light=settings.png,

--- a/src/MAUI/Maui.Samples/CategoryListPage.xaml
+++ b/src/MAUI/Maui.Samples/CategoryListPage.xaml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage x:Class="ArcGIS.CategoryListPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             >
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <ContentPage.ToolbarItems>
         <ToolbarItem Clicked="SettingsClicked"
                      IconImageSource="{AppThemeBinding Light=settings.png,
@@ -23,8 +22,7 @@
                   SelectionMode="None">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <TextCell Text="{Binding Name}" TextColor="{AppThemeBinding Light=Black, 
-                                                                                Dark=LightGray}" />
+                    <TextCell Text="{Binding Name}" TextColor="{AppThemeBinding Light=Black, Dark=LightGray}" />
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
@@ -36,8 +34,7 @@
                   SelectionMode="None">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <TextCell Text="{Binding SampleName}" TextColor="{AppThemeBinding Light=Black, 
-                                                                                      Dark=LightGray}" />
+                    <TextCell Text="{Binding SampleName}" TextColor="{AppThemeBinding Light=Black, Dark=LightGray}" />
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/src/MAUI/Maui.Samples/CategoryListPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/CategoryListPage.xaml.cs
@@ -7,10 +7,10 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
+using ArcGIS.Helpers;
 using ArcGIS.Samples.Managers;
 using ArcGIS.Samples.Shared.Managers;
 using ArcGIS.Samples.Shared.Models;
-using ArcGIS.Helpers;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -40,12 +40,11 @@ namespace ArcGIS
             // Workaround visibility binding bug on Mac Catalyst.
             ViewModel.PropertyChanged += MacVisibilityHandler;
 #endif
-
         }
 
         private void MacVisibilityHandler(object sender, PropertyChangedEventArgs e)
         {
-            if(e.PropertyName == "IsSearchOpen" )
+            if (e.PropertyName == "IsSearchOpen")
             {
                 SampleSearchResultList.IsVisible = ((SamplesSearchViewModel)sender).IsSearchOpen;
             }

--- a/src/MAUI/Maui.Samples/CategoryListPage.xaml.cs
+++ b/src/MAUI/Maui.Samples/CategoryListPage.xaml.cs
@@ -35,6 +35,20 @@ namespace ArcGIS
 
             // Update the binding.
             BindingContext = ViewModel;
+
+#if MACCATALYST
+            // Workaround visibility binding bug on Mac Catalyst.
+            ViewModel.PropertyChanged += MacVisibilityHandler;
+#endif
+
+        }
+
+        private void MacVisibilityHandler(object sender, PropertyChangedEventArgs e)
+        {
+            if(e.PropertyName == "IsSearchOpen" )
+            {
+                SampleSearchResultList.IsVisible = ((SamplesSearchViewModel)sender).IsSearchOpen;
+            }
         }
 
         private void FirstLoaded(object sender, EventArgs e)


### PR DESCRIPTION
# Description

Added a workaround for a visibility property that wasn't functioning correctly on MacCatalyst.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Maui WinUI
- [ ] Maui Android
- [ ] Maui iOS
- [x] Maui MacCatalyst

## Checklist

- [x] Runs and compiles on all active platforms
- [x] Legacy platforms still compile and run (if applicable)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] `sample_sync.py` runs without making changes
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] Code is commented with correct formatting
- [x] All variable and method names are good and make sense
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab
