### PR TITLE
Set correct Windows min version

### DIFF
--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -24,7 +24,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">26.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>ArcGISMapsSDKMaui</RootNamespace>
 		<AssemblyName>ArcGISMapsSDKMaui</AssemblyName>
         <DefineConstants>$(DefineConstants);MAUI</DefineConstants>

--- a/src/WPF/WPF.StorePackage/ArcGIS.WPF.StorePackage.wapproj
+++ b/src/WPF/WPF.StorePackage/ArcGIS.WPF.StorePackage.wapproj
@@ -37,7 +37,7 @@
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
     <ProjectGuid>13a60801-7b9a-4573-923f-9f2373e8bf84</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PackageCertificateKeyFile>ArcGISRuntime.WPF.StorePackage_TemporaryKey.pfx</PackageCertificateKeyFile>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -15,7 +15,7 @@
     <PublishSingleFile Condition="'$(RuntimeIdentifier)' != ''">true</PublishSingleFile>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <Platforms>AnyCPU;x64;x86</Platforms>
-    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
    </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
# Description

Min version for Win10 is 17763

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] WPF .NET 6
- [ ] WPF Framework
- [ ] WinUI
- [ ] Xamarin.Forms Android
- [ ] Xamarin.Forms iOS
- [ ] Xamarin.Forms UWP

- [ ] UWP
- [ ] Xamarin.Android
- [ ] Xamarin.iOS

## Checklist

- [ ] Runs and compiles on all active platforms
- [ ] Legacy platforms still compile and run (if applicable)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [ ] All variable and method names are good and make sense
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab
