### PR TITLE
WPF: Fix crash in Create mobile geodatabase

### DIFF
--- a/src/WPF/WPF.Viewer/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml
+++ b/src/WPF/WPF.Viewer/Samples/Data/CreateMobileGeodatabase/CreateMobileGeodatabase.xaml
@@ -28,7 +28,9 @@
                 Visibility="Hidden">
             <StackPanel>
                 <ScrollViewer Height="400" Margin="5">
-                    <DataGrid x:Name="TableDataGrid" AutoGenerateColumns="False">
+                    <DataGrid x:Name="TableDataGrid"
+                              AutoGenerateColumns="False"
+                              IsReadOnly="True">
                         <DataGrid.Columns>
                             <DataGridTextColumn Binding="{Binding Path=Attributes[oid]}" Header="OID" />
                             <DataGridTextColumn Binding="{Binding Path=Attributes[collection_timestamp]}" Header="Collection Timestamp" />


### PR DESCRIPTION
# Description

Makes table read only preventing a crash when users double-click on the table.

## Type of change

- [x] Bug fix