### PR TITLE
NullReferenceException fixed for WinUI sketch-on-map sample

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/GraphicsOverlay/SketchOnMap/SketchOnMap.xaml.cs
@@ -80,9 +80,6 @@ namespace ArcGIS.WinUI.Samples.SketchOnMap
 
         private Graphic SaveGraphic(Geometry geometry)
         {
-            // Gray out any selected tool.
-            EnabledTool.Background = LightGray;
-
             // Create a graphic to display the specified geometry.
             Esri.ArcGISRuntime.Symbology.Symbol symbol = null;
             if (geometry != null)


### PR DESCRIPTION
# Description

UI helper methods should set button background, not any other method. This fixes a NullReferenceException.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] WinUI

## Checklist

- [ ] Self-review of changes
- [ ] Runs and compiles on all active platforms
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] `sample_sync.py` runs without making changes
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] Code is commented with correct formatting
- [ ] All variable and method names are good and make sense
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, 600 height mobile screenshots for MAUI)
