### PR TITLE
Tools: don't use `latest` in redirect paths

### DIFF
--- a/tools/metadata_tools/sample_metadata.py
+++ b/tools/metadata_tools/sample_metadata.py
@@ -87,7 +87,7 @@ class sample_metadata:
 
         # populate redirect_from; it is based on a pattern
         real_platform = platform
-        redirect_string = f"/net/latest/{real_platform.lower()}/sample-code/{slugged_sample_name}.htm"
+        redirect_string = f"/net/{real_platform.lower()}/sample-code/{slugged_sample_name}.htm"
         self.redirect_from.append(redirect_string)
 
         # category is the name of the folder containing the sample folder

--- a/tools/sample_generator/templates/default/readme.metadata.json
+++ b/tools/sample_generator/templates/default/readme.metadata.json
@@ -9,7 +9,7 @@
     "keywords": [
     ],
     "redirect_from": [
-        "/net/latest/wpf/sample-code/sample_name.htm"
+        "/net/wpf/sample-code/sample_name.htm"
     ],
     "relevant_apis": [
     ],


### PR DESCRIPTION
Removes `latest` from redirect links in sample generator and sample metadata scripts