### PR TITLE
Changing .NET framework version to .NET 9 MAUI on \Build commands

### DIFF
--- a/.github/workflows/BuildSuccess_Check.yaml
+++ b/.github/workflows/BuildSuccess_Check.yaml
@@ -24,19 +24,19 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Build MAUI (Windows)
       run: |
-        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net8.0-windows10.0.19041.0 /p:RuntimeIdentifier=win10-x64 /p:RuntimeIdentifierOverride=win10-x64 /p:UseRidGraph=true
+        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net9.0-windows10.0.19041.0 /p:RuntimeIdentifier=win10-x64 /p:RuntimeIdentifierOverride=win10-x64 /p:UseRidGraph=true
     
     - name: Build MAUI (Android)
       run: |
-        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net8.0-android
+        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net9.0-android
     
     - name: Build MAUI (iOS)
       run: |
-        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net8.0-ios
+        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net9.0-ios
     
     - name: Build MAUI (Mac)
       run: |
-        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net8.0-maccatalyst
+        msbuild /restore /t:Build src/MAUI/ArcGIS.Samples.MAUI.sln /p:Configuration=Release /p:CentralPackageManagementEnabled=true /p:TargetFramework=net9.0-maccatalyst
 
 
 # WPF .NET Build


### PR DESCRIPTION
# Description

This PR aims to resolve the broken MAUI Build check GitHub action job that has been broken for some time now due to targeting .NET 8. MAUI has required .NET 9 since 200.7.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] Make sure the job passes on devtopia

## Checklist

<!--- Delete any that don't apply -->

- [ ] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
