### PR TITLE
WinUI: Fix button icons in UN geometry snapping sample

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml
@@ -23,7 +23,7 @@
         </DataTemplate>
         <Style x:Key="IconStyle" TargetType="Button">
             <Style.Setters>
-                <Setter Property="FontFamily" Value="pack://application:,,,/Resources/Fonts/#calcite-ui-icons-24" />
+                <Setter Property="FontFamily" Value="/Resources/Fonts/calcite-ui-icons-24.ttf#calcite-ui-icons-24" />
                 <Setter Property="FontSize" Value="25" />
                 <Setter Property="Background" Value="White" />
                 <Setter Property="HorizontalAlignment" Value="Stretch" />


### PR DESCRIPTION
# Description
Fix XAML reference to icon resources for SnapGeometryEditsWithUtilityNetworkRules.
Before:
<img width="188" height="148" alt="ArcGIS WinUI Viewer_4kFlkG9oDH" src="https://github.com/user-attachments/assets/0b0967ca-5886-41fb-b6bc-7dc65dc63e4c" />

After:
<img width="174" height="141" alt="ArcGIS WinUI Viewer_f2lhanayuD" src="https://github.com/user-attachments/assets/7582535b-79f5-44a6-b2f4-f08f14b5baf7" />

This is the only sample that had this font issue; all others already use icons correctly. No screenshot update needed.

## Type of change
- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WPF Framework
- [x] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] ~Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)~
