### PR TITLE
Fix WinUI PKI auth sample

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Security/CertificateAuthenticationWithPki/CertificateAuthenticationWithPKI.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Security/CertificateAuthenticationWithPki/CertificateAuthenticationWithPKI.xaml.cs
@@ -104,12 +104,6 @@ namespace ArcGIS.WinUI.Samples.CertificateAuthenticationWithPKI
         {
             try
             {
-                // Workaround for HTTP client bug affecting System.Net.HttpClient.
-                // https://github.com/dotnet/corefx/issues/37598
-                var httpClient = new Windows.Web.Http.HttpClient();
-                await httpClient.GetStringAsync(new Uri(PortalUrlTextbox.Text));
-                // End workaround
-
                 // Store the server URL for later reference.
                 _serverUrl = PortalUrlTextbox.Text;
 


### PR DESCRIPTION
# Description

Fix for WinUI PKI authentication sample attempting to connect to server before getting certificate.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
