### PR TITLE
Barrier routing sample hotfix

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -149,9 +149,6 @@ namespace ArcGIS.Samples.RouteAroundBarriers
 
         private async Task ConfigureThenRoute()
         {
-            // Show calculating dialog
-            UpdateInterfaceState(SampleState.Routing);
-
             // Guard against error conditions.
             if (_routeParameters == null)
             {
@@ -164,6 +161,9 @@ namespace ArcGIS.Samples.RouteAroundBarriers
                 ShowMessage("Not enough stops", "Add at least two stops before solving a route.");
                 return;
             }
+
+            // Show calculating dialog
+            UpdateInterfaceState(SampleState.Routing);
 
             // Clear any existing route from the map.
             _routeOverlay.Graphics.Clear();
@@ -398,7 +398,7 @@ namespace ArcGIS.Samples.RouteAroundBarriers
 
         private void ShowMessage(string title, string detail)
         {
-            DisplayAlert(title, detail, "OK");
+            Application.Current.Windows[0].Page.DisplayAlert(title, detail, "OK");
         }
     }
 }

--- a/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -156,9 +156,6 @@ namespace ArcGIS.WPF.Samples.RouteAroundBarriers
 
         private async Task ConfigureThenRoute()
         {
-            // Show calculating dialog
-            UpdateInterfaceState(SampleState.Routing);
-
             // Guard against error conditions.
             if (_routeParameters == null)
             {
@@ -171,6 +168,9 @@ namespace ArcGIS.WPF.Samples.RouteAroundBarriers
                 ShowMessage("Not enough stops", "Add at least two stops before solving a route.");
                 return;
             }
+
+            // Show calculating dialog
+            UpdateInterfaceState(SampleState.Routing);
 
             // Clear any existing route from the map.
             _routeOverlay.Graphics.Clear();

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/NetworkAnalysis/RouteAroundBarriers/RouteAroundBarriers.xaml.cs
@@ -154,9 +154,6 @@ namespace ArcGIS.WinUI.Samples.RouteAroundBarriers
 
         private async Task ConfigureThenRoute()
         {
-            // Show calculating dialog
-            UpdateInterfaceState(SampleState.Routing);
-
             // Guard against error conditions.
             if (_routeParameters == null)
             {
@@ -169,6 +166,9 @@ namespace ArcGIS.WinUI.Samples.RouteAroundBarriers
                 ShowMessage("Not enough stops", "Add at least two stops before solving a route.");
                 return;
             }
+
+            // Show calculating dialog
+            UpdateInterfaceState(SampleState.Routing);
 
             // Clear any existing route from the map.
             _routeOverlay.Graphics.Clear();


### PR DESCRIPTION
# Description

Fix for a bug introduced to the route around barriers samples in pull request #1671. When the Calculate Route button was pressed without having first defined 2 stops, the UI would disable the configuration bar and never re-enable it.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [ ] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
