### PR TITLE
WinUI: Remove x86 configs

### DIFF
--- a/src/WinUI/ArcGIS.WinUI.Viewer.sln
+++ b/src/WinUI/ArcGIS.WinUI.Viewer.sln
@@ -11,10 +11,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -23,14 +21,12 @@ Global
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|x64.ActiveCfg = Debug|x64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|x64.Build.0 = Debug|x64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|x64.Deploy.0 = Debug|x64
-		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|x86.ActiveCfg = Debug|x86
-		{22859B00-B68B-43E8-A402-20DBA622A27A}.Debug|x86.Build.0 = Debug|x86
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|ARM64.ActiveCfg = Release|ARM64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|ARM64.Build.0 = Release|ARM64
+		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|ARM64.Deploy.0 = Release|ARM64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.ActiveCfg = Release|x64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.Build.0 = Release|x64
-		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x86.ActiveCfg = Release|x86
-		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x86.Build.0 = Release|x86
+		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.Deploy.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Description

Removes the now invalid x86 config from the WinUI solution.
Follow-up to PR https://github.com/Esri/arcgis-maps-sdk-dotnet-samples/pull/1666

## Type of change

- Other enhancement

## Platforms tested on

- [x] WinUI

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [x] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
