### PR TITLE
Fix viewshed geoprocessing sample making requests to the wrong endpoint

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -113,8 +113,9 @@ namespace ArcGIS.Samples.AnalyzeViewshed
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
             // Create the parameters that are passed to the used geoprocessing task.
+            // Since the service used is only configured for the execute endpoint, construct the parameters using GeoprocessingExecutionType.SynchronousExecute.
             GeoprocessingParameters myViewshedParameters =
-                new GeoprocessingParameters(GeoprocessingExecutionType.AsynchronousSubmit)
+                new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
                     // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference

--- a/src/WPF/WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -129,8 +129,9 @@ namespace ArcGIS.WPF.Samples.AnalyzeViewshed
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
             // Create the parameters that are passed to the used geoprocessing task.
+            // Since the service used is only configured for the execute endpoint, construct the parameters using GeoprocessingExecutionType.SynchronousExecute.
             GeoprocessingParameters myViewshedParameters =
-                new GeoprocessingParameters(GeoprocessingExecutionType.AsynchronousSubmit)
+                new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
                     // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Geoprocessing/AnalyzeViewshed/AnalyzeViewshed.xaml.cs
@@ -129,8 +129,9 @@ namespace ArcGIS.WinUI.Samples.AnalyzeViewshed
             await myInputFeatures.AddFeatureAsync(myInputFeature);
 
             // Create the parameters that are passed to the used geoprocessing task.
+            // Since the service used is only configured for the execute endpoint, construct the parameters using GeoprocessingExecutionType.SynchronousExecute.
             GeoprocessingParameters myViewshedParameters =
-                new GeoprocessingParameters(GeoprocessingExecutionType.AsynchronousSubmit)
+                new GeoprocessingParameters(GeoprocessingExecutionType.SynchronousExecute)
                 {
                     // Request the output features to use the same SpatialReference as the map view.
                     OutputSpatialReference = MyMapView.SpatialReference


### PR DESCRIPTION
# Description

The Analyze Viewshed (geoprocessing) sample was passing a parameter that caused its GeoprocessingJob to query the wrong endpoint on the example viewshed service. This fixes the parameter.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
