### PR TITLE
Increment android version number

### DIFF
--- a/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
+++ b/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.samples.maui" android:versionCode="8" android:versionName="300.0.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.samples.maui" android:versionCode="9" android:versionName="300.0.0">
 	<application android:allowBackup="true" android:usesCleartextTraffic="true" android:icon="@mipmap/appiconandroid" android:roundIcon="@mipmap/appiconandroid_round" android:supportsRtl="true" android:label="ArcGIS Maps .NET MAUI Samples"></application>
 	<uses-sdk android:minSdkVersion="26" android:targetSdkVersion="35" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
# Description

As part of the internal release exercises a bundle was uploaded to google developer console and added it to an internal test track. Bundles that have been added to a track may not be deleted, and new bundles uploaded to the console must not share an android version number. This branch increments the android version number to avoid conflicts during the true release.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI Android

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
