### PR TITLE
Handle snap geometry exception

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
@@ -265,9 +265,16 @@ namespace ArcGIS.Samples.SnapGeometryEditsWithUtilityNetworkRules
             // Stop the geometry editor and get the updated geometry.
             Geometry geometry = MyMapView.GeometryEditor.Stop();
 
-            // Update the feature with the new geometry.
-            _selectedFeature.Geometry = geometry;
-            await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            try
+            {
+                // Update the feature with the new geometry.
+                _selectedFeature.Geometry = geometry;
+                await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            }
+            catch (Exception ex)
+            {
+                await Application.Current.Windows[0].Page.DisplayAlert("Error", ex.ToString(), "OK");
+            }
 
             // Reset the selection.
             ResetSelections();

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
@@ -20,10 +20,10 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using Esri.ArcGISRuntime.UI.Editing;
-using Geometry = Esri.ArcGISRuntime.Geometry.Geometry;
 using ArcGIS.Samples.Managers;
 using Esri.ArcGISRuntime.UtilityNetworks;
 using System.Collections.Generic;
+using Geometry = Esri.ArcGISRuntime.Geometry.Geometry;
 
 namespace ArcGIS.WPF.Samples.SnapGeometryEditsWithUtilityNetworkRules
 {
@@ -269,9 +269,16 @@ namespace ArcGIS.WPF.Samples.SnapGeometryEditsWithUtilityNetworkRules
             // Stop the geometry editor and get the updated geometry.
             Geometry geometry = MyMapView.GeometryEditor.Stop();
 
-            // Update the feature with the new geometry.
-            _selectedFeature.Geometry = geometry;
-            await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            try
+            {
+                // Update the feature with the new geometry.
+                _selectedFeature.Geometry = geometry;
+                await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString(), "Error");
+            }
 
             // Reset the selection.
             ResetSelections();

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/SnapGeometryEditsWithUtilityNetworkRules/SnapGeometryEditsWithUtilityNetworkRules.xaml.cs
@@ -269,9 +269,16 @@ namespace ArcGIS.WinUI.Samples.SnapGeometryEditsWithUtilityNetworkRules
             // Stop the geometry editor and get the updated geometry.
             Geometry geometry = MyMapView.GeometryEditor.Stop();
 
-            // Update the feature with the new geometry.
-            _selectedFeature.Geometry = geometry;
-            await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            try
+            {
+                // Update the feature with the new geometry.
+                _selectedFeature.Geometry = geometry;
+                await ((GeodatabaseFeatureTable)_selectedFeature.FeatureTable).UpdateFeatureAsync(_selectedFeature);
+            }
+            catch (Exception ex)
+            {
+                await new MessageDialog2(ex.ToString(), "Error").ShowAsync();
+            }
 
             // Reset the selection.
             ResetSelections();


### PR DESCRIPTION
# Description

Currently the Snap geometry edits with utility network rules sample crashes when the user attempts to place a point outside of the geodatabase replica boundaries. This branch handles the exception.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
