### PR TITLE
Fix MAUI NMEA sample crash

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/LocationWithNMEA/LocationWithNMEA.xaml.cs
@@ -64,7 +64,7 @@ namespace ArcGIS.Samples.LocationWithNMEA
             // Load the map and assign the location data source.
             MyMapView.PropertyChanged += (s, e) =>
             {
-                if (e.PropertyName == nameof(MapView.LocationDisplay))
+                if (e.PropertyName == nameof(MapView.LocationDisplay) && MyMapView.LocationDisplay != null)
                     MyMapView.LocationDisplay.DataSource = _nmeaSource;
             };
 


### PR DESCRIPTION
# Description

Adds a null check to avoid crashing when exiting the sample.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [ ] No unrelated changes have been made to any other code or project files
