### PR TITLE
Fix Maui navigate route bug

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/NavigateRoute/NavigateRoute.xaml.cs
@@ -198,9 +198,11 @@ namespace ArcGIS.Samples.NavigateRoute
                 {
                     _tracker.SwitchToNextDestinationAsync();
                 }
-
-                // Stop the simulated location data source.
-                MyMapView.LocationDisplay.DataSource.StopAsync();
+                else
+                {
+                    // Stop the simulated location data source.
+                    MyMapView.LocationDisplay.DataSource.StopAsync();
+                }
             }
 
             Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>


### PR DESCRIPTION
# Description

Previously the LocationDisplay DataSource would always be stopped when a waypoint was hit, causing the display to disappear and stop following the route. This fixes the issue

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [ ] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
