### PR TITLE
Maui: Addressed a xamlc binding warning in FilterBuildingSceneLayer

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/FilterBuildingSceneLayer/FilterBuildingSceneLayer.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FilterBuildingSceneLayer/FilterBuildingSceneLayer.xaml
@@ -3,6 +3,7 @@
     x:Class="ArcGIS.Samples.FilterBuildingSceneLayer.FilterBuildingSceneLayer"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:ArcGIS.Samples.FilterBuildingSceneLayer"
     xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
     <Grid>
         <!--  LocalSceneView displays the 3D building scene.  -->
@@ -86,7 +87,7 @@
                 <ScrollView Grid.Row="1" MaximumHeightRequest="200">
                     <CollectionView x:Name="FeatureAttributesCollection" ItemsLayout="VerticalList">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="local:BuildingSceneFeatureAttribute">
                                 <VerticalStackLayout Margin="0,4" Spacing="2">
                                     <Label FontAttributes="Bold" FontSize="12">
                                         <Label.FormattedText>

--- a/src/MAUI/Maui.Samples/Samples/Layers/FilterBuildingSceneLayer/FilterBuildingSceneLayer.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Layers/FilterBuildingSceneLayer/FilterBuildingSceneLayer.xaml.cs
@@ -266,7 +266,7 @@ namespace ArcGIS.Samples.FilterBuildingSceneLayer
         private void DisplayFeatureAttributes(Feature feature)
         {
             FeatureAttributesCollection.ItemsSource = feature.Attributes
-                .Select(a => new KeyValuePair<string, string>(a.Key, a.Value?.ToString() ?? "N/A"))
+                .Select(a => new BuildingSceneFeatureAttribute(a.Key, a.Value?.ToString() ?? "N/A"))
                 .ToList();
 
             SettingsPanel.IsVisible = false;
@@ -284,6 +284,22 @@ namespace ArcGIS.Samples.FilterBuildingSceneLayer
             FeaturePanel.IsVisible = false;
             FeatureAttributesCollection.ItemsSource = null;
             SettingsPanel.IsVisible = true;
+        }
+    }
+
+    /// <summary>
+    /// This class represents a key-value pair for displaying feature attributes. It is used instead of a
+    /// KeyValuePair generic to help data binding in the xaml file.
+    /// </summary>
+    public sealed class BuildingSceneFeatureAttribute
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+
+        public BuildingSceneFeatureAttribute(string key, string value)
+        {
+            Key = key;
+            Value = value;
         }
     }
 }


### PR DESCRIPTION
# Description

Addressed a xamlc binding warning on Maui.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
