### PR TITLE
Update indoor positioning sample

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/IndoorPositioning.xaml.cs
@@ -30,13 +30,12 @@ namespace ArcGIS.Samples.IndoorPositioning
 
         private int? _currentFloor = null;
 
-        // Provide your own data in order to use this sample. Code in the sample may need to be modified to work with other maps.
-
+        // Provide your own data in order to use this sample in a local building
         #region BuildingData
 
         private Uri _portalUri = new Uri("https://www.arcgis.com/");
 
-        private const string ItemId = "YOUR_ITEM_ID_HERE";
+        private const string ItemId = "8fa941613b4b4b2b8a34ad4cdc3e4bba";
 
         private string[] _layerNames = new string[] { "Details", "Units", "Levels" };
 

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
@@ -10,7 +10,7 @@ An indoor positioning system (IPS) allows you to locate yourself and others insi
 
 ## How to use the sample
 
-When the device is within range of an IPS beacon, toggle "Show Location" to change the visibility of the location indicator in the map view. The system will ask for permission to use the device's location if the user has not yet used location services in this app. It will then start the location display with auto-pan mode set to `navigation`.
+When the device is within range of an IPS beacon, toggle "Show Location" to change the visibility of the location indicator in the map view. The system will ask for permission to use the device's location if the user has not yet used location services in this app. It will then start the location display with auto-pan mode set to `Navigation`.
 
 When there is no IPS beacons nearby, or other errors occur while initializing the indoors location data source, it will seamlessly fall back to the current device location as determined by GPS.
 
@@ -27,7 +27,7 @@ When there is no IPS beacons nearby, or other errors occur while initializing th
 
 * IndoorPositioningDefinition
 * IndoorsLocationDataSource
-* LocationChangeHandlerDelegate
+* Location
 * LocationDisplay
 * LocationDisplayAutoPanMode
 * Map

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.md
@@ -10,14 +10,14 @@ An indoor positioning system (IPS) allows you to locate yourself and others insi
 
 ## How to use the sample
 
-When the device is within range of an IPS beacon, toggle "Show Location" to change the visibility of the location indicator in the map view. The system will ask for permission to use the device's location if the user has not yet used location services in this app. It will then start the location display with auto-pan mode set to `Navigation`.
+When the device is within range of an IPS beacon, toggle "Show Location" to change the visibility of the location indicator in the map view. The system will ask for permission to use the device's location if the user has not yet used location services in this app. It will then start the location display with auto-pan mode set to `navigation`.
 
 When there is no IPS beacons nearby, or other errors occur while initializing the indoors location data source, it will seamlessly fall back to the current device location as determined by GPS.
 
 ## How it works
 
 1. Load an IPS-aware map. This can be a web map hosted as a portal item in ArcGIS Online, an Enterprise Portal, or a mobile map package (.mmpk) created with ArcGIS Pro.
-2. Create and load an `IndoorsLocationDataSource` (stored with the map), then create an `IndoorsLocationDataSource` from it.
+2. Create and load an `IndoorPositioningDefinition` (stored with IPS-aware maps), then create an `IndoorsLocationDataSource` from it.
 3. Handle location change events to respond to floor changes or read other metadata for locations.
 4. Assign the `IndoorsLocationDataSource` to the map view's location display.
 5. Enable and disable the map view's location display using `StartAsync()` and `StopAsync()`. Device location will appear on the display as a blue dot and update as the user moves throughout the space.
@@ -25,11 +25,9 @@ When there is no IPS beacons nearby, or other errors occur while initializing th
 
 ## Relevant API
 
-* ArcGISFeatureTable
-* FeatureTable
 * IndoorPositioningDefinition
 * IndoorsLocationDataSource
-* Location
+* LocationChangeHandlerDelegate
 * LocationDisplay
 * LocationDisplayAutoPanMode
 * Map
@@ -37,7 +35,7 @@ When there is no IPS beacons nearby, or other errors occur while initializing th
 
 ## About the data
 
-This sample uses an [IPS-enabled web map](https://www.arcgis.com/home/item.html?id=8fa941613b4b4b2b8a34ad4cdc3e4bba) that displays Building L on the Esri Redlands campus. Please note: you would only be able to use the indoor positioning functionalities when you are inside this building. Swap the web map to test with your own IPS setup.
+This sample uses an [IPS-enabled web map](https://www.arcgis.com/home/item.html?id=8fa941613b4b4b2b8a34ad4cdc3e4bba) that displays Building M on the Esri Redlands campus. Please note: you would only be able to use the indoor positioning functionalities when you are inside this building. Swap the web map to test with your own IPS setup.
 
 ## Additional information
 

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
@@ -30,7 +30,7 @@
     "relevant_apis": [
         "IndoorPositioningDefinition",
         "IndoorsLocationDataSource",
-        "LocationChangeHandlerDelegate",
+        "Location",
         "LocationDisplay",
         "LocationDisplayAutoPanMode",
         "Map",

--- a/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
+++ b/src/MAUI/Maui.Samples/Samples/Location/IndoorPositioning/readme.metadata.json
@@ -28,11 +28,9 @@
         "/net/latest/maui/sample-code/show-device-location-using-indoor-positioning.htm"
     ],
     "relevant_apis": [
-        "ArcGISFeatureTable",
-        "FeatureTable",
         "IndoorPositioningDefinition",
         "IndoorsLocationDataSource",
-        "Location",
+        "LocationChangeHandlerDelegate",
         "LocationDisplay",
         "LocationDisplayAutoPanMode",
         "Map",


### PR DESCRIPTION
# Description

The indoor positioning sample was set up to only work if a user provided their own IPS-aware map. This leaves a blindspot during our own testing efforts, so I have added the Building M map that other home teams use. Also updated the readme with the latest information from common-samples.

## Note
You need to be on the second floor of M for the sample to work properly with the new data. (As in you need to be there physically with your device)

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI Android
- [x] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
