### PR TITLE
Address remaining xamlc warnings

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Layers/BrowseWfsLayers/BrowseWfsLayers.xaml
@@ -3,7 +3,8 @@
     x:Class="ArcGIS.Samples.BrowseWfsLayers.BrowseWfsLayers"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui">
+    xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Maui;assembly=Esri.ArcGISRuntime.Maui"
+    xmlns:esriOgc="clr-namespace:Esri.ArcGISRuntime.Ogc;assembly=Esri.ArcGISRuntime">
     <Grid Style="{DynamicResource EsriSampleContainer}">
         <esriUI:MapView x:Name="MyMapView" Style="{DynamicResource EsriSampleGeoView}" />
         <Border Style="{DynamicResource EsriSampleControlPanel}">
@@ -21,7 +22,7 @@
                     <Picker
                         x:Name="WfsLayerList"
                         Grid.Column="1"
-                        ItemDisplayBinding="{Binding Title}" />
+                        ItemDisplayBinding="{Binding Title, x:DataType=esriOgc:WfsLayerInfo}" />
                 </Grid>
                 <Label Text="Swap coordinate order:" />
                 <Switch x:Name="AxisOrderSwapCheckbox" HorizontalOptions="Start" />

--- a/src/MAUI/Maui.Samples/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.xaml
@@ -74,15 +74,13 @@
                     Margin="5"
                     HorizontalOptions="Fill"
                     IsEnabled="False"
-                    x:DataType="esri:BasemapStyleLanguageInfo"
-                    ItemDisplayBinding="{Binding DisplayName}" />
+                    ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:BasemapStyleLanguageInfo}" />
             <Label FontAttributes="Bold" Text="Worldview:" />
             <Picker x:Name="WorldviewPicker"
                     Margin="5"
                     HorizontalOptions="Fill"
                     IsEnabled="False"
-                    x:DataType="esri:Worldview"
-                    ItemDisplayBinding="{Binding DisplayName}" />
+                    ItemDisplayBinding="{Binding DisplayName, x:DataType=esri:Worldview}" />
             <Button Margin="5"
                     Clicked="LoadButton_Click"
                     Text="Load" />

--- a/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/ManageBookmarks/ManageBookmarks.xaml
@@ -15,8 +15,7 @@
                    VerticalTextAlignment="Center" />
             <Picker x:Name="BookmarkPicker"
                     Margin="5"
-                    x:DataType="esriMapping:Bookmark"
-                    ItemDisplayBinding="{Binding Path=Name}"
+                    ItemDisplayBinding="{Binding Path=Name, x:DataType=esriMapping:Bookmark}"
                     SelectedIndexChanged="BookmarkPicker_SelectedIndexChanged"
                     WidthRequest="200" />
             <Button x:Name="ButtonAddBookmark"

--- a/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml
+++ b/src/MAUI/Maui.Samples/Samples/Map/MapReferenceScale/MapReferenceScale.xaml
@@ -14,10 +14,9 @@
                     <!--  When the user's selection changes, the SelectedItem binding will apply the value to the Map's ReferenceScale property.  -->
                     <Picker x:Name="ReferenceScaleBox"
                             Margin="5"
-                            x:DataType="esriUI:MapView"
                             BindingContext="{x:Reference MyMapView}"
-                            ItemDisplayBinding="{Binding StringFormat='{0:n0}'}"
-                            SelectedItem="{Binding Path=Map.ReferenceScale}"
+                            ItemDisplayBinding="{Binding StringFormat='{0:n0}', x:DataType=x:Double}"
+                            SelectedItem="{Binding Path=Map.ReferenceScale, x:DataType=esriUI:MapView}"
                             VerticalOptions="Center" />
                     <Label Text="Choose layers to apply scale to:" />
                     <!--  Binding is used to display the operational layers for the map view's map, no code behind needed.  -->

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/FindRoute/FindRoute.xaml
@@ -36,13 +36,13 @@
                     RowSpacing="5">
                     <Label Grid.Row="0" Text="Route directions:" />
                     <ScrollView Grid.Row="1">
-                        <VerticalStackLayout x:Name="DirectionsListBox" BindableLayout.ItemsSource="{Binding}">
+                        <VerticalStackLayout x:Name="DirectionsListBox">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate>
                                     <Label
                                         Padding="5,3"
                                         FontSize="13"
-                                        Text="{Binding .}" />
+                                        Text="{Binding ., x:DataType=x:String}" />
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>
                         </VerticalStackLayout>

--- a/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml
+++ b/src/MAUI/Maui.Samples/Samples/NetworkAnalysis/OfflineRouting/OfflineRouting.xaml
@@ -16,8 +16,7 @@
                        Text="Click the map to add up to 5 stops. Route lines will be displayed automatically." />
                 <Picker x:Name="TravelModesPicker"
                         Grid.Row="1"
-                        x:DataType="networkAnalysis:TravelMode"
-                        ItemDisplayBinding="{Binding Name}" />
+                        ItemDisplayBinding="{Binding Name, x:DataType=networkAnalysis:TravelMode}" />
                 <Button Grid.Row="2"
                         Clicked="ResetButton_Click"
                         Text="Reset" />

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.xaml
@@ -56,8 +56,7 @@
                             <Picker x:Name="Attributes"
                                     Grid.Row="0"
                                     HorizontalOptions="Start"
-                                    x:DataType="esriUtility:UtilityNetworkAttribute"
-                                    ItemDisplayBinding="{Binding Name}"
+                                    ItemDisplayBinding="{Binding Name, x:DataType=esriUtility:UtilityNetworkAttribute}"
                                     MinimumWidthRequest="100"
                                     SelectedIndexChanged="OnAttributeChanged" />
                             <Picker x:Name="Operators"
@@ -67,8 +66,7 @@
                             <Picker x:Name="ValueSelection"
                                     Grid.Row="2"
                                     HorizontalOptions="Start"
-                                    x:DataType="esri:CodedValue"
-                                    ItemDisplayBinding="{Binding Name}"
+                                    ItemDisplayBinding="{Binding Name, x:DataType=esri:CodedValue}"
                                     MinimumWidthRequest="100" />
                             <Entry x:Name="ValueEntry"
                                    Grid.Row="2"

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml
@@ -12,9 +12,8 @@
             <Label Text="Add phases from the dropdown list, then run report." />
             <HorizontalStackLayout Spacing="5">
                 <Picker x:Name="PhasesList"
-                        x:DataType="esri:CodedValue"
                         IsEnabled="False"
-                        ItemDisplayBinding="{Binding Name}"
+                        ItemDisplayBinding="{Binding Name, x:DataType=esri:CodedValue}"
                         WidthRequest="150" />
                 <Button Clicked="OnAddPhase" Text="Add" />
             </HorizontalStackLayout>

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.xaml
@@ -20,10 +20,9 @@
                         <ColumnDefinition Width="auto" />
                     </Grid.ColumnDefinitions>
                     <Picker x:Name="CategoryPicker"
-                            x:DataType="esriUtility:UtilityCategory"
                             Grid.Column="0"
                             Margin="5"
-                            ItemDisplayBinding="{Binding Name}" />
+                            ItemDisplayBinding="{Binding Name,x:DataType=esriUtility:UtilityCategory}" />
                     <Button Grid.Column="1"
                             Margin="5"
                             Clicked="OnTrace"

--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.xaml
@@ -67,8 +67,7 @@
                        WidthRequest="170" />
                 <Picker x:Name="Choices"
                         Grid.Column="1"
-                        x:DataType="esri:CodedValue"
-                        ItemDisplayBinding="{Binding Name}"
+                        ItemDisplayBinding="{Binding Name, x:DataType=esri:CodedValue}"
                         WidthRequest="130" />
                 <Button Grid.Row="1"
                         Clicked="OnApplyEdits"


### PR DESCRIPTION
# Description

Turns out I handled a few xamlc warnings wrong, so they were still showing up and occasionally causing usability issues.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
