### PR TITLE
Add iOS CI build script

### DIFF
--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Default environment variables
-DOTNET_MAJOR_VERSION=10.0
+DOTNET_VERSION="${DOTNET_VERSION:-10.0.203}"
 RELEASE_VERSION="${RELEASE_VERSION:-300.1.0}"
-FRAMEWORK="net${DOTNET_MAJOR_VERSION}-ios"
+FRAMEWORK="net${DOTNET_VERSION%%.*}.0-ios"
 
 # Get script directory
 SCRIPT_DIR="$( realpath "$(dirname "${BASH_SOURCE[0]}")" )"
@@ -12,14 +12,12 @@ SCRIPT_DIR="$( realpath "$(dirname "${BASH_SOURCE[0]}")" )"
 if [[ -z "${DOTNET_CACHE_FOLDER}" ]]; then
   DOTNET_INSTALL_FOLDER="${WORKSPACE}/.dotnet"
 else
-  DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION:-${DOTNET_MAJOR_VERSION}-latest}"
+  DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION}"
 fi
 
-mkdir -p "${DOTNET_INSTALL_FOLDER}"
-curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
-if [[ -z "${DOTNET_VERSION}" ]]; then
-  bash "${WORKSPACE}/dotnet-install.sh" --channel "${DOTNET_MAJOR_VERSION}" --install-dir "${DOTNET_INSTALL_FOLDER}"
-else
+if [[ ! -x "${DOTNET_INSTALL_FOLDER}/dotnet" ]]; then
+  mkdir -p "${DOTNET_INSTALL_FOLDER}"
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
   bash "${WORKSPACE}/dotnet-install.sh" --version "${DOTNET_VERSION}" --install-dir "${DOTNET_INSTALL_FOLDER}"
 fi
 

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Default environment variables
+DOTNET_VERSION="${DOTNET_VERSION:-10.0.203}"
+RELEASE_VERSION="${RELEASE_VERSION:-300.1.0}"
+FRAMEWORK="net${DOTNET_VERSION%%.*}.0-ios"
+
+# Get script directory
+SCRIPT_DIR="$( realpath "$(dirname "${BASH_SOURCE[0]}")" )"
+
+# Install the desired dotnet version if not already cached
+if [[ -z "${DOTNET_CACHE_FOLDER}" ]]; then
+  DOTNET_INSTALL_FOLDER="${WORKSPACE}/.dotnet"
+else
+  DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION}"
+fi
+
+if [[ ! -x "${DOTNET_INSTALL_FOLDER}/dotnet" ]]; then
+  mkdir -p "${DOTNET_INSTALL_FOLDER}"
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
+  bash "${WORKSPACE}/dotnet-install.sh" --version "${DOTNET_VERSION}" --install-dir "${DOTNET_INSTALL_FOLDER}"
+fi
+
+DOTNET_EXE="${DOTNET_INSTALL_FOLDER}/dotnet"
+echo "Installed dotnet at ${DOTNET_EXE}"
+
+# Configure NuGet
+"${DOTNET_EXE}" new nugetconfig --force -o "${SCRIPT_DIR}/../"
+if [[ -e "${NUGET_REPO}" ]]; then
+  "${DOTNET_EXE}" nuget add source "${NUGET_REPO}"
+fi
+
+export NUGET_PACKAGES="${SCRIPT_DIR}/../.nuget/packages"
+export NUGET_HTTP_CACHE_PATH="${SCRIPT_DIR}/../.nuget/cache"
+mkdir -p "${NUGET_PACKAGES}"
+mkdir -p "${NUGET_HTTP_CACHE_PATH}"
+
+# Install maui workload
+"${DOTNET_EXE}" workload install maui --version "${DOTNET_VERSION}"
+
+# Embed API key
+if [[ ! -z "${API_KEY}" ]]; then
+  sed -i '' "s/\/\/ return \"YOUR_API_KEY_HERE\";/return \"${API_KEY}\";/" \
+    ${SCRIPT_DIR}/../src/Samples.Shared/Managers/ApiKeyManager.cs || exit 1
+
+  # Disable API key tab in settings menu
+  sed -i '' '/string versionNumber = string.Empty;/a\
+    ToolbarItems.Remove(ApiKeyButton);' \
+    ${SCRIPT_DIR}/../src/MAUI/Maui.Samples/Views/SettingsPage.xaml.cs || exit 1
+fi
+
+# Set license keys
+if [[ ! -z "${LICENSE_KEY}" ]]; then
+  # License key
+  sed -i '' "s/public static string ArcGISLicenseKey { get; } = null;/public static string ArcGISLicenseKey { get; } = \\"${LICENSE_KEY}\\";/" \
+    ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
+
+  # Analysis license key
+  sed -i '' "s/public static string ArcGISAnalysisLicenseKey { get; } = null;/public static string ArcGISAnalysisLicenseKey { get; } = \\"${ANALYSIS_LICENSE_KEY}\\";/" \
+    ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
+
+  # Advanced Editing User Type License Key
+  sed -i '' "s/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = null;/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = \\"${ADVANCED_EDITING_USER_TYPE_LICENSE_KEY}\\";/" \
+    ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
+fi
+
+# Set ArcGISMapsSDKVersion in Directory.Packages.props
+export PATH=/opt/homebrew/bin:/usr/local/bin:${PATH} # add homebrew bin to path to use xmlstarlet
+
+xmlstarlet ed -P -L -u '/Project/PropertyGroup/ArcGISMapsSDKVersion' \
+  -v ${RELEASE_VERSION} \
+  ${SCRIPT_DIR}/../src/Directory.Packages.props || exit 1
+
+# Add an empty bundleid so it can be set during the different builds
+/usr/libexec/PlistBuddy -c "add :CFBundleIdentifier string """ \
+  ${SCRIPT_DIR}/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist || exit 1
+
+# Internal Build
+/usr/libexec/PlistBuddy -c "set :CFBundleIdentifier com.esri.arcgisruntime.samples.maui-enterprise" \
+  ${SCRIPT_DIR}/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist || exit 1
+
+"${DOTNET_EXE}" publish ${SCRIPT_DIR}/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
+  -f:${FRAMEWORK} \
+  -p:ApplicationDisplayVersion=${RELEASE_VERSION} \
+  -p:ApplicationVersion=${ABSOLUTE_BUILD_NUM} \
+  -p:ArchiveOnBuild=true \
+  -p:CodesignKey="${CODESIGN_IPHONE_DISTRIBUTION_INTERNAL}" \
+  -p:CodesignProvision="${CODESIGN_PROVISION_INTERNAL}" \
+  -p:Configuration="Release" \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:PublishDir=${WORKSPACE}/output/internalBuild/ \
+  -p:ValidateXcodeVersion=false
+
+# External Build
+/usr/libexec/PlistBuddy -c "set :CFBundleIdentifier com.esri.arcgisruntime.samples.maui" \
+  "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist || exit 1
+
+"${DOTNET_EXE}" publish "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
+  -f:${FRAMEWORK} \
+  -p:ApplicationDisplayVersion=${RELEASE_VERSION} \
+  -p:ApplicationVersion=${ABSOLUTE_BUILD_NUM} \
+  -p:ArchiveOnBuild=true \
+  -p:CodesignKey="${CODESIGN_APPLE_DISTRIBUTION}" \
+  -p:CodesignProvision="${CODESIGN_PROVISION_APPSTORE}" \
+  -p:Configuration="Release" \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:PublishDir=${WORKSPACE}/output/externalBuild/ \
+  -p:ValidateXcodeVersion=false

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -117,6 +117,12 @@ echo "Made it past internal build"
 echo "Updated plist:"
 cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
 
+"${DOTNET_EXE}" build "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
+  -t:Clean \
+  -p:Configuration="Release" \
+  -p:RuntimeIdentifier=ios-arm64 \
+  -p:ValidateXcodeVersion=false
+
 "${DOTNET_EXE}" publish "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
   -f:${FRAMEWORK} \
   -p:ApplicationDisplayVersion=${RELEASE_VERSION} \

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Default environment variables
-DOTNET_VERSION="${DOTNET_VERSION:-10.0.203}"
+DOTNET_MAJOR_VERSION=10.0
 RELEASE_VERSION="${RELEASE_VERSION:-300.1.0}"
-FRAMEWORK="net${DOTNET_VERSION%%.*}.0-ios"
+FRAMEWORK="net${DOTNET_MAJOR_VERSION}-ios"
 
 # Get script directory
 SCRIPT_DIR="$( realpath "$(dirname "${BASH_SOURCE[0]}")" )"
@@ -12,12 +12,14 @@ SCRIPT_DIR="$( realpath "$(dirname "${BASH_SOURCE[0]}")" )"
 if [[ -z "${DOTNET_CACHE_FOLDER}" ]]; then
   DOTNET_INSTALL_FOLDER="${WORKSPACE}/.dotnet"
 else
-  DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION}"
+  DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION:-${DOTNET_MAJOR_VERSION}-latest}"
 fi
 
-if [[ ! -x "${DOTNET_INSTALL_FOLDER}/dotnet" ]]; then
-  mkdir -p "${DOTNET_INSTALL_FOLDER}"
-  curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
+mkdir -p "${DOTNET_INSTALL_FOLDER}"
+curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
+if [[ -z "${DOTNET_VERSION}" ]]; then
+  bash "${WORKSPACE}/dotnet-install.sh" --channel "${DOTNET_MAJOR_VERSION}" --install-dir "${DOTNET_INSTALL_FOLDER}"
+else
   bash "${WORKSPACE}/dotnet-install.sh" --version "${DOTNET_VERSION}" --install-dir "${DOTNET_INSTALL_FOLDER}"
 fi
 

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -117,8 +117,8 @@ echo "Made it past internal build"
 echo "Updated plist:"
 cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
 
-"${DOTNET_EXE}" build "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
-  -t:Clean \
+"${DOTNET_EXE}" clean "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
+  -f:${FRAMEWORK} \
   -p:Configuration="Release" \
   -p:RuntimeIdentifier=ios-arm64 \
   -p:ValidateXcodeVersion=false

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -15,9 +15,6 @@ else
   DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION}"
 fi
 
-echo "Install folder: ${DOTNET_INSTALL_FOLDER}"
-echo $SCRIPT_DIR
-
 if [[ ! -x "${DOTNET_INSTALL_FOLDER}/dotnet" ]]; then
   mkdir -p "${DOTNET_INSTALL_FOLDER}"
   curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
@@ -27,30 +24,17 @@ fi
 DOTNET_EXE="${DOTNET_INSTALL_FOLDER}/dotnet"
 echo "Installed dotnet at ${DOTNET_EXE}"
 
-"${DOTNET_EXE}" nuget config get ALL --show-path
-
 # Configure NuGet
-"${DOTNET_EXE}" nuget list source
 CONFIG_FILE="${SCRIPT_DIR}/../NuGet.Config"
 "${DOTNET_EXE}" new nugetconfig --force -o "${SCRIPT_DIR}/../"
-"${DOTNET_EXE}" nuget list source
 if [[ -e "${NUGET_REPO}" ]]; then
-  echo "Made it inside the if"
   "${DOTNET_EXE}" nuget add source "${NUGET_REPO}" --configfile "${CONFIG_FILE}"
 fi
-"${DOTNET_EXE}" nuget list source --configfile "${CONFIG_FILE}"
-
-echo "NUGET_REPO: ${NUGET_REPO}"
 
 export NUGET_PACKAGES="${SCRIPT_DIR}/../.nuget/packages"
 export NUGET_HTTP_CACHE_PATH="${SCRIPT_DIR}/../.nuget/cache"
 mkdir -p "${NUGET_PACKAGES}"
 mkdir -p "${NUGET_HTTP_CACHE_PATH}"
-
-echo "NUGET_PACKAGES: ${NUGET_PACKAGES}"
-echo "NUGET_HTTP_CACHE_PATH: ${NUGET_HTTP_CACHE_PATH}"
-
-"${DOTNET_EXE}" nuget config get ALL --show-path
 
 # Install maui workload
 "${DOTNET_EXE}" workload install maui --version "${DOTNET_VERSION}"
@@ -107,14 +91,9 @@ xmlstarlet ed -P -L -u '/Project/PropertyGroup/ArcGISMapsSDKVersion' \
   -p:RuntimeIdentifier=ios-arm64 \
   -p:PublishDir=${WORKSPACE}/output/internalBuild/
 
-echo "Made it past internal build"
-
 # External Build
 /usr/libexec/PlistBuddy -c "set :CFBundleIdentifier com.esri.arcgisruntime.samples.maui" \
   "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist || exit 1
-
-echo "Updated plist:"
-cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
 
 "${DOTNET_EXE}" clean "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
   -f:${FRAMEWORK} \

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -29,9 +29,12 @@ echo "Installed dotnet at ${DOTNET_EXE}"
 
 # Configure NuGet
 "${DOTNET_EXE}" new nugetconfig --force -o "${SCRIPT_DIR}/../"
+"${DOTNET_EXE}" nuget list source
 if [[ -e "${NUGET_REPO}" ]]; then
+  echo "Made it inside the if"
   "${DOTNET_EXE}" nuget add source "${NUGET_REPO}"
 fi
+"${DOTNET_EXE}" nuget list source
 
 echo "NUGET_REPO: ${NUGET_REPO}"
 

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -69,15 +69,15 @@ fi
 # Set license keys
 if [[ ! -z "${LICENSE_KEY}" ]]; then
   # License key
-  sed -i '' "s/public static string ArcGISLicenseKey { get; } = null;/public static string ArcGISLicenseKey { get; } = \\"${LICENSE_KEY}\\";/" \
+  sed -i '' "s/public static string ArcGISLicenseKey { get; } = null;/public static string ArcGISLicenseKey { get; } = \"${LICENSE_KEY}\";/" \
     ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
 
   # Analysis license key
-  sed -i '' "s/public static string ArcGISAnalysisLicenseKey { get; } = null;/public static string ArcGISAnalysisLicenseKey { get; } = \\"${ANALYSIS_LICENSE_KEY}\\";/" \
+  sed -i '' "s/public static string ArcGISAnalysisLicenseKey { get; } = null;/public static string ArcGISAnalysisLicenseKey { get; } = \"${ANALYSIS_LICENSE_KEY}\";/" \
     ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
 
   # Advanced Editing User Type License Key
-  sed -i '' "s/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = null;/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = \\"${ADVANCED_EDITING_USER_TYPE_LICENSE_KEY}\\";/" \
+  sed -i '' "s/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = null;/public static string ArcGISAdvancedEditingUserTypeLicenseKey { get; } = \"${ADVANCED_EDITING_USER_TYPE_LICENSE_KEY}\";/" \
     ${SCRIPT_DIR}/../src/Samples.Shared/Managers/LicenseStrings.cs || exit 1
 fi
 

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -105,8 +105,7 @@ xmlstarlet ed -P -L -u '/Project/PropertyGroup/ArcGISMapsSDKVersion' \
   -p:CodesignProvision="${CODESIGN_PROVISION_INTERNAL}" \
   -p:Configuration="Release" \
   -p:RuntimeIdentifier=ios-arm64 \
-  -p:PublishDir=${WORKSPACE}/output/internalBuild/ \
-  -p:ValidateXcodeVersion=false
+  -p:PublishDir=${WORKSPACE}/output/internalBuild/
 
 echo "Made it past internal build"
 
@@ -120,8 +119,7 @@ cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
 "${DOTNET_EXE}" clean "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
   -f:${FRAMEWORK} \
   -p:Configuration="Release" \
-  -p:RuntimeIdentifier=ios-arm64 \
-  -p:ValidateXcodeVersion=false
+  -p:RuntimeIdentifier=ios-arm64
 
 "${DOTNET_EXE}" publish "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
   -f:${FRAMEWORK} \
@@ -132,5 +130,5 @@ cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
   -p:CodesignProvision="${CODESIGN_PROVISION_APPSTORE}" \
   -p:Configuration="Release" \
   -p:RuntimeIdentifier=ios-arm64 \
-  -p:PublishDir=${WORKSPACE}/output/externalBuild/ \
-  -p:ValidateXcodeVersion=false
+  -p:PublishDir=${WORKSPACE}/output/externalBuild/
+  

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -27,14 +27,18 @@ fi
 DOTNET_EXE="${DOTNET_INSTALL_FOLDER}/dotnet"
 echo "Installed dotnet at ${DOTNET_EXE}"
 
+"${DOTNET_EXE}" nuget config get ALL --show-path
+
 # Configure NuGet
+"${DOTNET_EXE}" nuget list source
+CONFIG_FILE="${SCRIPT_DIR}/../NuGet.Config"
 "${DOTNET_EXE}" new nugetconfig --force -o "${SCRIPT_DIR}/../"
 "${DOTNET_EXE}" nuget list source
 if [[ -e "${NUGET_REPO}" ]]; then
   echo "Made it inside the if"
-  "${DOTNET_EXE}" nuget add source "${NUGET_REPO}"
+  "${DOTNET_EXE}" nuget add source "${NUGET_REPO}" --configfile "${CONFIG_FILE}"
 fi
-"${DOTNET_EXE}" nuget list source
+"${DOTNET_EXE}" nuget list source --configfile "${CONFIG_FILE}"
 
 echo "NUGET_REPO: ${NUGET_REPO}"
 
@@ -45,6 +49,8 @@ mkdir -p "${NUGET_HTTP_CACHE_PATH}"
 
 echo "NUGET_PACKAGES: ${NUGET_PACKAGES}"
 echo "NUGET_HTTP_CACHE_PATH: ${NUGET_HTTP_CACHE_PATH}"
+
+"${DOTNET_EXE}" nuget config get ALL --show-path
 
 # Install maui workload
 "${DOTNET_EXE}" workload install maui --version "${DOTNET_VERSION}"

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -37,7 +37,7 @@ mkdir -p "${NUGET_PACKAGES}"
 mkdir -p "${NUGET_HTTP_CACHE_PATH}"
 
 # Install maui workload
-"${DOTNET_EXE}" workload install maui --version "${DOTNET_VERSION}"
+"${DOTNET_EXE}" workload install maui
 
 # Embed API key
 if [[ ! -z "${API_KEY}" ]]; then

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -15,6 +15,9 @@ else
   DOTNET_INSTALL_FOLDER="${DOTNET_CACHE_FOLDER}/${DOTNET_VERSION}"
 fi
 
+echo "Install folder: ${DOTNET_INSTALL_FOLDER}"
+echo $SCRIPT_DIR
+
 if [[ ! -x "${DOTNET_INSTALL_FOLDER}/dotnet" ]]; then
   mkdir -p "${DOTNET_INSTALL_FOLDER}"
   curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${WORKSPACE}/dotnet-install.sh"
@@ -30,10 +33,15 @@ if [[ -e "${NUGET_REPO}" ]]; then
   "${DOTNET_EXE}" nuget add source "${NUGET_REPO}"
 fi
 
+echo "NUGET_REPO: ${NUGET_REPO}"
+
 export NUGET_PACKAGES="${SCRIPT_DIR}/../.nuget/packages"
 export NUGET_HTTP_CACHE_PATH="${SCRIPT_DIR}/../.nuget/cache"
 mkdir -p "${NUGET_PACKAGES}"
 mkdir -p "${NUGET_HTTP_CACHE_PATH}"
+
+echo "NUGET_PACKAGES: ${NUGET_PACKAGES}"
+echo "NUGET_HTTP_CACHE_PATH: ${NUGET_HTTP_CACHE_PATH}"
 
 # Install maui workload
 "${DOTNET_EXE}" workload install maui --version "${DOTNET_VERSION}"

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -108,9 +108,14 @@ xmlstarlet ed -P -L -u '/Project/PropertyGroup/ArcGISMapsSDKVersion' \
   -p:PublishDir=${WORKSPACE}/output/internalBuild/ \
   -p:ValidateXcodeVersion=false
 
+echo "Made it past internal build"
+
 # External Build
 /usr/libexec/PlistBuddy -c "set :CFBundleIdentifier com.esri.arcgisruntime.samples.maui" \
   "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist || exit 1
+
+echo "Updated plist:"
+cat "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/Platforms/iOS/Info.plist
 
 "${DOTNET_EXE}" publish "${SCRIPT_DIR}"/../src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj \
   -f:${FRAMEWORK} \


### PR DESCRIPTION
# Description

This branch transfers logic from the internal devops CI build scripts to more closely align with the windows CI build. Adds the same behavior as the windows CI build for downloading dotnet automatically.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI iOS

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] No unrelated changes have been made to any other code or project files
