### PR TITLE
Update Maui samples to .NET 10 and increment ArcGIS packages

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -36,5 +36,9 @@
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.60" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.60" />
+    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing" Version="1.3.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" Version="1.3.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Concurrent.Futures" Version="1.3.0.1" />
+    <PackageVersion Include="Xamarin.AndroidX.Concurrent.Futures.Ktx" Version="1.3.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ArcGISMapsSDKVersion Condition="'$(ArcGISMapsSDKVersion)'==''">200.8.0</ArcGISMapsSDKVersion>
+    <ArcGISMapsSDKVersion Condition="'$(ArcGISMapsSDKVersion)'==''">200.8.2</ArcGISMapsSDKVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Esri.ArcGISRuntime" Version="$(ArcGISMapsSDKVersion)" />
@@ -34,8 +34,7 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="7.1.3" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.8.7" />
     <PackageVersion Include="Monaco.Editor" Version="0.8.1-alpha" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.120" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" />
-    <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.6" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.60" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.60" />
   </ItemGroup>
 </Project>

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ArcGIS.Samples</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -142,9 +142,6 @@
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <PackageReference Include="WinUIEx" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
-  </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" />
   </ItemGroup>
   <ItemGroup>
     <MauiXaml Update="Views\*.xaml">

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -138,6 +138,14 @@
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
+  <!-- .NET 10 Toolkit workaround -->
+  <ItemGroup Condition="'$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))'=='android'">
+    <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing" />
+    <PackageReference Include="Xamarin.AndroidX.Tracing.Tracing.Ktx" />
+    <PackageReference Include="Xamarin.AndroidX.Concurrent.Futures" />
+    <PackageReference Include="Xamarin.AndroidX.Concurrent.Futures.Ktx" />
+  </ItemGroup>
+
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <PackageReference Include="WinUIEx" />

--- a/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
+++ b/src/MAUI/Maui.Samples/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.esri.arcgisruntime.samples.maui" android:versionCode="7" android:versionName="200.8.0">
 	<application android:allowBackup="true" android:usesCleartextTraffic="true" android:icon="@mipmap/appiconandroid" android:roundIcon="@mipmap/appiconandroid_round" android:supportsRtl="true" android:label="ArcGIS Maps .NET MAUI Samples"></application>
-	<uses-sdk android:minSdkVersion="26" android:targetSdkVersion="35" />
+	<uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Geoprocessing/AnalyzeHotspots/AnalyzeHotspots.xaml.cs
@@ -65,7 +65,7 @@ namespace ArcGIS.Samples.AnalyzeHotspots
             MyActivityIndicator.IsRunning = true;
 
             // The end date must be at least one day after the start date
-            if (EndDate.Date <= StartDate.Date.AddDays(1))
+            if (EndDate.Date <= StartDate.Date.Value.AddDays(1))
             {
                 // Show error message
                 _ = DisplayAlert("Invalid date range", "Please select valid time range. There has to be at least one day in between To and From dates.", "OK");


### PR DESCRIPTION
# Description

Updates the Maui samples to net10.0, MauiVersion to 10.0.60, and the ArcGIS SDK to 200.8.2

## Type of change

<!--- Delete any that don't apply -->

- Bug fix
- New sample implementation
- Sample viewer enhancement
- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [ ] There are no warnings related to changes
  - There are many deprecation warnings with .NET 10, but too many to address on short notice
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
