### PR TITLE
Fix WPF README hyperlink navigation

### DIFF
--- a/src/WPF/WPF.Viewer/Description.xaml.cs
+++ b/src/WPF/WPF.Viewer/Description.xaml.cs
@@ -10,6 +10,7 @@
 using ArcGIS.Samples.Shared.Models;
 using System.Diagnostics;
 using System.IO;
+using System.Windows.Forms;
 
 namespace ArcGIS.WPF.Viewer
 {
@@ -18,6 +19,8 @@ namespace ArcGIS.WPF.Viewer
         public Description()
         {
             InitializeComponent();
+
+            DescriptionView.Navigating += DescriptionView_Navigating;
         }
 
         public void SetSample(SampleInfo sample)
@@ -38,10 +41,23 @@ namespace ArcGIS.WPF.Viewer
             DescriptionView.Document.OpenNew(false);
             DescriptionView.Document.Write(htmlString);
             DescriptionView.Refresh();
+        }
 
-            // Disable navigation in the web browser control.
-            // This prevents script errors when users click links in READMEs.
-            DescriptionView.AllowNavigation = false;
+        private void DescriptionView_Navigating(object sender, WebBrowserNavigatingEventArgs e)
+        {
+            // Open links in a new window instead of inside the web view.
+            if (e.Url != null && e.Url.AbsoluteUri.StartsWith("http"))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo(e.Url.AbsoluteUri) { UseShellExecute = true });
+                    e.Cancel = true;
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
Hyperlinks in WPF Viewer sample READMEs were clickable but did nothing.
Fixes #1788  

## Type of change

- Other enhancement

## Platforms tested on

- [x] WPF .NET 8

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files

