### PR TITLE
Update Calcite to 1.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,9 +13,9 @@
     <PackageVersion Include="Esri.ArcGISRuntime.Hydrography" Version="$(ArcGISMapsSDKVersion)" />
     <PackageVersion Include="Esri.ArcGISRuntime.LocalServices" Version="200.8.0" />
     <PackageVersion Include="Esri.ArcGISRuntime.Toolkit.WinUI" Version="$(ArcGISMapsSDKVersion)" />
-    <PackageVersion Include="Esri.Calcite.WPF" Version="1.0.0-rc.1" />
-    <PackageVersion Include="Esri.Calcite.Maui" Version="1.0.0-rc.1" />
-    <PackageVersion Include="Esri.Calcite.WinUI" Version="1.0.0-rc.1" />
+    <PackageVersion Include="Esri.Calcite.WPF" Version="1.0.0" />
+    <PackageVersion Include="Esri.Calcite.Maui" Version="1.0.0" />
+    <PackageVersion Include="Esri.Calcite.WinUI" Version="1.0.0" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3800.47" />
     <PackageVersion Include="System.Text.Json" Version="9.0.13" />


### PR DESCRIPTION
# Description

Updates the samples to use [Calcite](https://github.com/Esri/calcite-dotnet-toolkit) version 1.0.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
