### PR TITLE
Update CI scripts to shutdown the dotnet build server on completion

### DIFF
--- a/tools/cibuild.cmd
+++ b/tools/cibuild.cmd
@@ -67,3 +67,5 @@ IF "%ARCGIS_API_KEY%" NEQ "" (
 
 set PUBLISHER=%PUBLISHER:\"="%
 %DOTNET_EXE% msbuild %~dp0GenerateApps.msbuild -t:BuildAll -p:BUILD_NUM=%BUILD_NUM% -p:RELEASE_VERSION=%RELEASE_VERSION% -p:PFXSignaturePassword=%PFXSignaturePassword% -p:PFXSignatureFile=%PFXSignatureFile% -p:PackageCertificateThumbprint=%PackageCertificateThumbprint% -p:KeyStoreFile=%KeyStoreFile% -p:KeyPass=%KeyPass% -p:KeyAlias=%KeyAlias%
+
+%DOTNET_EXE% build-server shutdown

--- a/tools/cibuild.sh
+++ b/tools/cibuild.sh
@@ -110,4 +110,5 @@ xmlstarlet ed -P -L -u '/Project/PropertyGroup/ArcGISMapsSDKVersion' \
   -p:Configuration="Release" \
   -p:RuntimeIdentifier=ios-arm64 \
   -p:PublishDir=${WORKSPACE}/output/externalBuild/
-  
+
+"${DOTNET_EXE}" build-server shutdown


### PR DESCRIPTION
# Description

Update CI scripts to shutdown the dotnet build server on completion.

## Type of change

<!--- Delete any that don't apply -->

- Other enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] Windows
- [x] Mac

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [x] No unrelated changes have been made to any other code or project files
