### PR TITLE
ui: Lazy-load samples through generated catalog

### DIFF
--- a/src/ArcGIS.AllSampleViewers.sln
+++ b/src/ArcGIS.AllSampleViewers.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArcGIS.Samples.Maui", "MAUI
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ArcGIS.Samples.Shared", "Samples.Shared\ArcGIS.Samples.Shared.shproj", "{0AD85845-0BA1-4DC9-8C32-E6FD7632E32D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CatalogGenerator", "Samples.CatalogGenerator\Samples.CatalogGenerator.csproj", "{BBFBE218-B123-9B87-6B83-C46602227A09}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,18 @@ Global
 		{7F7B3255-9EA0-4296-B690-14BE9E2204F3}.Release|x64.ActiveCfg = Release|Any CPU
 		{7F7B3255-9EA0-4296-B690-14BE9E2204F3}.Release|x64.Build.0 = Release|Any CPU
 		{7F7B3255-9EA0-4296-B690-14BE9E2204F3}.Release|x64.Deploy.0 = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Debug|x64.Build.0 = Debug|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|ARM64.Build.0 = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|x64.ActiveCfg = Release|Any CPU
+		{BBFBE218-B123-9B87-6B83-C46602227A09}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +97,7 @@ Global
 		{FE1B81E3-59BE-4632-A1EB-12FF19F4B59A} = {AFB4071E-38D8-4C36-BFED-48AE0A4A3F42}
 		{F39D6B3E-4E1D-4211-B152-59F8F71C8544} = {14502F3B-7A88-4C48-8EA7-F44D1E4BA42B}
 		{7F7B3255-9EA0-4296-B690-14BE9E2204F3} = {5EA55853-597D-4ED0-BAF9-6B737EBC5AC1}
+		{BBFBE218-B123-9B87-6B83-C46602227A09} = {14502F3B-7A88-4C48-8EA7-F44D1E4BA42B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7243EE6-BDF4-4C46-AEEB-057BC82B116E}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,5 +33,6 @@
     <PackageVersion Include="Microsoft.Maui.Controls" Version="9.0.120" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.120" />
     <PackageVersion Include="Xamarin.AndroidX.AppCompat" Version="1.7.0.6" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
 </Project>

--- a/src/MAUI/ArcGIS.Samples.Maui.sln
+++ b/src/MAUI/ArcGIS.Samples.Maui.sln
@@ -6,6 +6,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArcGIS.Samples.Maui", "Maui
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ArcGIS.Samples.Shared", "..\Samples.Shared\ArcGIS.Samples.Shared.shproj", "{0AD85845-0BA1-4DC9-8C32-E6FD7632E32D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CatalogGenerator", "..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj", "{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,6 +20,10 @@ Global
 		{E299EF97-AB8E-46D7-B402-7A386DAFC30F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E299EF97-AB8E-46D7-B402-7A386DAFC30F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E299EF97-AB8E-46D7-B402-7A386DAFC30F}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
+++ b/src/MAUI/Maui.Samples/ArcGIS.Samples.Maui.csproj
@@ -137,6 +137,12 @@
     <PackageReference Include="Microsoft.Maui.Controls" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
 
   <!-- WinUIEx is used to workaround the lack of a WebAuthenticationBroker for WinUI. https://github.com/microsoft/WindowsAppSDK/issues/441 -->
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/CategoryViewModel.cs
@@ -18,6 +18,8 @@ namespace ArcGIS.ViewModels
 
         public CategoryViewModel()
         {
+            SampleManager.Current.Initialize();
+
             // Calculate the sample image width and height on mobile platforms based on device display size. 
             _sampleImageWidth = 400;
 
@@ -73,9 +75,7 @@ namespace ArcGIS.ViewModels
 
         private static List<SampleInfo> GetSamplesInCategory(string category)
         {
-            var categoryNode = SampleManager.Current.FullTree.Items.OfType<SearchableTreeNode>().FirstOrDefault(c => c.Name == category);
-
-            return categoryNode.Items.OfType<SampleInfo>().ToList();
+            return SampleManager.Current.GetSamplesForCategory(category).ToList();
         }
 
         [ObservableProperty]

--- a/src/Samples.CatalogGenerator/SampleCatalogGenerator.cs
+++ b/src/Samples.CatalogGenerator/SampleCatalogGenerator.cs
@@ -1,0 +1,366 @@
+// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace ArcGIS.Samples.CatalogGenerator
+{
+    [Generator(LanguageNames.CSharp)]
+    public sealed class SampleCatalogGenerator : IIncrementalGenerator
+    {
+        private const string SampleAttributeName = "ArcGIS.Samples.Shared.Attributes.SampleAttribute";
+        private const string OfflineDataAttributeName = "ArcGIS.Samples.Shared.Attributes.OfflineDataAttribute";
+        private const string XamlFilesAttributeName = "ArcGIS.Samples.Shared.Attributes.XamlFilesAttribute";
+        private const string AndroidLayoutAttributeName = "ArcGIS.Samples.Shared.Attributes.AndroidLayoutAttribute";
+        private const string ClassFileAttributeName = "ArcGIS.Samples.Shared.Attributes.ClassFileAttribute";
+        private const string EmbeddedResourceAttributeName = "ArcGIS.Samples.Shared.Attributes.EmbeddedResourceAttribute";
+
+        private static readonly DiagnosticDescriptor DuplicateFormalNameDiagnostic = new DiagnosticDescriptor(
+            id: "AGSAMPLECAT001",
+            title: "Duplicate sample formal name",
+            messageFormat: "Multiple sample classes use the formal name '{0}'. Sample formal names must be unique.",
+            category: "SampleCatalog",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor MalformedSampleAttributeDiagnostic = new DiagnosticDescriptor(
+            id: "AGSAMPLECAT002",
+            title: "Malformed sample attribute",
+            messageFormat: "Sample class '{0}' has a malformed SampleAttribute and cannot be added to the generated sample catalog",
+            category: "SampleCatalog",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            IncrementalValuesProvider<SampleMetadata> samples = context.SyntaxProvider
+                .CreateSyntaxProvider(
+                    static (node, _) => node is ClassDeclarationSyntax classDeclaration && classDeclaration.AttributeLists.Count > 0,
+                    static (context, _) => GetSampleMetadata(context))
+                .Where(static sample => sample != null)!;
+
+            context.RegisterSourceOutput(samples.Collect(), static (context, samples) => Execute(context, samples));
+        }
+
+        private static SampleMetadata? GetSampleMetadata(GeneratorSyntaxContext context)
+        {
+            var classDeclaration = (ClassDeclarationSyntax)context.Node;
+            if (context.SemanticModel.GetDeclaredSymbol(classDeclaration) is not INamedTypeSymbol classSymbol || classSymbol.IsAbstract)
+            {
+                return null;
+            }
+
+            ImmutableArray<AttributeData> attributes = classSymbol.GetAttributes();
+            AttributeData? sampleAttribute = GetAttribute(attributes, SampleAttributeName);
+            if (sampleAttribute == null)
+            {
+                return null;
+            }
+
+            if (sampleAttribute.ConstructorArguments.Length < 4)
+            {
+                return SampleMetadata.Malformed(classSymbol.Name, classDeclaration.Identifier.GetLocation());
+            }
+
+            return new SampleMetadata(
+                formalName: classSymbol.Name,
+                sampleName: GetString(sampleAttribute.ConstructorArguments[0]),
+                category: GetString(sampleAttribute.ConstructorArguments[1]),
+                description: GetString(sampleAttribute.ConstructorArguments[2]),
+                instructions: GetString(sampleAttribute.ConstructorArguments[3]),
+                tags: sampleAttribute.ConstructorArguments.Length > 4 ? GetStringArray(sampleAttribute.ConstructorArguments[4]) : Array.Empty<string>(),
+                offlineDataItems: GetAttributeStringArray(attributes, OfflineDataAttributeName),
+                xamlLayouts: GetAttributeStringArray(attributes, XamlFilesAttributeName),
+                androidLayouts: GetAttributeStringArray(attributes, AndroidLayoutAttributeName),
+                classFiles: GetAttributeStringArray(attributes, ClassFileAttributeName),
+                embeddedResources: GetAttributeStringArray(attributes, EmbeddedResourceAttributeName),
+                typeName: classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        }
+
+        private static AttributeData? GetAttribute(ImmutableArray<AttributeData> attributes, string metadataName)
+        {
+            foreach (AttributeData attribute in attributes)
+            {
+                if (attribute.AttributeClass?.ToDisplayString() == metadataName)
+                {
+                    return attribute;
+                }
+            }
+
+            return null;
+        }
+
+        private static string[]? GetAttributeStringArray(ImmutableArray<AttributeData> attributes, string metadataName)
+        {
+            AttributeData? attribute = GetAttribute(attributes, metadataName);
+            if (attribute == null || attribute.ConstructorArguments.Length == 0)
+            {
+                return null;
+            }
+
+            return GetStringArray(attribute.ConstructorArguments[0]);
+        }
+
+        private static string GetString(TypedConstant constant)
+        {
+            return constant.Value as string ?? string.Empty;
+        }
+
+        private static string[] GetStringArray(TypedConstant constant)
+        {
+            if (constant.Kind == TypedConstantKind.Array)
+            {
+                return constant.Values
+                    .Select(static value => value.Value as string)
+                    .Where(static value => value != null)
+                    .Select(static value => value!)
+                    .ToArray();
+            }
+
+            return constant.Value is string value ? new[] { value } : Array.Empty<string>();
+        }
+
+        private static void Execute(SourceProductionContext context, ImmutableArray<SampleMetadata> samples)
+        {
+            if (samples.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            foreach (SampleMetadata malformedSample in samples.Where(static sample => sample.IsMalformed))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MalformedSampleAttributeDiagnostic, malformedSample.Location, malformedSample.FormalName));
+            }
+
+            List<SampleMetadata> validSamples = samples.Where(static sample => !sample.IsMalformed).ToList();
+            if (validSamples.Count == 0)
+            {
+                return;
+            }
+
+            List<SampleMetadata> orderedSamples = validSamples
+                .GroupBy(static sample => sample.FormalName, StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    if (group.Count() > 1)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(DuplicateFormalNameDiagnostic, Location.None, group.Key));
+                    }
+
+                    return group.First();
+                })
+                .OrderBy(static sample => sample.Category, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static sample => sample.SampleName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var categories = orderedSamples
+                .Select(static sample => sample.Category)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static category => category, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var source = new StringBuilder();
+            source.AppendLine("// <auto-generated />");
+            source.AppendLine("#nullable enable");
+            source.AppendLine("namespace ArcGIS.Samples.Managers");
+            source.AppendLine("{");
+            source.AppendLine("    public sealed class GeneratedSampleCatalog : global::ArcGIS.Samples.Managers.ISampleCatalogProvider");
+            source.AppendLine("    {");
+            source.AppendLine($"        private static readonly string[] Categories = {ArrayLiteral(categories)};");
+            source.AppendLine($"        private static readonly string[] SampleNames = {ArrayLiteral(orderedSamples.Select(static sample => sample.FormalName).ToList())};");
+            source.AppendLine();
+            source.AppendLine("        public global::System.Collections.Generic.IReadOnlyList<string> GetCategories() => Categories;");
+            source.AppendLine();
+            source.AppendLine("        public global::System.Collections.Generic.IReadOnlyList<string> GetSampleNames() => SampleNames;");
+            source.AppendLine();
+            AppendCategoryLookup(source, orderedSamples, categories);
+            source.AppendLine();
+            AppendSampleInfoFactory(source, orderedSamples);
+            source.AppendLine();
+            AppendSampleFactory(source, orderedSamples);
+            source.AppendLine("    }");
+            source.AppendLine();
+            source.AppendLine("    public partial class SampleManager");
+            source.AppendLine("    {");
+            source.AppendLine("        static partial void TryCreateGeneratedCatalogProvider(ref global::ArcGIS.Samples.Managers.ISampleCatalogProvider provider)");
+            source.AppendLine("        {");
+            source.AppendLine("            provider = new global::ArcGIS.Samples.Managers.GeneratedSampleCatalog();");
+            source.AppendLine("        }");
+            source.AppendLine("    }");
+            source.AppendLine("}");
+
+            context.AddSource("GeneratedSampleCatalog.g.cs", source.ToString());
+        }
+
+        private static void AppendCategoryLookup(StringBuilder source, List<SampleMetadata> samples, List<string> categories)
+        {
+            source.AppendLine("        public global::System.Collections.Generic.IReadOnlyList<string> GetSampleNamesForCategory(string category)");
+            source.AppendLine("        {");
+            source.AppendLine("            switch (category)");
+            source.AppendLine("            {");
+
+            foreach (string category in categories)
+            {
+                List<string> sampleNames = samples
+                    .Where(sample => string.Equals(sample.Category, category, StringComparison.OrdinalIgnoreCase))
+                    .Select(static sample => sample.FormalName)
+                    .ToList();
+
+                source.AppendLine($"                case {Literal(category)}:");
+                source.AppendLine($"                    return {ArrayLiteral(sampleNames)};");
+            }
+
+            source.AppendLine("                default:");
+            source.AppendLine("                    return global::System.Array.Empty<string>();");
+            source.AppendLine("            }");
+            source.AppendLine("        }");
+        }
+
+        private static void AppendSampleInfoFactory(StringBuilder source, List<SampleMetadata> samples)
+        {
+            source.AppendLine("        public global::ArcGIS.Samples.Shared.Models.SampleInfo CreateSampleInfo(string formalName)");
+            source.AppendLine("        {");
+            source.AppendLine("            switch (formalName)");
+            source.AppendLine("            {");
+
+            foreach (SampleMetadata sample in samples)
+            {
+                source.AppendLine($"                case {Literal(sample.FormalName)}:");
+                source.AppendLine("                    return new global::ArcGIS.Samples.Shared.Models.SampleInfo(");
+                source.AppendLine($"                        formalName: {Literal(sample.FormalName)},");
+                source.AppendLine($"                        sampleName: {Literal(sample.SampleName)},");
+                source.AppendLine($"                        category: {Literal(sample.Category)},");
+                source.AppendLine($"                        description: {Literal(sample.Description)},");
+                source.AppendLine($"                        instructions: {Literal(sample.Instructions)},");
+                source.AppendLine($"                        tags: {ArrayLiteral(sample.Tags)},");
+                source.AppendLine($"                        offlineDataItems: {ArrayLiteral(sample.OfflineDataItems)},");
+                source.AppendLine($"                        androidLayouts: {ArrayLiteral(sample.AndroidLayouts)},");
+                source.AppendLine($"                        xamlLayouts: {ArrayLiteral(sample.XamlLayouts)},");
+                source.AppendLine($"                        classFiles: {ArrayLiteral(sample.ClassFiles)},");
+                source.AppendLine($"                        embeddedResources: {ArrayLiteral(sample.EmbeddedResources)},");
+                source.AppendLine($"                        sampleType: typeof({sample.TypeName}));");
+            }
+
+            source.AppendLine("                default:");
+            source.AppendLine("                    throw new global::System.ArgumentException($\"Unknown sample '{formalName}'.\", nameof(formalName));");
+            source.AppendLine("            }");
+            source.AppendLine("        }");
+        }
+
+        private static void AppendSampleFactory(StringBuilder source, List<SampleMetadata> samples)
+        {
+            source.AppendLine("        public object CreateSample(string formalName)");
+            source.AppendLine("        {");
+            source.AppendLine("            switch (formalName)");
+            source.AppendLine("            {");
+
+            foreach (SampleMetadata sample in samples)
+            {
+                source.AppendLine($"                case {Literal(sample.FormalName)}:");
+                source.AppendLine($"                    return new {sample.TypeName}();");
+            }
+
+            source.AppendLine("                default:");
+            source.AppendLine("                    throw new global::System.ArgumentException($\"Unknown sample '{formalName}'.\", nameof(formalName));");
+            source.AppendLine("            }");
+            source.AppendLine("        }");
+        }
+
+        private static string ArrayLiteral(IReadOnlyList<string>? values)
+        {
+            if (values == null)
+            {
+                return "null";
+            }
+
+            if (values.Count == 0)
+            {
+                return "global::System.Array.Empty<string>()";
+            }
+
+            return "new string[] { " + string.Join(", ", values.Select(Literal)) + " }";
+        }
+
+        private static string Literal(string value)
+        {
+            return SymbolDisplay.FormatLiteral(value ?? string.Empty, quote: true);
+        }
+
+        private sealed class SampleMetadata
+        {
+            public SampleMetadata(
+                string formalName,
+                string sampleName,
+                string category,
+                string description,
+                string instructions,
+                string[] tags,
+                string[]? offlineDataItems,
+                string[]? xamlLayouts,
+                string[]? androidLayouts,
+                string[]? classFiles,
+                string[]? embeddedResources,
+                string typeName)
+            {
+                FormalName = formalName;
+                SampleName = sampleName;
+                Category = category;
+                Description = description;
+                Instructions = instructions;
+                Tags = tags;
+                OfflineDataItems = offlineDataItems;
+                XamlLayouts = xamlLayouts;
+                AndroidLayouts = androidLayouts;
+                ClassFiles = classFiles;
+                EmbeddedResources = embeddedResources;
+                TypeName = typeName;
+            }
+
+            private SampleMetadata(string formalName, Location location)
+            {
+                FormalName = formalName;
+                SampleName = string.Empty;
+                Category = string.Empty;
+                Description = string.Empty;
+                Instructions = string.Empty;
+                Tags = Array.Empty<string>();
+                TypeName = string.Empty;
+                IsMalformed = true;
+                Location = location;
+            }
+
+            public static SampleMetadata Malformed(string formalName, Location location)
+            {
+                return new SampleMetadata(formalName, location);
+            }
+
+            public string FormalName { get; }
+            public string SampleName { get; }
+            public string Category { get; }
+            public string Description { get; }
+            public string Instructions { get; }
+            public string[] Tags { get; }
+            public string[]? OfflineDataItems { get; }
+            public string[]? XamlLayouts { get; }
+            public string[]? AndroidLayouts { get; }
+            public string[]? ClassFiles { get; }
+            public string[]? EmbeddedResources { get; }
+            public string TypeName { get; }
+            public bool IsMalformed { get; }
+            public Location? Location { get; }
+        }
+    }
+}

--- a/src/Samples.CatalogGenerator/Samples.CatalogGenerator.csproj
+++ b/src/Samples.CatalogGenerator/Samples.CatalogGenerator.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);RS1036;RS2008</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Samples.Shared/Managers/ISampleCatalogProvider.cs
+++ b/src/Samples.Shared/Managers/ISampleCatalogProvider.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+using ArcGIS.Samples.Shared.Models;
+using System.Collections.Generic;
+
+namespace ArcGIS.Samples.Managers
+{
+    /// <summary>
+    /// Provides generated sample metadata and sample factories without requiring runtime assembly scans.
+    /// </summary>
+    public interface ISampleCatalogProvider
+    {
+        IReadOnlyList<string> GetCategories();
+
+        IReadOnlyList<string> GetSampleNames();
+
+        IReadOnlyList<string> GetSampleNamesForCategory(string category);
+
+        SampleInfo CreateSampleInfo(string formalName);
+
+        object CreateSample(string formalName);
+    }
+}

--- a/src/Samples.Shared/Managers/ReflectionSampleCatalogProvider.cs
+++ b/src/Samples.Shared/Managers/ReflectionSampleCatalogProvider.cs
@@ -1,0 +1,117 @@
+﻿// Copyright 2026 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+using ArcGIS.Samples.Shared.Attributes;
+using ArcGIS.Samples.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace ArcGIS.Samples.Managers
+{
+    /// <summary>
+    /// Reflection-backed sample catalog used when a generated catalog is not available.
+    /// </summary>
+    public sealed class ReflectionSampleCatalogProvider : ISampleCatalogProvider
+    {
+        private readonly Dictionary<string, SampleInfo> _samplesByName;
+        private readonly Dictionary<string, string[]> _sampleNamesByCategory;
+        private readonly string[] _categories;
+        private readonly string[] _sampleNames;
+
+        public ReflectionSampleCatalogProvider(Assembly samplesAssembly)
+        {
+            if (samplesAssembly == null)
+            {
+                throw new ArgumentNullException(nameof(samplesAssembly));
+            }
+
+            List<SampleInfo> samples = CreateSampleInfos(samplesAssembly)
+                .OrderBy(info => info.Category, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(info => info.SampleName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            List<SampleInfo> uniqueSamples = samples
+                .GroupBy(sample => sample.FormalName, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToList();
+
+            _samplesByName = uniqueSamples.ToDictionary(sample => sample.FormalName, sample => sample, StringComparer.OrdinalIgnoreCase);
+            _sampleNames = uniqueSamples.Select(sample => sample.FormalName).ToArray();
+            _categories = uniqueSamples.Select(sample => sample.Category)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(category => category, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            _sampleNamesByCategory = _categories.ToDictionary(
+                category => category,
+                category => uniqueSamples
+                    .Where(sample => sample.Category.Equals(category, StringComparison.OrdinalIgnoreCase))
+                    .Select(sample => sample.FormalName)
+                    .ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IReadOnlyList<string> GetCategories() => _categories;
+
+        public IReadOnlyList<string> GetSampleNames() => _sampleNames;
+
+        public IReadOnlyList<string> GetSampleNamesForCategory(string category)
+        {
+            return !string.IsNullOrEmpty(category) && _sampleNamesByCategory.TryGetValue(category, out string[] sampleNames)
+                ? sampleNames
+                : Array.Empty<string>();
+        }
+
+        public SampleInfo CreateSampleInfo(string formalName)
+        {
+            return GetRequiredSampleInfo(formalName);
+        }
+
+        public object CreateSample(string formalName)
+        {
+            SampleInfo sampleInfo = GetRequiredSampleInfo(formalName);
+            return Activator.CreateInstance(sampleInfo.SampleType);
+        }
+
+        private SampleInfo GetRequiredSampleInfo(string formalName)
+        {
+            if (!string.IsNullOrEmpty(formalName) && _samplesByName.TryGetValue(formalName, out SampleInfo sampleInfo))
+            {
+                return sampleInfo;
+            }
+
+            throw new ArgumentException($"Unknown sample '{formalName}'.", nameof(formalName));
+        }
+
+        private static IList<SampleInfo> CreateSampleInfos(Assembly assembly)
+        {
+            IEnumerable<Type> sampleTypes = assembly.GetTypes()
+                .Where(type => type.GetTypeInfo().GetCustomAttributes().OfType<SampleAttribute>().Any());
+
+            List<SampleInfo> samples = new List<SampleInfo>();
+
+            foreach (Type type in sampleTypes)
+            {
+                try
+                {
+                    samples.Add(new SampleInfo(type));
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Could not create sample from " + type + ": " + ex);
+                }
+            }
+
+            return samples;
+        }
+    }
+}

--- a/src/Samples.Shared/Managers/SampleManager.cs
+++ b/src/Samples.Shared/Managers/SampleManager.cs
@@ -11,11 +11,9 @@
 // Uncomment the following line to include the samples subset in the app.
 //#define INCLUDE_SAMPLES_SUBSET
 
-using ArcGIS.Samples.Shared.Attributes;
 using ArcGIS.Samples.Shared.Models;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -26,14 +24,23 @@ namespace ArcGIS.Samples.Managers
     /// <summary>
     /// Single instance class to manage samples.
     /// </summary>
-    public class SampleManager
+    public partial class SampleManager
     {
-        // Private constructor
-        private SampleManager()
-        { }
+        private const string _favoritedSampleFileName = "favoritedSamples";
 
         // Static initialization of the unique instance
         private static readonly SampleManager SingleInstance = new SampleManager();
+
+        private readonly Dictionary<string, SampleInfo> _sampleCache = new Dictionary<string, SampleInfo>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _catalogSampleNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _catalogCategories = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private ISampleCatalogProvider _catalogProvider;
+        private IList<SampleInfo> _allSamples;
+        private bool _initialized;
+
+        // Private constructor
+        private SampleManager()
+        { }
 
         public static SampleManager Current
         {
@@ -41,11 +48,48 @@ namespace ArcGIS.Samples.Managers
         }
 
         /// <summary>
+        /// The catalog provider used to discover sample metadata and create sample controls.
+        /// </summary>
+        public ISampleCatalogProvider CatalogProvider
+        {
+            get
+            {
+                if (_catalogProvider == null)
+                {
+                    TryCreateGeneratedCatalogProvider(ref _catalogProvider);
+                    _catalogProvider ??= new ReflectionSampleCatalogProvider(GetType().GetTypeInfo().Assembly);
+                }
+
+                return _catalogProvider;
+            }
+        }
+
+        /// <summary>
         /// A list of all samples.
         /// </summary>
         /// <remarks>This is public on purpose. Other solutions that consume
         /// this project reference it directly.</remarks>
-        public IList<SampleInfo> AllSamples { get; set; }
+        public IList<SampleInfo> AllSamples
+        {
+            get
+            {
+                EnsureInitialized();
+                return _allSamples ??= CreateAllSamples();
+            }
+            set
+            {
+                _allSamples = value;
+                _sampleCache.Clear();
+
+                if (_allSamples != null)
+                {
+                    foreach (SampleInfo sample in _allSamples)
+                    {
+                        _sampleCache[sample.FormalName] = sample;
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// A collection of all samples organized by category.
@@ -57,28 +101,121 @@ namespace ArcGIS.Samples.Managers
         /// </summary>
         public SampleInfo SelectedSample { get; set; }
 
-        private const string _favoritedSampleFileName = "favoritedSamples";
-
         /// <summary>
-        /// Initializes the sample manager by loading all of the samples in the app.
+        /// Initializes the sample manager by preparing the generated sample catalog when available.
         /// </summary>
         public void Initialize()
         {
-            // Get the currently-executing assembly.
-            Assembly samplesAssembly = GetType().GetTypeInfo().Assembly;
+            if (_initialized)
+            {
+                return;
+            }
 
-            // Get the list of all samples in the assembly.
-            AllSamples = CreateSampleInfos(samplesAssembly).OrderBy(info => info.Category)
-                .ThenBy(info => info.SampleName.ToLowerInvariant())
-                .ToList();
+            ISampleCatalogProvider catalogProvider = CatalogProvider;
+            _initialized = true;
+
+            foreach (string sampleName in catalogProvider.GetSampleNames())
+            {
+                _catalogSampleNames[sampleName] = sampleName;
+            }
+
+            foreach (string category in catalogProvider.GetCategories())
+            {
+                _catalogCategories[category] = category;
+            }
 
             BuildSampleCategories();
         }
 
+        /// <summary>
+        /// Gets the metadata for a sample by formal name, creating it only when first requested.
+        /// </summary>
+        public SampleInfo GetSample(string formalName)
+        {
+            EnsureInitialized();
+
+            if (string.IsNullOrEmpty(formalName))
+            {
+                return null;
+            }
+
+            if (_sampleCache.TryGetValue(formalName, out SampleInfo cachedSample))
+            {
+                return cachedSample;
+            }
+
+            if (!TryGetCatalogSampleName(formalName, out string catalogFormalName))
+            {
+                return null;
+            }
+
+            SampleInfo sampleInfo = CatalogProvider.CreateSampleInfo(catalogFormalName);
+
+#if !(WinUI)
+            sampleInfo.IsFavorite = IsSampleFavorited(sampleInfo.FormalName);
+#endif
+
+            _sampleCache[sampleInfo.FormalName] = sampleInfo;
+            return sampleInfo;
+        }
+
+        /// <summary>
+        /// Gets all samples for the requested category, materializing only that category.
+        /// </summary>
+        public IList<SampleInfo> GetSamplesForCategory(string category)
+        {
+            EnsureInitialized();
+
+            if (TryGetCatalogCategory(category, out string catalogCategory))
+            {
+                return CatalogProvider.GetSampleNamesForCategory(catalogCategory)
+                    .Select(GetSample)
+                    .Where(sample => sample != null)
+                    .OrderBy(sample => sample.SampleName.ToLowerInvariant())
+                    .ToList();
+            }
+
+            SearchableTreeNode categoryNode = FullTree?.Items.OfType<SearchableTreeNode>()
+                .FirstOrDefault(node => node.Name.Equals(category, StringComparison.OrdinalIgnoreCase));
+
+            return categoryNode?.Items.OfType<SampleInfo>().ToList() ?? new List<SampleInfo>();
+        }
+
+        private bool TryGetCatalogSampleName(string formalName, out string catalogFormalName)
+        {
+            catalogFormalName = null;
+            return !string.IsNullOrEmpty(formalName) && _catalogSampleNames.TryGetValue(formalName, out catalogFormalName);
+        }
+
+        private bool TryGetCatalogCategory(string category, out string catalogCategory)
+        {
+            catalogCategory = null;
+            return !string.IsNullOrEmpty(category) && _catalogCategories.TryGetValue(category, out catalogCategory);
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                Initialize();
+            }
+        }
+
+        static partial void TryCreateGeneratedCatalogProvider(ref ISampleCatalogProvider provider);
+
+        private IList<SampleInfo> CreateAllSamples()
+        {
+            return CatalogProvider.GetSampleNames()
+                .Select(GetSample)
+                .Where(sample => sample != null)
+                .OrderBy(info => info.Category)
+                .ThenBy(info => info.SampleName.ToLowerInvariant())
+                .ToList();
+        }
+
         private void BuildSampleCategories()
         {
-            // Create a tree from the list of all samples.
-            FullTree = BuildFullTree(AllSamples);
+            FullTree = BuildFullTreeFromCatalog();
 
 #if INCLUDE_SAMPLES_SUBSET
             // Add a category for the samples subset.
@@ -95,72 +232,50 @@ namespace ArcGIS.Samples.Managers
 #endif
         }
 
+        private SearchableTreeNode BuildFullTreeFromCatalog()
+        {
+            return new SearchableTreeNode(
+                "All Samples",
+                () => CatalogProvider.GetCategories()
+                    .OrderBy(category => category)
+                    .Select(category => new SearchableTreeNode(category, () => GetSamplesForCategory(category).Cast<object>()))
+                    .Cast<object>());
+        }
+
         /// <summary>
         /// Get a list of sample names from a resource file.
         /// </summary>
         /// <returns>An searchable tree node containing the samples found in the resource file.</returns>
         private SearchableTreeNode GetSearchableTreeNodeFromFile(string fileName, string searchableTreeNodeTitle, bool orderByName = true)
         {
-            // Instantiate a null XElement to be populated by the resource file.
             XElement sampleElement = null;
-
-            // Create a list to hold the names of the samples.
             List<string> samples = new List<string>();
 
-            string resourceStreamName = this.GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith(fileName));
+            string resourceStreamName = GetType().Assembly.GetManifestResourceNames().Single(str => str.EndsWith(fileName));
 
-            // Load the FeaturedSamples resource file.
-            using (Stream stream = this.GetType().Assembly.
-                       GetManifestResourceStream(resourceStreamName))
+            using (Stream stream = GetType().Assembly.GetManifestResourceStream(resourceStreamName))
             {
                 sampleElement = XElement.Load(stream);
             }
 
-            // If the resource file has been successfully loaded populate the list of samples.
             if (sampleElement != null)
             {
                 samples = sampleElement.Descendants("Sample").Select(x => x.Value).ToList();
             }
 
-            IEnumerable<SampleInfo> searchableTreeNodeItems = AllSamples.Where(sample => samples.Contains(sample.FormalName, StringComparer.OrdinalIgnoreCase));
-
-            if (orderByName)
+            return new SearchableTreeNode(searchableTreeNodeTitle, () =>
             {
-                searchableTreeNodeItems = searchableTreeNodeItems.OrderBy(sample => sample.SampleName);
-            }
+                IEnumerable<SampleInfo> searchableTreeNodeItems = samples
+                    .Select(GetSample)
+                    .Where(sample => sample != null);
 
-            return new SearchableTreeNode(searchableTreeNodeTitle, searchableTreeNodeItems);
-        }
-
-        /// <summary>
-        /// Creates a list of sample metadata objects for each sample in the assembly.
-        /// </summary>
-        /// <param name="assembly">The assembly to search for samples.</param>
-        /// <returns>List of sample metadata objects.</returns>
-        private static IList<SampleInfo> CreateSampleInfos(Assembly assembly)
-        {
-            // Get all the types in the assembly that are decorated with a SampleAttribute.
-            IEnumerable<Type> sampleTypes = assembly.GetTypes()
-                .Where(type => type.GetTypeInfo().GetCustomAttributes().OfType<SampleAttribute>().Any());
-
-            // Create a list to hold all constructed sample metadata objects.
-            List<SampleInfo> samples = new List<SampleInfo>();
-
-            // Create the sample metadata for each sample.
-            foreach (Type type in sampleTypes)
-            {
-                try
+                if (orderByName)
                 {
-                    SampleInfo sampleInfo = new SampleInfo(type);
+                    searchableTreeNodeItems = searchableTreeNodeItems.OrderBy(sample => sample.SampleName);
+                }
 
-                    samples.Add(sampleInfo);
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine("Could not create sample from " + type + ": " + ex);
-                }
-            }
-            return samples;
+                return searchableTreeNodeItems.Cast<object>();
+            });
         }
 
         /// <summary>
@@ -203,7 +318,19 @@ namespace ArcGIS.Samples.Managers
         /// <returns>Sample as a control.</returns>
         public object SampleToControl(SampleInfo sampleModel)
         {
-            return Activator.CreateInstance(sampleModel.SampleType);
+            EnsureInitialized();
+
+            if (TryGetCatalogSampleName(sampleModel.FormalName, out string catalogFormalName))
+            {
+                return CatalogProvider.CreateSample(catalogFormalName);
+            }
+
+            if (sampleModel.SampleType != null)
+            {
+                return Activator.CreateInstance(sampleModel.SampleType);
+            }
+
+            throw new InvalidOperationException($"Sample '{sampleModel.FormalName}' cannot be created because no factory or sample type is available.");
         }
 
         /// <summary>
@@ -214,62 +341,73 @@ namespace ArcGIS.Samples.Managers
         /// <returns><c>true</c> if the sample matches the query.</returns>
         public bool SampleSearchFunc(SampleInfo sample, string searchText)
         {
-            searchText = searchText.ToLower();
-            return sample.SampleName.ToLower().Contains(searchText) ||
-                   sample.Category.ToLower().Contains(searchText) ||
-                   sample.Description.ToLower().Contains(searchText) ||
-                   sample.Tags.Any(tag => tag.Contains(searchText));
+            searchText = (searchText ?? string.Empty).ToLowerInvariant();
+            return sample.SampleName.ToLowerInvariant().Contains(searchText) ||
+                   sample.Category.ToLowerInvariant().Contains(searchText) ||
+                   sample.Description.ToLowerInvariant().Contains(searchText) ||
+                   sample.Tags.Any(tag => tag.ToLowerInvariant().Contains(searchText));
         }
 
 #if !(WinUI)
         public bool IsSampleFavorited(string sampleFormalName)
         {
-            return GetFavoriteSampleNames().Contains(sampleFormalName);
+            return GetFavoriteSampleNames().Contains(sampleFormalName, StringComparer.OrdinalIgnoreCase);
         }
 
         private static List<string> GetFavoriteSampleNames()
         {
-            // Get the names of the favorite samples from the saved file if it exists.
-            // If the file does not exist, create it.
-            if (File.Exists(Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName)))
+            string favoritesFile = Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName);
+
+            if (File.Exists(favoritesFile))
             {
-                return File.ReadAllLines(Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName)).ToList();
+                return File.ReadAllLines(favoritesFile).ToList();
             }
-            else
-            {
-                File.Create(Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName));
-            }
+
+            using FileStream _ = File.Create(favoritesFile);
 
             return new List<string>();
         }
 
         public void AddRemoveFavorite(string sampleName)
         {
-            // Get the list of favorites from the saved file.
-            List<string> favorites = File.ReadAllLines(Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName)).ToList();
+            string favoritesFile = Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName);
+            List<string> favorites = File.ReadAllLines(favoritesFile).ToList();
+            string existingFavorite = favorites.FirstOrDefault(name => name.Equals(sampleName, StringComparison.OrdinalIgnoreCase));
 
-            // If the sample currently being added/removed is present or not present remove or add it to the list accordingly.
-            if (favorites.Contains(sampleName))
+            if (existingFavorite != null)
             {
-                favorites.Remove(sampleName);
+                favorites.Remove(existingFavorite);
             }
             else
             {
                 favorites.Add(sampleName);
 
 #if ENABLE_ANALYTICS
+                SampleInfo favoritedSample = GetSample(sampleName);
                 var eventData = new Dictionary<string, string> {
-                    { "Sample", AllSamples.FirstOrDefault(s => s.FormalName.Equals(sampleName)).SampleName }
+                    { "Sample", favoritedSample?.SampleName ?? sampleName }
                 };
 
                 _ = Helpers.AnalyticsHelper.TrackEvent("favorite_added", eventData);
 #endif
             }
 
-            // Save the new list of favorites.
-            File.WriteAllLines(Path.Combine(GetFavoritesFolder(), _favoritedSampleFileName), favorites);
+            File.WriteAllLines(favoritesFile, favorites);
 
-            // Build the categories tree again with the updated favorite category.
+            HashSet<string> favoriteNames = new HashSet<string>(favorites, StringComparer.OrdinalIgnoreCase);
+            foreach (SampleInfo sample in _sampleCache.Values)
+            {
+                sample.IsFavorite = favoriteNames.Contains(sample.FormalName);
+            }
+
+            if (_allSamples != null)
+            {
+                foreach (SampleInfo sample in _allSamples)
+                {
+                    sample.IsFavorite = favoriteNames.Contains(sample.FormalName);
+                }
+            }
+
             BuildSampleCategories();
         }
 
@@ -292,16 +430,27 @@ namespace ArcGIS.Samples.Managers
 
         public SearchableTreeNode GetFavoritesCategory()
         {
-            IEnumerable<string> favoriteSamples = GetFavoriteSampleNames();
+            List<string> favoriteSampleNames = GetFavoriteSampleNames();
+            HashSet<string> favoriteNames = new HashSet<string>(favoriteSampleNames, StringComparer.OrdinalIgnoreCase);
 
-            // Set favorited samples.
-            foreach (var sample in AllSamples)
+            foreach (SampleInfo sample in _sampleCache.Values)
             {
-                sample.IsFavorite = favoriteSamples.Contains(sample.FormalName, StringComparer.OrdinalIgnoreCase);
+                sample.IsFavorite = favoriteNames.Contains(sample.FormalName);
             }
 
-            // Create a new SearchableTreeNode for the updated favorites.
-            return new SearchableTreeNode("Favorites", AllSamples.Where(sample => favoriteSamples.Contains(sample.FormalName, StringComparer.OrdinalIgnoreCase)).OrderBy(sample => sample.SampleName));
+            if (_allSamples != null)
+            {
+                foreach (SampleInfo sample in _allSamples)
+                {
+                    sample.IsFavorite = favoriteNames.Contains(sample.FormalName);
+                }
+            }
+
+            return new SearchableTreeNode("Favorites", () => favoriteSampleNames
+                .Select(GetSample)
+                .Where(sample => sample != null)
+                .OrderBy(sample => sample.SampleName)
+                .Cast<object>());
         }
 
         internal static string GetFavoritesFolder()

--- a/src/Samples.Shared/Models/SampleInfo.cs
+++ b/src/Samples.Shared/Models/SampleInfo.cs
@@ -177,6 +177,37 @@ namespace ArcGIS.Samples.Shared.Models
         }
 
         /// <summary>
+        /// This constructor is for use by generated sample catalogs.
+        /// </summary>
+        public SampleInfo(
+            string formalName,
+            string sampleName,
+            string category,
+            string description,
+            string instructions,
+            IEnumerable<string> tags,
+            IEnumerable<string> offlineDataItems = null,
+            IEnumerable<string> androidLayouts = null,
+            IEnumerable<string> xamlLayouts = null,
+            IEnumerable<string> classFiles = null,
+            IEnumerable<string> embeddedResources = null,
+            Type sampleType = null)
+        {
+            SampleType = sampleType;
+            FormalName = formalName;
+            SampleName = sampleName;
+            Category = category;
+            Description = description;
+            Instructions = instructions;
+            Tags = tags ?? Enumerable.Empty<string>();
+            AndroidLayouts = androidLayouts;
+            XamlLayouts = xamlLayouts;
+            ClassFiles = classFiles;
+            OfflineDataItems = offlineDataItems;
+            EmbeddedResources = embeddedResources;
+        }
+
+        /// <summary>
         /// Gets the attribute of type <typeparamref name="T"/> for a type described by <paramref name="typeInfo"/>.
         /// </summary>
         /// <typeparam name="T">The type of the attribute object to return.</typeparam>

--- a/src/Samples.Shared/Models/SearchableTreeNode.cs
+++ b/src/Samples.Shared/Models/SearchableTreeNode.cs
@@ -19,7 +19,12 @@ namespace ArcGIS.Samples.Shared.Models
         public string Name { get; private set; }
 
         // List of child items. These are expected to be other SearchableTreeNodes or SampleInfos.
-        public List<object> Items { get; private set; }
+        private readonly Lazy<List<object>> _items;
+
+        public List<object> Items
+        {
+            get { return _items.Value; }
+        }
 
         /// <summary>
         /// Creates a new SearchableTreeNode from a list of items.
@@ -27,9 +32,19 @@ namespace ArcGIS.Samples.Shared.Models
         /// <param name="name">The name for this node in the tree.</param>
         /// <param name="items">A list of containing <c>SampleInfo</c>s and <c>SearchableTreeNode</c>s.</param>
         public SearchableTreeNode(string name, IEnumerable<object> items)
+            : this(name, () => items)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new searchable tree node whose child items are created on first use.
+        /// </summary>
+        /// <param name="name">The name for this node in the tree.</param>
+        /// <param name="getItems">A function that returns child <c>SampleInfo</c>s and <c>SearchableTreeNode</c>s.</param>
+        public SearchableTreeNode(string name, Func<IEnumerable<object>> getItems)
         {
             Name = name;
-            Items = items.ToList();
+            _items = new Lazy<List<object>>(() => getItems()?.ToList() ?? new List<object>());
         }
 
         /// <summary>

--- a/src/WPF/ArcGIS.WPF.Viewer.Net.sln
+++ b/src/WPF/ArcGIS.WPF.Viewer.Net.sln
@@ -9,6 +9,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ArcGIS.Samples.Shared", "..
 EndProject
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "ArcGIS.WPF.StorePackage", "WPF.StorePackage\ArcGIS.WPF.StorePackage.wapproj", "{13A60801-7B9A-4573-923F-9F2373E8BF84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CatalogGenerator", "..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj", "{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,18 @@ Global
 		{13A60801-7B9A-4573-923F-9F2373E8BF84}.Release|x64.ActiveCfg = Release|x64
 		{13A60801-7B9A-4573-923F-9F2373E8BF84}.Release|x64.Build.0 = Release|x64
 		{13A60801-7B9A-4573-923F-9F2373E8BF84}.Release|x64.Deploy.0 = Release|x64
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|x64.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|ARM64.Build.0 = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|x64.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
+++ b/src/WPF/WPF.Viewer/ArcGIS.WPF.Viewer.Net.csproj
@@ -65,6 +65,12 @@
     <PackageReference Include="System.Speech" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="Converters\*.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>

--- a/src/WinUI/ArcGIS.WinUI.Viewer.sln
+++ b/src/WinUI/ArcGIS.WinUI.Viewer.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArcGIS.WinUI.Viewer", "ArcG
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ArcGIS.Samples.Shared", "..\Samples.Shared\ArcGIS.Samples.Shared.shproj", "{0AD85845-0BA1-4DC9-8C32-E6FD7632E32D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CatalogGenerator", "..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj", "{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -27,6 +29,14 @@ Global
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.ActiveCfg = Release|x64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.Build.0 = Release|x64
 		{22859B00-B68B-43E8-A402-20DBA622A27A}.Release|x64.Deploy.0 = Release|x64
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Debug|x64.Build.0 = Debug|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|ARM64.Build.0 = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|x64.ActiveCfg = Release|Any CPU
+		{462BC71C-3CB5-3F3B-15F1-CF200B4F1B94}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/ArcGIS.WinUI.Viewer.csproj
@@ -71,6 +71,12 @@
     <PackageReference Include="Esri.ArcGISRuntime.Toolkit.WinUI" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Samples.CatalogGenerator\Samples.CatalogGenerator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="Converters\*.cs">


### PR DESCRIPTION
# Description

Add a Roslyn source generator that emits an ISampleCatalogProvider with sample metadata and sample factories at build time. The generated provider lets startup build the category shell and Featured list without reflecting over every sample type or constructing every SampleInfo up front. This reduces launch work and helps avoid the iOS watchdog as the sample set grows.

Generated catalog shape:

```csharp
    public sealed class GeneratedSampleCatalog : ISampleCatalogProvider
    {
        public IReadOnlyList<string> GetCategories() => Categories;
        public IReadOnlyList<string> GetSampleNames() => SampleNames;

        public SampleInfo CreateSampleInfo(string formalName)
        {
            switch (formalName)
            {
                case "DisplayMap":
                    return new SampleInfo(
                        formalName: "DisplayMap",
                        sampleName: "Display map",
                        category: "Map",
                        sampleType: typeof(DisplayMap));
                default:
                    throw new ArgumentException(...);
            }
        }

        public object CreateSample(string formalName)
        {
            switch (formalName)
            {
                case "DisplayMap":
                    return new DisplayMap();
                default:
                    throw new ArgumentException(...);
            }
        }
    }
```

Old startup flow:

```text
    AppShell / flyout start
        |
        v
    SampleManager.Initialize()
        |
        v
    Assembly.GetTypes()
        |
        v
    Read attributes and create every SampleInfo
        |
        v
    Build full tree, Featured, Favorites
        |
        v
    First page can render
```

New startup flow:

```text
    AppShell / flyout start
        |
        v
    SampleManager.Initialize()
        |
        v
    GeneratedSampleCatalog via partial hook
        |
        v
    Load sample names and category names only
        |
        v
    Build category shell and materialize Featured
        |
        v
    First page can render
        |
        v
    Category, search, offline data, and samples load on demand
```

Route SampleManager through the catalog provider API for sample lookup, category loading, all-sample materialization, and sample creation. Search, offline data, and full sample lists still materialize on demand when those flows need them instead of during boot.

Keep ReflectionSampleCatalogProvider as a plan B for consumers or targets that do not wire in the generator. The fallback preserves the old reflection-based discovery behavior behind the same ISampleCatalogProvider contract while normal app builds use the generated catalog and avoid startup reflection.

## Type of change

<!--- Delete any that don't apply -->

- Sample viewer enhancement

## Platforms tested on

<!--- Delete any that don't apply -->

- [ ] WPF .NET 8
- [ ] WinUI
- [ ] MAUI WinUI
- [ ] MAUI Android
- [x] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards

