### PR TITLE
Replace retired dark gray basemap with BasemapStyle.ArcGISDarkGray

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Location/ShowLocationHistory/ShowLocationHistory.xaml.cs
@@ -26,9 +26,6 @@ namespace ArcGIS.Samples.ShowLocationHistory
         tags: new[] { "GPS", "bread crumb", "breadcrumb", "history", "movement", "navigation", "real-time", "trace", "track", "trail" })]
     public partial class ShowLocationHistory : ContentPage, IDisposable
     {
-        // URL to the raster dark gray canvas basemap.
-        private const string BasemapUrl = "https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45";
-
         // Track whether location tracking is enabled.
         private bool _isTrackingEnabled;
 
@@ -56,7 +53,7 @@ namespace ArcGIS.Samples.ShowLocationHistory
         private void Initialize()
         {
             // Create new Map with basemap.
-            Map myMap = new Map(new Uri(BasemapUrl));
+            Map myMap = new Map(BasemapStyle.ArcGISDarkGray);
 
             // Display the map.
             MyMapView.Map = myMap;

--- a/src/WPF/WPF.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -59,7 +59,7 @@ namespace ArcGIS.WPF.Samples.AnimateImageOverlay
             }
 
             // Create the scene.
-            MySceneView.Scene = new Scene(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")));
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISDarkGray);
 
             // Create an envelope for the imagery.
             var pointForFrame = new MapPoint(-120.0724273439448, 35.131016955536694, SpatialReferences.Wgs84);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/SceneView/AnimateImageOverlay/AnimateImageOverlay.xaml.cs
@@ -61,7 +61,7 @@ namespace ArcGIS.WinUI.Samples.AnimateImageOverlay
             }
 
             // Create the scene.
-            MySceneView.Scene = new Scene(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45")));
+            MySceneView.Scene = new Scene(BasemapStyle.ArcGISDarkGray);
 
             // Create an envelope for the imagery.
             var pointForFrame = new MapPoint(-120.0724273439448, 35.131016955536694, SpatialReferences.Wgs84);


### PR DESCRIPTION
# Description

Replace retired dark gray basemap with BasemapStyle.ArcGISDarkGray

## Type of change

- Other enhancement

## Platforms tested on

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI


## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes

