### PR TITLE
Update CreateLoadReport to exclude barriers as specified in the sample description

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -104,6 +104,7 @@ namespace ArcGIS.Samples.CreateLoadReport
                     _traceParameters = new UtilityTraceParameters(UtilityTraceType.Downstream, new[] { startingLocation });
                     _traceParameters.ResultTypes.Add(UtilityTraceResultType.FunctionOutputs);
                     _traceParameters.TraceConfiguration = tier?.GetDefaultTraceConfiguration();
+                    _traceParameters.TraceConfiguration.IncludeBarriers = false;
 
                     // Create function input and output condition.
                     UtilityCategory serviceCategory = _utilityNetwork.Definition.Categories.FirstOrDefault(c => c.Name == ServiceCategoryName);

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -121,6 +121,7 @@ namespace ArcGIS.WPF.Samples.CreateLoadReport
                     _traceParameters = new UtilityTraceParameters(UtilityTraceType.Downstream, new[] { startingLocation });
                     _traceParameters.ResultTypes.Add(UtilityTraceResultType.FunctionOutputs);
                     _traceParameters.TraceConfiguration = tier?.GetDefaultTraceConfiguration();
+                    _traceParameters.TraceConfiguration.IncludeBarriers = false;
 
                     // Create function input and output condition.
                     UtilityCategory serviceCategory = _utilityNetwork.Definition.Categories.FirstOrDefault(c => c.Name == ServiceCategoryName);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/CreateLoadReport/CreateLoadReport.xaml.cs
@@ -121,6 +121,7 @@ namespace ArcGIS.WinUI.Samples.CreateLoadReport
                     _traceParameters = new UtilityTraceParameters(UtilityTraceType.Downstream, new[] { startingLocation });
                     _traceParameters.ResultTypes.Add(UtilityTraceResultType.FunctionOutputs);
                     _traceParameters.TraceConfiguration = tier?.GetDefaultTraceConfiguration();
+                    _traceParameters.TraceConfiguration.IncludeBarriers = false;
 
                     // Create function input and output condition.
                     UtilityCategory serviceCategory = _utilityNetwork.Definition.Categories.FirstOrDefault(c => c.Name == ServiceCategoryName);


### PR DESCRIPTION
# Description

The Qt team pointed this issue out while working on cert for their own samples. Keeping this in draft until we merge main for next release.

## Type of change

<!--- Delete any that don't apply -->

- Bug fix

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [ ] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)
