### PR TITLE
Search functionality on WPF, WinUI, Maui is shared

### DIFF
--- a/src/MAUI/Maui.Samples/ViewModels/SearchResultViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/SearchResultViewModel.cs
@@ -1,0 +1,36 @@
+﻿using ArcGIS.Samples.Shared.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ArcGIS.ViewModels
+{
+    public partial class SearchResultViewModel : ObservableObject
+    {
+        public SearchResultViewModel(SampleInfo sampleResult, int score)
+        {
+            SampleName = sampleResult.SampleName;
+            SampleCategory = sampleResult.Category;
+            SampleDescription = sampleResult.Description;
+            SampleImage = new FileImageSource() { File = sampleResult.SampleImageName };
+            Score = score;
+            SampleObject = sampleResult;
+        }
+
+        [ObservableProperty]
+        int _score;
+
+        [ObservableProperty]
+        string _sampleName;
+
+        [ObservableProperty]
+        string _sampleCategory;
+
+        [ObservableProperty]
+        string _sampleDescription;
+
+        [ObservableProperty]
+        ImageSource _sampleImage;
+
+        [ObservableProperty]
+        SampleInfo _sampleObject;
+    }
+}

--- a/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
+++ b/src/MAUI/Maui.Samples/ViewModels/SearchViewModel.cs
@@ -11,30 +11,13 @@ namespace ArcGIS.ViewModels
     {
         private IDispatcherTimer _delaySearchTimer;
         private const int _delayedTextChangedTimeout = 500;
-
-        private Dictionary<SampleInfo, (string[] nameKeywords, string[] categoryKeywords, string[] descriptionKeywords, string[] tagsKeywords)>
-            _sampleKeywords = new();
-
-        private static readonly HashSet<string> _commonWords = ["in", "a", "of", "the", "by", "an", "and"];
+        private const int _maxSearchResults = 15;
 
         private List<SearchResultViewModel> _results;
-
-        [GeneratedRegex("[^a-zA-Z0-9 -]")]
-        private static partial Regex NonWordCharRegex();
 
         public SearchViewModel()
         {
             SearchItems = new ObservableCollection<SearchResultViewModel>();
-
-            // Initialize the dictionary of sample keywords.
-            foreach (var sample in SampleManager.Current.AllSamples.ToList())
-            {
-                string[] sampleNameKeywords = GetKeywords(sample.SampleName).Append(sample.FormalName.ToLower()).ToArray();
-                var categoryKeywords = GetKeywords(sample.Category);
-                var descriptionKeywords = GetKeywords(sample.Description);
-                var tagsKeywords = sample.Tags.ToArray();
-                _sampleKeywords.Add(sample, (sampleNameKeywords, categoryKeywords, descriptionKeywords, tagsKeywords));
-            }
         }
 
         [ObservableProperty]
@@ -45,8 +28,6 @@ namespace ArcGIS.ViewModels
 
         [ObservableProperty]
         bool _noSearchResults;
-
-        private string[] _previousSearchKeywords = [];
 
         partial void OnSearchTextChanged(string value)
         {
@@ -64,108 +45,30 @@ namespace ArcGIS.ViewModels
             if (string.IsNullOrWhiteSpace(SearchText))
             {
                 SearchItems = new ObservableCollection<SearchResultViewModel>();
+                return;
             }
-            else
+
+            var sampleMatches = SampleManager.Current.SearchEngine.Search(SearchText);
+
+            _results = sampleMatches.Select(r =>
             {
-                // Remove punctuation from the search text and any trailing white space at the end.
-                var searchKeywords = SearchViewModel.GetKeywords(SearchText);
+                var sampleInfo = SampleManager.Current.GetSample(r.SampleFormalName);
+                return new SearchResultViewModel(sampleInfo, r.Score);
+            }).ToList();
 
-                // Check if the keywords are the same as the previous search.
-                if (Enumerable.SequenceEqual(searchKeywords, _previousSearchKeywords))
-                {
-                    return;
-                }
-                else
-                {
-                    _previousSearchKeywords = searchKeywords;
-                }
-
-                List<SearchResultViewModel> sampleResults = new List<SearchResultViewModel>();
-
-                foreach (var sample in _sampleKeywords)
-                {
-                    int score = 0;
-
-                    score += GetMatches(sample.Value.nameKeywords, searchKeywords) * 6;
-                    score += GetMatches(sample.Value.categoryKeywords, searchKeywords) * 3;
-                    score += GetMatches(sample.Value.descriptionKeywords, searchKeywords) * 2;
-                    score += GetMatches(sample.Value.tagsKeywords, searchKeywords);
-
-                    if (score > 0)
-                    {
-                        sampleResults.Add(new SearchResultViewModel(sample.Key, score));
-                    }
-                }
-
-                try
-                {
-                    if (sampleResults.Count != 0)
-                    {
-                        sampleResults = sampleResults.OrderByDescending(sampleResults => sampleResults.Score).ThenBy(sampleResults => sampleResults.SampleName).ToList();
-                        _results = sampleResults;
-
-                        // Limit the number of search results to 15
-                        if (sampleResults.Count > 15)
-                            sampleResults = sampleResults[0..15];
-
-                        SearchItems = new ObservableCollection<SearchResultViewModel>(sampleResults);
-                    }
-                    else
-                    {
-                        SearchItems = new ObservableCollection<SearchResultViewModel>();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine(ex.ToString());
-                }
-            }
+            SearchItems = new ObservableCollection<SearchResultViewModel>(_results.Take(_maxSearchResults));
         }
 
         [RelayCommand]
         void BatchResults()
         {
             var startIndex = SearchItems.Count;
-            var endIndex = Math.Min(startIndex + 15, _results.Count);
+            var endIndex = Math.Min(startIndex + _maxSearchResults, _results.Count);
 
             if (endIndex >= _results.Count) return;
 
-            foreach(var result in _results[startIndex..endIndex])
+            foreach (var result in _results[startIndex..endIndex])
                 SearchItems.Add(result);
-        }
-
-        private static int GetMatches(string[] contentKeywords, string[] searchKeywords)
-        {
-            int matches = 0;
-
-            foreach (var searchKeyword in searchKeywords)
-            {
-                foreach (var contentKeyword in contentKeywords)
-                {
-                    if (contentKeyword == searchKeyword)
-                    {
-                        matches += 2;
-                    }
-                    else if (contentKeyword.Contains(searchKeyword))
-                    {
-                        matches++;
-                    }
-                }
-            }
-
-            return matches;
-        }
-
-        private static string[] GetKeywords(string text)
-        {
-            // Remove punctuation from the search text and any trailing white space at the end.
-            text = NonWordCharRegex().Replace(text, "").ToLower();
-
-            // Split the text into words, remove duplicates, and filter out common words in one go.
-            return text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                       .Distinct()
-                       .Where(static word => !_commonWords.Contains(word))
-                       .ToArray();
         }
 
         private void SearchTextChanged()
@@ -195,36 +98,5 @@ namespace ArcGIS.ViewModels
                 _delaySearchTimer.Stop();
             }
         }
-    }
-
-    public partial class SearchResultViewModel : ObservableObject
-    {
-        public SearchResultViewModel(SampleInfo sampleResult, int score)
-        {
-            SampleName = sampleResult.SampleName;
-            SampleCategory = sampleResult.Category;
-            SampleDescription = sampleResult.Description;
-            SampleImage = new FileImageSource() { File = sampleResult.SampleImageName };
-            Score = score;
-            SampleObject = sampleResult;
-        }
-
-        [ObservableProperty]
-        int _score;
-
-        [ObservableProperty]
-        string _sampleName;
-
-        [ObservableProperty]
-        string _sampleCategory;
-
-        [ObservableProperty]
-        string _sampleDescription;
-
-        [ObservableProperty]
-        ImageSource _sampleImage;
-
-        [ObservableProperty]
-        SampleInfo _sampleObject;
     }
 }

--- a/src/Samples.Shared/Managers/SampleManager.cs
+++ b/src/Samples.Shared/Managers/SampleManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Esri.
+// Copyright 2018 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
@@ -100,6 +100,12 @@ namespace ArcGIS.Samples.Managers
         /// The sample that is currently being shown to the user.
         /// </summary>
         public SampleInfo SelectedSample { get; set; }
+
+        private SearchEngine _searchEngine;
+        /// <summary>
+        /// A search engine for searching samples.
+        /// </summary>
+        public SearchEngine SearchEngine => _searchEngine ??= new SearchEngine(AllSamples);
 
         /// <summary>
         /// Initializes the sample manager by preparing the generated sample catalog when available.
@@ -331,21 +337,6 @@ namespace ArcGIS.Samples.Managers
             }
 
             throw new InvalidOperationException($"Sample '{sampleModel.FormalName}' cannot be created because no factory or sample type is available.");
-        }
-
-        /// <summary>
-        /// Common sample search predicate implementation
-        /// </summary>
-        /// <param name="sample">Sample to evaluate</param>
-        /// <param name="searchText">Query</param>
-        /// <returns><c>true</c> if the sample matches the query.</returns>
-        public bool SampleSearchFunc(SampleInfo sample, string searchText)
-        {
-            searchText = (searchText ?? string.Empty).ToLowerInvariant();
-            return sample.SampleName.ToLowerInvariant().Contains(searchText) ||
-                   sample.Category.ToLowerInvariant().Contains(searchText) ||
-                   sample.Description.ToLowerInvariant().Contains(searchText) ||
-                   sample.Tags.Any(tag => tag.ToLowerInvariant().Contains(searchText));
         }
 
 #if !(WinUI)

--- a/src/Samples.Shared/Managers/SearchEngine.cs
+++ b/src/Samples.Shared/Managers/SearchEngine.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2018 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+
+// Uncomment the following line to include the samples subset in the app.
+//#define INCLUDE_SAMPLES_SUBSET
+
+using ArcGIS.Samples.Shared.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace ArcGIS.Samples.Managers
+{
+    /// <summary>
+    /// A class that manages the search functionality for the samples.
+    /// </summary>
+    public partial class SearchEngine
+    {
+        private string[] _previousSearchKeywords;
+        private List<SampleSearchResult> _cachedResults = new();
+        private static readonly HashSet<string> _commonWords = ["a", "an", "and", "at", "but", "by", "for", "from", "in", "is", "it", "of", "on", "or", "the", "to", "with"];
+        
+        public IList<SampleSearchableProfile> ItemKeywords { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchManager"/> class with the provided list of samples.
+        /// </summary>
+        /// <param name="samples">The list of samples to be managed by the search engine.</param>
+        public SearchEngine(IList<SampleInfo> samples)
+        {
+            this.ItemKeywords = samples.Select(sample =>
+            {
+                var item = new SampleSearchableProfile() {  SampleFormalName = sample.FormalName };
+                item.KeywordScoreCollection.Add(new SampleKeywordScore()
+                {
+                    Keywords = GetKeywords(sample.SampleName).Append(sample.FormalName.ToLower()).ToArray(),
+                    ScoreFactor = 6
+                });
+                item.KeywordScoreCollection.Add(new SampleKeywordScore()
+                {
+                    Keywords = GetKeywords(sample.Category),
+                    ScoreFactor = 3
+                });
+                item.KeywordScoreCollection.Add(new SampleKeywordScore()
+                {
+                    Keywords = GetKeywords(sample.Description),
+                    ScoreFactor = 2
+                });
+                item.KeywordScoreCollection.Add(new SampleKeywordScore()
+                {
+                    Keywords = sample.Tags.ToArray(),
+                    ScoreFactor = 1
+                });
+                return item;
+            }).ToList();
+        }
+
+        /// <summary>
+        /// Searches for samples based on the provided search text and returns a list of search results.
+        /// </summary>
+        /// <param name="searchText">The text to search for within the samples.</param>
+        /// <returns>A list of search results matching the search text sorted by score and then by name.</returns>
+        public List<SampleSearchResult> Search(string searchText)
+        {
+            var searchKeywords = GetKeywords(searchText);
+            // If the keywords are the same as the previous search we exit
+            if (_previousSearchKeywords != null && _previousSearchKeywords.SequenceEqual(searchKeywords))
+                return _cachedResults;
+
+            _previousSearchKeywords = searchKeywords;
+
+            List<SampleSearchResult> sampleResults = new List<SampleSearchResult>();
+
+            foreach (var sample in ItemKeywords)
+            {
+                int score = 0;
+
+                foreach (var kws in sample.KeywordScoreCollection.OrderBy(s => s.ScoreFactor))
+                    score += GetMatches(kws.Keywords, searchKeywords) * kws.ScoreFactor;
+
+                if (score > 0)
+                    sampleResults.Add(new SampleSearchResult() { SampleFormalName = sample.SampleFormalName, Score = score });
+            }
+
+            _cachedResults = sampleResults.OrderByDescending(sampleResults => sampleResults.Score).ThenBy(sampleResults => sampleResults.SampleFormalName).ToList();
+            return _cachedResults;
+        }
+        
+        [GeneratedRegex("[^a-zA-Z0-9 -]")]
+        private static partial Regex NonWordCharRegex();
+
+        private string[] GetKeywords(string text)
+        {
+            // Remove punctuation from the search text and any trailing white space at the end.
+            text = NonWordCharRegex().Replace(text, "").ToLower();
+
+            // Split the text into words, remove duplicates, and filter out common words in one go.
+            return text.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                       .Distinct()
+                       .Where(static word => !_commonWords.Contains(word))
+                       .ToArray();
+        }
+
+        private int GetMatches(string[] contentKeywords, string[] searchKeywords)
+        {
+            int matches = 0;
+
+            foreach (var searchKeyword in searchKeywords)
+            {
+                foreach (var contentKeyword in contentKeywords)
+                {
+                    if (contentKeyword == searchKeyword)
+                        matches += 2;
+                    else if (contentKeyword.Contains(searchKeyword))
+                        matches++;
+                }
+            }
+
+            return matches;
+        }
+    }
+}

--- a/src/Samples.Shared/Managers/SearchEngine.cs
+++ b/src/Samples.Shared/Managers/SearchEngine.cs
@@ -93,7 +93,38 @@ namespace ArcGIS.Samples.Managers
             _cachedResults = sampleResults.OrderByDescending(sampleResults => sampleResults.Score).ThenBy(sampleResults => sampleResults.SampleFormalName).ToList();
             return _cachedResults;
         }
-        
+
+        /// <summary>
+        /// Searches <paramref name="fullTree"/> for samples matching <paramref name="searchText"/> and
+        /// returns every match flattened into a single category, sorted by score (desc) then title.
+        /// </summary>
+        /// <param name="searchText">The text to search for within the samples.</param>
+        /// <param name="fullTree">The full tree of categories and samples to search and filter.</param>
+        /// <returns>
+        /// <paramref name="fullTree"/> filtered but unflattened when <paramref name="searchText"/> is empty;
+        /// a single-category tree containing every match when there are results; otherwise <c>null</c>.
+        /// </returns>
+        public SearchableTreeNode Search(string searchText, SearchableTreeNode fullTree)
+        {
+            bool isSearching = !string.IsNullOrWhiteSpace(searchText);
+
+            var scoresByFormalName = Search(searchText).ToDictionary(r => r.SampleFormalName, r => r.Score);
+
+            var categoriesList = fullTree.Search((s) => scoresByFormalName.ContainsKey(s.FormalName) || !isSearching);
+
+            if (!isSearching || categoriesList == null) return categoriesList;
+
+            // Flatten every matching sample across all categories into a single list, then sort by
+            // score (desc) then title, so callers can show one flat, relevance-ordered result set.
+            var flatMatches = categoriesList.Items.OfType<SearchableTreeNode>()
+                .SelectMany(category => category.Items.OfType<SampleInfo>())
+                .DistinctBy(s => s.FormalName)
+                .OrderByDescending(s => scoresByFormalName.TryGetValue(s.FormalName, out var score) ? score : 0)
+                .ThenBy(s => s.SampleName, StringComparer.OrdinalIgnoreCase);
+
+            return new SearchableTreeNode("Search Results", new[] { new SearchableTreeNode("Search Results", flatMatches) });
+        }
+
         [GeneratedRegex("[^a-zA-Z0-9 -]")]
         private static partial Regex NonWordCharRegex();
 

--- a/src/Samples.Shared/Managers/SearchEngine.cs
+++ b/src/Samples.Shared/Managers/SearchEngine.cs
@@ -7,10 +7,6 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 
-
-// Uncomment the following line to include the samples subset in the app.
-//#define INCLUDE_SAMPLES_SUBSET
-
 using ArcGIS.Samples.Shared.Models;
 using System;
 using System.Collections.Generic;
@@ -31,7 +27,7 @@ namespace ArcGIS.Samples.Managers
         public IList<SampleSearchableProfile> ItemKeywords { get; private set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SearchManager"/> class with the provided list of samples.
+        /// Initializes a new instance of the <see cref="SearchEngine"/> class with the provided list of samples.
         /// </summary>
         /// <param name="samples">The list of samples to be managed by the search engine.</param>
         public SearchEngine(IList<SampleInfo> samples)
@@ -46,6 +42,11 @@ namespace ArcGIS.Samples.Managers
                 });
                 item.KeywordScoreCollection.Add(new SampleKeywordScore()
                 {
+                    Keywords = sample.Tags.ToArray(),
+                    ScoreFactor = 4
+                });
+                item.KeywordScoreCollection.Add(new SampleKeywordScore()
+                {
                     Keywords = GetKeywords(sample.Category),
                     ScoreFactor = 3
                 });
@@ -53,11 +54,6 @@ namespace ArcGIS.Samples.Managers
                 {
                     Keywords = GetKeywords(sample.Description),
                     ScoreFactor = 2
-                });
-                item.KeywordScoreCollection.Add(new SampleKeywordScore()
-                {
-                    Keywords = sample.Tags.ToArray(),
-                    ScoreFactor = 1
                 });
                 return item;
             }).ToList();

--- a/src/Samples.Shared/Models/SampleKeywordScore.cs
+++ b/src/Samples.Shared/Models/SampleKeywordScore.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2018 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+namespace ArcGIS.Samples.Shared.Models;
+
+public class SampleKeywordScore
+{
+    /// <summary>
+    /// Gets or sets the keywords associated with this level. Keywords are used to match search terms to samples.
+    /// </summary>
+    public string[] Keywords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the score factor for this level of keywords. The score factor is used to weight the relevance of matches.
+    /// </summary>
+    public int ScoreFactor { get; set; } = 1;
+}

--- a/src/Samples.Shared/Models/SampleSearchResult.cs
+++ b/src/Samples.Shared/Models/SampleSearchResult.cs
@@ -1,0 +1,26 @@
+// Copyright 2018 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+namespace ArcGIS.Samples.Shared.Models;
+
+/// <summary>
+/// Represents the result of a search operation, containing the score of the match and the identifier of the matched item.
+/// </summary>
+public class SampleSearchResult
+{
+    /// <summary>
+    /// Gets or sets the identifier of the matched item. This identifier is used to reference the specific item that was matched in the search operation.
+    /// </summary>
+	public string SampleFormalName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the score of the search result. The score indicates the relevance of the match, with higher scores representing more relevant matches.
+    /// </summary>
+    public int Score { get; set; }
+}

--- a/src/Samples.Shared/Models/SampleSearchableProfile.cs
+++ b/src/Samples.Shared/Models/SampleSearchableProfile.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2018 Esri.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+using System.Collections.Generic;
+
+namespace ArcGIS.Samples.Shared.Models;
+
+/// <summary>
+/// Represents a searchable profile for a sample, containing its formal name and associated keyword scores.
+/// </summary>
+public class SampleSearchableProfile
+{
+    /// <summary>
+    /// Gets or sets the formal name of the sample. This is used as an identifier for the sample in search operations.
+    /// </summary>
+    public string SampleFormalName { get; set; }
+
+    /// <summary>
+    /// Gets the collection of keyword scores associated with the sample. Each keyword score contains keywords and a score factor that indicates the relevance of those keywords for search operations.
+    /// </summary>
+    public List<SampleKeywordScore> KeywordScoreCollection { get; private set; } = new List<SampleKeywordScore>();
+}

--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -433,7 +433,10 @@ namespace ArcGIS.Samples.Desktop
 
         private void PopulateSearchedTree()
         {
-            var results = SampleManager.Current.FullTree.Search(SampleSearchFunc);
+            // Get the formal names of the samples that match the search text.
+            var sampleMatches = SampleManager.Current.SearchEngine.Search(SearchFilterBox.SearchText).Select(r => r.SampleFormalName).ToList();
+
+            var results = SampleManager.Current.FullTree.Search((s) => sampleMatches.Contains(s.FormalName) || string.IsNullOrWhiteSpace(SearchFilterBox.SearchText));
 
             // Set category data context
             Categories.DataContext = WPF.Viewer.Helpers.ToTreeViewItem(results);
@@ -467,11 +470,6 @@ namespace ArcGIS.Samples.Desktop
 #if ENABLE_ANALYTICS
             _ = AnalyticsHelper.TrackEvent("search_text", eventData);
 #endif
-        }
-
-        private bool SampleSearchFunc(SampleInfo sample)
-        {
-            return SampleManager.Current.SampleSearchFunc(sample, SearchFilterBox.SearchText);
         }
 
         private void SettingsButton_Click(object sender, RoutedEventArgs e)

--- a/src/WPF/WPF.Viewer/MainWindow.xaml.cs
+++ b/src/WPF/WPF.Viewer/MainWindow.xaml.cs
@@ -433,16 +433,15 @@ namespace ArcGIS.Samples.Desktop
 
         private void PopulateSearchedTree()
         {
-            // Get the formal names of the samples that match the search text.
-            var sampleMatches = SampleManager.Current.SearchEngine.Search(SearchFilterBox.SearchText).Select(r => r.SampleFormalName).ToList();
+            bool isSearching = !string.IsNullOrWhiteSpace(SearchFilterBox.SearchText);
 
-            var results = SampleManager.Current.FullTree.Search((s) => sampleMatches.Contains(s.FormalName) || string.IsNullOrWhiteSpace(SearchFilterBox.SearchText));
+            var results = SampleManager.Current.SearchEngine.Search(SearchFilterBox.SearchText, SampleManager.Current.FullTree);
 
             // Set category data context
             Categories.DataContext = WPF.Viewer.Helpers.ToTreeViewItem(results);
 
             // Open all if query isn't empty
-            if (!string.IsNullOrWhiteSpace(SearchFilterBox.SearchText))
+            if (isSearching)
             {
                 OpenCategoryLeaves();
                 TrackSearchEvent();

--- a/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
@@ -204,9 +204,9 @@ namespace ArcGIS.WinUI.Viewer
             await Task.Delay(200);
             _waitFlag = false;
 
-            var sampleMatches = SampleManager.Current.SearchEngine.Search(SearchBox.Text).Select(r => r.SampleFormalName).ToList();
             // Search using the sample manager
-            var categoriesList = SampleManager.Current.FullTree.Search((s) => sampleMatches.Contains(s.FormalName) || string.IsNullOrWhiteSpace(SearchBox.Text));
+            var categoriesList = SampleManager.Current.SearchEngine.Search(SearchBox.Text, SampleManager.Current.FullTree);
+
             if (categoriesList == null)
             {
                 categoriesList = new SearchableTreeNode("Search", new[] { new SearchableTreeNode("No results", new List<object>()) });

--- a/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/MainPage.xaml.cs
@@ -204,8 +204,9 @@ namespace ArcGIS.WinUI.Viewer
             await Task.Delay(200);
             _waitFlag = false;
 
+            var sampleMatches = SampleManager.Current.SearchEngine.Search(SearchBox.Text).Select(r => r.SampleFormalName).ToList();
             // Search using the sample manager
-            var categoriesList = SampleManager.Current.FullTree.Search(SampleSearchFunc);
+            var categoriesList = SampleManager.Current.FullTree.Search((s) => sampleMatches.Contains(s.FormalName) || string.IsNullOrWhiteSpace(SearchBox.Text));
             if (categoriesList == null)
             {
                 categoriesList = new SearchableTreeNode("Search", new[] { new SearchableTreeNode("No results", new List<object>()) });
@@ -234,11 +235,6 @@ namespace ArcGIS.WinUI.Viewer
             SamplePageContainer.Content = null;
             SampleManager.Current.SelectedSample = null;
             SampleSelectionGrid.Visibility = Visibility.Visible;
-        }
-
-        private bool SampleSearchFunc(SampleInfo sample)
-        {
-            return SampleManager.Current.SampleSearchFunc(sample, SearchBox.Text);
         }
 
         private async void CategoriesTree_ItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs e)


### PR DESCRIPTION
# Description

To improve the search functionality on WPF and WinUI we abstracted the Maui search functionality to be shared between all projects. Previously, a search "dynamic gallery" would attempt to match the full string into a name or description and return no results. This PR fixes that.

<img width="1422" height="741" alt="Screenshot 2026-08-05 111215" src="https://github.com/user-attachments/assets/1901804e-91b5-4549-8944-461335297476" />


## Type of change
- Sample viewer enhancement
_Changes are visible on WPF and WinUI, although underlying changes apply to all projects._

Implementation:
1. Abstract the search functionality in the Maui project into a shared `SearchEngine` class in the Shared project.
2. Added models to profile a sample into keywords and hit score
3. Remove concrete references to the SearchResultViewModel and created a model to reflect the results.
4. Added SearchEngine to SampleManager class.
5. Call SearchEngine from Maui, WPF, WinUI.

## Platforms tested on

<!--- Delete any that don't apply -->

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [x] MAUI Android
- [x] MAUI iOS
- [x] MAUI MacCatalyst

## Checklist

<!--- Delete any that don't apply -->

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
