### PR TITLE
Fix Find place address attribute

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -138,8 +138,8 @@ namespace ArcGIS.Samples.FindPlace
             // Create the geocode parameters.
             GeocodeParameters parameters = new GeocodeParameters();
 
-            // Request the matched address so it can be displayed in callouts.
-            parameters.ResultAttributeNames.Add("Match_addr");
+            // Request the place address so it can be displayed in callouts.
+            parameters.ResultAttributeNames.Add("Place_addr");
 
             try
             {
@@ -192,7 +192,7 @@ namespace ArcGIS.Samples.FindPlace
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
+                    point.Attributes["Match_Address"] = location.Attributes["Place_addr"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);

--- a/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -138,8 +138,8 @@ namespace ArcGIS.Samples.FindPlace
             // Create the geocode parameters.
             GeocodeParameters parameters = new GeocodeParameters();
 
-            // Request that the "Address" attribute is included with results, to display in callouts.
-            parameters.ResultAttributeNames.Add("Address");
+            // Request the matched address so it can be displayed in callouts.
+            parameters.ResultAttributeNames.Add("Match_addr");
 
             try
             {
@@ -192,7 +192,7 @@ namespace ArcGIS.Samples.FindPlace
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Address"];
+                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);

--- a/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -147,8 +147,8 @@ namespace ArcGIS.WPF.Samples.FindPlace
                 // Create the geocode parameters.
                 GeocodeParameters parameters = new GeocodeParameters();
 
-                // Request the matched address so it can be displayed in callouts.
-                parameters.ResultAttributeNames.Add("Match_addr");
+                // Request the place address so it can be displayed in callouts.
+                parameters.ResultAttributeNames.Add("Place_addr");
 
                 // Get the MapPoint for the current search location.
                 MapPoint searchLocation = await GetSearchMapPoint(locationText);
@@ -195,7 +195,7 @@ namespace ArcGIS.WPF.Samples.FindPlace
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
+                    point.Attributes["Match_Address"] = location.Attributes["Place_addr"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);

--- a/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -147,8 +147,8 @@ namespace ArcGIS.WPF.Samples.FindPlace
                 // Create the geocode parameters.
                 GeocodeParameters parameters = new GeocodeParameters();
 
-                // Request that the "Address" attribute is included with results, to display in callouts.
-                parameters.ResultAttributeNames.Add("Address");
+                // Request the matched address so it can be displayed in callouts.
+                parameters.ResultAttributeNames.Add("Match_addr");
 
                 // Get the MapPoint for the current search location.
                 MapPoint searchLocation = await GetSearchMapPoint(locationText);
@@ -195,7 +195,7 @@ namespace ArcGIS.WPF.Samples.FindPlace
 
                     // Add the specific result data to the point.
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Address"];
+                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
 
                     // Add the Graphic to the GraphicsOverlay.
                     resultOverlay.Graphics.Add(point);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -145,8 +145,8 @@ namespace ArcGIS.WinUI.Samples.FindPlace
             // Create the geocode parameters
             GeocodeParameters parameters = new GeocodeParameters();
 
-            // Request that the "Address" attribute is included with results, to display in callouts.
-            parameters.ResultAttributeNames.Add("Address");
+            // Request the matched address so it can be displayed in callouts.
+            parameters.ResultAttributeNames.Add("Match_addr");
 
             try
             {
@@ -198,7 +198,7 @@ namespace ArcGIS.WinUI.Samples.FindPlace
 
                     // Add the specific result data to the point
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Address"];
+                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
 
                     // Add the Graphic to the GraphicsOverlay
                     resultOverlay.Graphics.Add(point);

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/Search/FindPlace/FindPlace.xaml.cs
@@ -145,8 +145,8 @@ namespace ArcGIS.WinUI.Samples.FindPlace
             // Create the geocode parameters
             GeocodeParameters parameters = new GeocodeParameters();
 
-            // Request the matched address so it can be displayed in callouts.
-            parameters.ResultAttributeNames.Add("Match_addr");
+            // Request the place address so it can be displayed in callouts.
+            parameters.ResultAttributeNames.Add("Place_addr");
 
             try
             {
@@ -198,7 +198,7 @@ namespace ArcGIS.WinUI.Samples.FindPlace
 
                     // Add the specific result data to the point
                     point.Attributes["Match_Title"] = location.Label;
-                    point.Attributes["Match_Address"] = location.Attributes["Match_addr"];
+                    point.Attributes["Match_Address"] = location.Attributes["Place_addr"];
 
                     // Add the Graphic to the GraphicsOverlay
                     resultOverlay.Graphics.Add(point);


### PR DESCRIPTION
# Description

The Find place sample failed with a missing dictionary key because the geocoding response does not expose an `Address` attribute. Request and read `Place_addr` across WPF, WinUI, and MAUI so result callouts show the street address.

## Type of change

- Bug fix

## Platforms tested on

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)