### PR TITLE
Avoid duplicate utility association initialization

### DIFF
--- a/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/MAUI/Maui.Samples/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -98,9 +98,6 @@ namespace ArcGIS.Samples.DisplayUtilityAssociations
 
                 // Set the starting viewpoint.
                 await MyMapView.SetViewpointAsync(InitialViewpoint);
-
-                // Add the associations in the starting viewpoint.
-                _ = AddAssociations();
             }
             catch (Exception ex)
             {

--- a/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/WPF/WPF.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -107,9 +107,6 @@ namespace ArcGIS.WPF.Samples.DisplayUtilityAssociations
 
                 // Set the starting viewpoint.
                 await MyMapView.SetViewpointAsync(InitialViewpoint);
-
-                // Add the associations in the starting viewpoint.
-                _ = AddAssociations();
             }
             catch (Exception ex)
             {

--- a/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
+++ b/src/WinUI/ArcGIS.WinUI.Viewer/Samples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.xaml.cs
@@ -106,9 +106,6 @@ namespace ArcGIS.WinUI.Samples.DisplayUtilityAssociations
 
                 // Set the starting viewpoint.
                 await MyMapView.SetViewpointAsync(InitialViewpoint);
-
-                // Add the associations in the starting viewpoint.
-                _ = AddAssociations();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Description

Setting the initial viewpoint raises `NavigationCompleted`, which already loads utility associations. Remove the redundant explicit `AddAssociations` call from the WPF, WinUI, and MAUI implementations to avoid duplicate initial queries while preserving behavior.

Fixes #1131

## Type of change

- Bug fix

## Platforms tested on

- [x] WPF .NET 8
- [x] WinUI
- [x] MAUI WinUI
- [ ] MAUI Android
- [ ] MAUI iOS
- [ ] MAUI MacCatalyst

## Checklist

- [x] Self-review of changes
- [x] All changes work as expected on all affected platforms
- [x] There are no warnings related to changes
- [x] Code is commented and follows .NET conventions and standards
- [ ] Codemaid and XAML styler extensions have been run on every changed file
- [x] No unrelated changes have been made to any other code or project files
- [ ] Screenshots are correct size and display in description tab (800 x 600 on Windows, MAUI mobile platforms use the MAUI Windows screenshot)